### PR TITLE
docs: require git worktree + PR workflow for rk-skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@
 - Comment only where logic isn't self-evident.
 - Keep solutions minimal unless correctness or safety demands more.
 - **Correctness and safety outrank cleanliness, elegance, and minimal surface — always.** Never pick the tidier design if it leaves any correctness/safety gap (money, data integrity, security, auto-protective mechanisms); weigh gaps against the realistic worst case, not the average. Derive the right solution from first principles even if it means more code.
-- **Always pursue the absolute best solution.** Cost, compute, time, effort, token spend, code volume, and convenience never narrow the option space. Use the most capable models and most thorough verification. Only correctness/safety and the explicit non-negotiables (branch+PR workflow, verifying claims against code, destructive-action safety) override "best."
+- **Always pursue the absolute best solution.** Cost, compute, time, effort, token spend, code volume, and convenience never narrow the option space. Use the most capable models and most thorough verification. Only correctness/safety and the explicit non-negotiables (worktree+PR workflow, verifying claims against code, destructive-action safety) override "best."
 - Parallel tool calls when operations are independent.
 - Check git status before commits.
 - Prefer editing existing files over creating new ones.
@@ -69,4 +69,4 @@
 
 ## This Repository
 
-- **All changes land via branch + pull request — never commit directly to main.**
+- **All changes land via git worktree + pull request — never commit directly to main, never work in the main checkout.** Create a worktree off the latest `origin/main` for every change (the `EnterWorktree` tool, or `git worktree add`), do the work there, then open a PR from that branch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,3 +66,7 @@
 ## GitHub Issues
 
 - **Before creating or editing any GitHub issue, load the `github-issue-format` skill** — it defines the mandatory `[C<score>]` title convention, complexity rationale line, and complete-body rule. Never file an issue without it.
+
+## This Repository
+
+- **All changes land via branch + pull request — never commit directly to main.**

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ mkdir -p .github/workflows && \
 
 Also included:
 
-- `CLAUDE.md` — an example set of global instructions these skills are tuned for (attribution footers, complexity scores, the branch+PR workflow). Use it as a reference for your own `~/.claude/CLAUDE.md`.
+- `CLAUDE.md` — an example set of global instructions these skills are tuned for (attribution footers, complexity scores, the worktree+PR workflow). Use it as a reference for your own `~/.claude/CLAUDE.md`.
 - `commands/commit.md` — a `/commit` slash command for creating well-formed git commits.
 
 ## Install (with npx)


### PR DESCRIPTION
Adds a repo rule to CLAUDE.md: every change is developed in a dedicated git worktree off the latest `origin/main` and lands via pull request. The main checkout is never used for work, and nothing is committed directly to main.

Also aligns the two existing references to the old "branch+PR workflow" wording (CLAUDE.md non-negotiables list, README's CLAUDE.md description).

---
Updated with LLM: Opus 4.8 | high | Harness: Claude Code

https://claude.ai/code/session_01RCjSkFmes3abQRRZarweF5