### PR TITLE
Vendor the @claude trigger workflow: rk-skills becomes its own first consumer (#13)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,383 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened]
+  pull_request_review:
+    types: [submitted]
+
+# Serialize runs per issue/PR: the footer/failure comment-patch steps rewrite
+# "the latest bot comment", so overlapping runs would stamp each other's
+# comments. The group is per workflow RUN, so the classify -> review/implement
+# jobs of one run never overlap a second run on the same issue/PR.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+# Least-privilege split (#1178): a zero-permission classify job plus the two
+# runner jobs. The runner body is the reusable claude-run.yml workflow
+# published from richkuo/rk-skills — it fetches its prompts and scripts from
+# rk-skills at run time, so this file is the ONLY piece a consumer repo
+# vendors (plus optional .github/prompts/<route>-local.md tailoring); only the
+# permissions (and route) differ at the call sites below. The review job must
+# never carry contents: write or id-token: write — a review run reads
+# untrusted, potentially prompt-injected PR content, and id-token: write would
+# let injected code mint the Claude App installation token (which has push
+# rights) itself via the OIDC exchange, bypassing the job permissions.
+jobs:
+  classify:
+    if: |
+      (
+        (github.actor == 'claude[bot]' && github.event.issue.pull_request != null) ||
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association)
+      ) && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      invoked: ${{ steps.verify_invocation.outputs.invoked }}
+      mode: ${{ steps.classify_mode.outputs.mode }}
+      flow: ${{ steps.resolve_model.outputs.flow }}
+      model_id: ${{ steps.resolve_model.outputs.model_id }}
+      effort: ${{ steps.resolve_model.outputs.effort }}
+    steps:
+      - name: Verify @claude is an actual invocation (not in a code block or example)
+        id: verify_invocation
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          REVIEW_BODY: ${{ github.event.review.body }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          TRIGGER_ACTOR: ${{ github.actor }}
+        run: |
+          # Select body based on event type
+          case "$EVENT_NAME" in
+            issue_comment|pull_request_review_comment)
+              BODY="$COMMENT_BODY"
+              ;;
+            pull_request_review)
+              BODY="$REVIEW_BODY"
+              ;;
+            issues)
+              BODY="$ISSUE_BODY"
+              ;;
+          esac
+
+          # Strip fenced code blocks (``` ... ```) and inline code spans (` ... `)
+          # shellcheck disable=SC2016  # single quotes are intentional — Perl regex has no shell vars
+          STRIPPED=$(printf '%s' "$BODY" | perl -0777 -pe 's/```.*?```//gs' | sed 's/`[^`]*`//g')
+
+          # Publish the code-stripped body as a single source of truth: both
+          # classify_mode (which decides review vs. push-capable fix-pr from the
+          # word "review") and resolve_model consume THIS text, so the body that
+          # gates "is @claude invoked" and the body that gates "does this run earn
+          # push access" can never diverge. The heredoc delimiter is randomized
+          # because the body is attacker-influenced — a fixed delimiter appearing
+          # inside the body could inject additional step outputs.
+          DELIM="STRIPPED_$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+          {
+            printf 'stripped<<%s\n' "$DELIM"
+            printf '%s\n' "$STRIPPED"
+            printf '%s\n' "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$TRIGGER_ACTOR" = "claude[bot]" ]; then
+            # Bot self-trigger loop prevention: a claude[bot]-authored comment is a
+            # valid invocation ONLY when its stripped body is exactly a one-line
+            # review trigger (optional model shorthand + effort token). Review
+            # output that merely quotes @claude at a line start must never chain
+            # another run.
+            # Normalize CRLF, trim each line, and DROP blank lines so whitespace
+            # padding (leading/trailing spaces, blank lines, or a stray CR) around
+            # an otherwise exact one-line "@claude review" trigger cannot defeat
+            # the guard. Any real content on a second non-blank line keeps
+            # NONBLANK_LINES > 1, so multi-line review output that merely quotes
+            # @claude at a line start never chains another run.
+            NONBLANK=$(printf '%s' "$STRIPPED" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d')
+            NONBLANK_LINES=$(printf '%s' "$NONBLANK" | awk 'END{print NR}')
+            if [ "$NONBLANK_LINES" -eq 1 ] && \
+               printf '%s' "$NONBLANK" | grep -qE '^@claude([[:space:]]+[a-z]+)?[[:space:]]+review([[:space:]]+effort:(low|medium|high|xhigh))?$'; then
+              echo "invoked=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "invoked=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::claude[bot] comment is not an exact one-line @claude review trigger — skipping."
+            fi
+          # @claude is a real invocation only when it appears at the start of a line
+          elif printf '%s' "$STRIPPED" | grep -qE '(^|(\r?\n))[[:space:]]*@claude([[:space:]]|$)'; then
+            echo "invoked=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "invoked=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::@claude found but only inside code blocks or examples — skipping."
+          fi
+
+      - name: Resolve model from @claude invocation
+        if: steps.verify_invocation.outputs.invoked == 'true'
+        id: resolve_model
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          # The code-stripped body from verify_invocation — the exact text the
+          # invocation gate saw, by construction (single source of truth).
+          STRIPPED: ${{ steps.verify_invocation.outputs.stripped }}
+          # Repo variable feature-flag (issue #223): the docs-sync / create-release
+          # comment flows stay OFF until this is set to 'true', so merging this
+          # workflow to main does not immediately arm the trigger in production.
+          # Empty when unset.
+          DOCS_RELEASE_ENABLED: ${{ vars.DOCS_RELEASE_ENABLED }}
+        run: |
+          # Extract optional model shorthand after @claude on a line boundary
+          # e.g. "@claude sonnet fix this" → "sonnet"
+          MODEL_SHORT=$(printf '%s' "$STRIPPED" | grep -oE '(^|(\r?\n))[[:space:]]*@claude[[:space:]]+[a-z]+' | head -1 | awk '{print $NF}' || true)
+
+          case "$MODEL_SHORT" in
+            opus)    MODEL_ID="claude-opus-4-8[1m]" ;;
+            sonnet)  MODEL_ID="claude-sonnet-5" ;;
+            fable)   MODEL_ID="claude-fable-5" ;;
+            *)       MODEL_ID="claude-opus-4-8[1m]" ;;  # default (no model specified)
+          esac
+
+          echo "model_id=$MODEL_ID" >> "$GITHUB_OUTPUT"
+          echo "::notice::Using model: $MODEL_ID"
+
+          # Extract optional effort level from comment: "effort:low", "effort:medium", "effort:high", "effort:xhigh"
+          EFFORT_RAW=$(printf '%s' "$STRIPPED" | grep -oiE 'effort:(low|medium|xhigh|high)' | head -1 | tr '[:upper:]' '[:lower:]' | cut -d: -f2 || true)
+          EFFORT="${EFFORT_RAW:-xhigh}"
+          echo "effort=$EFFORT" >> "$GITHUB_OUTPUT"
+          echo "::notice::Using effort: $EFFORT"
+
+          # Detect a docs-sync / release trigger phrase (issue #223). These flows
+          # ONLY run on issue_comment events and ONLY when the DOCS_RELEASE_ENABLED
+          # repo variable is 'true' (feature-flagged rollout). The phrase is matched
+          # against the same code-stripped body as verify_invocation, so a mention
+          # inside a fenced/inline code block never triggers. Precedence when a
+          # comment names more than one: create-release > sync-docs. An empty flow
+          # falls through to the existing issue-workflow / PR-review paths in
+          # claude-run.yml, so the read-only PR-review contract and today's behavior
+          # are untouched for every non-trigger comment. sync-release is
+          # intentionally omitted from this template: it requires a repo-side
+          # merge-triggered release workflow that parses the docs-release/*
+          # branch name. The run body supports flow=sync-release — a repo that
+          # has such a workflow adds sync-release to the candidate list below,
+          # between create-release and sync-docs.
+          #
+          # Note: the model-shorthand parser above reads the flow word after @claude
+          # (e.g. 'sync' in '@claude sync-docs') as an unknown model token and falls
+          # through to the default model — intended and harmless; '@claude opus
+          # create-release' still selects opus via the optional model group below.
+          FLOW=""
+          if [ "$EVENT_NAME" = "issue_comment" ] && [ "$DOCS_RELEASE_ENABLED" = "true" ]; then
+            for cand in create-release sync-docs; do
+              if printf '%s' "$STRIPPED" | grep -qiE "(^|(\r?\n))[[:space:]]*@claude([[:space:]]+(opus|sonnet|fable))?[[:space:]]+${cand}([[:space:]]|\$)"; then
+                FLOW="$cand"
+                break
+              fi
+            done
+          fi
+          echo "flow=$FLOW" >> "$GITHUB_OUTPUT"
+          if [ -n "$FLOW" ]; then
+            echo "::notice::Docs/release flow: $FLOW"
+          fi
+
+      - name: Classify invocation route (review, implement, fix-pr, or fix-pr-review)
+        if: steps.verify_invocation.outputs.invoked == 'true'
+        id: classify_mode
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_URL: ${{ github.event.issue.pull_request.url }}
+          FLOW: ${{ steps.resolve_model.outputs.flow }}
+          # Same code-stripped body the invocation gate saw — the route keyword
+          # (first word after @claude) is parsed from THIS text, so the body that
+          # gates "is @claude invoked" and the body that gates "does this run earn
+          # push access" can never diverge.
+          STRIPPED: ${{ steps.verify_invocation.outputs.stripped }}
+          # On an issue_comment for a PR, these describe the PULL REQUEST's author
+          # (github.event.issue is the PR). They gate the push-capable fix-pr path:
+          # only a trusted-author PR earns an in-place fix, so the agent never
+          # writes while reading an untrusted contributor's diff.
+          PR_AUTHOR_ASSOC: ${{ github.event.issue.author_association }}
+          PR_AUTHOR_LOGIN: ${{ github.event.issue.user.login }}
+        run: |
+          # Fail-closed routing keyed on the FIRST word after @claude (an
+          # optional model shorthand — opus/sonnet/fable — is skipped). Five
+          # outcomes:
+          #   - implement: a docs-sync/release FLOW, or a plain issue (an `issues`
+          #     event, or an issue_comment whose issue is NOT a PR) — the
+          #     issue-workflow that opens its OWN pull request.
+          #   - review (always): PR-review surfaces (pull_request_review and inline
+          #     pull_request_review_comment) — reading untrusted diff content never
+          #     earns push there, even for an inline "fix X" ask.
+          #   - review: a PR issue_comment whose route keyword is "review"
+          #     ("@claude review ..."), or whose PR author is untrusted
+          #     (external/fork) — read-only. NOTE: only the keyword position
+          #     counts; "review" later in the sentence ("@claude fix the review
+          #     comments") no longer forces read-only.
+          #   - fix-pr-review: keyword "fix-pr" on a trusted-author PR — the
+          #     review-fixing playbook (validate all review feedback against the
+          #     code, fix what survives, disposition comment, re-review trigger).
+          #   - fix-pr: any other keyword on a trusted-author PR — generic
+          #     in-place PR edit per the comment's instructions.
+          # Anything not positively identified as write-safe degrades to
+          # read-only review (the review job holds no push capability, so a
+          # misroute 403s on write rather than running write-capable over
+          # untrusted PR content).
+          IS_ISSUE=false
+          case "$EVENT_NAME" in
+            issues) IS_ISSUE=true ;;
+            issue_comment) if [ -z "$PR_URL" ]; then IS_ISSUE=true; fi ;;
+          esac
+
+          if [ -n "$FLOW" ] || [ "$IS_ISSUE" = "true" ]; then
+            MODE=implement
+          else
+            case "$EVENT_NAME" in
+              pull_request_review|pull_request_review_comment)
+                MODE=review
+                ;;
+              *)
+                # issue_comment on a PR conversation. Route keyword = first
+                # token after @claude on its invocation line, skipping an
+                # optional model shorthand.
+                KEYWORD=$(printf '%s' "$STRIPPED" | tr -d '\r' \
+                  | sed -n 's/^[[:space:]]*@claude[[:space:]]\{1,\}//p' | head -n 1 \
+                  | awk '{ if ($1 == "opus" || $1 == "sonnet" || $1 == "fable") { print $2 } else { print $1 } }' \
+                  | tr '[:upper:]' '[:lower:]')
+
+                PR_AUTHOR_TRUSTED=false
+                case "$PR_AUTHOR_ASSOC" in
+                  OWNER|MEMBER|COLLABORATOR) PR_AUTHOR_TRUSTED=true ;;
+                esac
+                if [ "$PR_AUTHOR_LOGIN" = "claude[bot]" ]; then
+                  PR_AUTHOR_TRUSTED=true
+                fi
+
+                if [ "$KEYWORD" = "review" ]; then
+                  MODE=review
+                elif [ "$PR_AUTHOR_TRUSTED" != "true" ]; then
+                  MODE=review
+                elif [ "$KEYWORD" = "fix-pr" ]; then
+                  MODE=fix-pr-review
+                else
+                  MODE=fix-pr
+                fi
+                ;;
+            esac
+          fi
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "::notice::Route: $MODE"
+
+  # Review runs read untrusted PR content: the job token is the hard boundary
+  # (the Bash allowlist is bypassable through allowed interpreters), so it gets
+  # contents: read only, and claude-run.yml binds the agent to this token via
+  # github_token. No id-token: write — see the note above.
+  review:
+    needs: classify
+    if: needs.classify.outputs.invoked == 'true' && needs.classify.outputs.mode == 'review'
+    permissions:
+      # Untrusted-content path: read-only on CODE (contents: read blocks
+      # push/merge — a prompt-injected diff can never ship). pull-requests: write
+      # is REQUIRED, not optional: a review comment targets a PR, and GitHub
+      # authorizes POST /issues/{n}/comments by the target's type — for a pull
+      # request that is pull-requests: write, NOT issues: write (which only
+      # covers real issues). The residual power it grants (close/edit/retitle a
+      # PR via an allowed interpreter on a prompt-injected diff) is the accepted
+      # cost of posting the review at all; merge still requires contents: write.
+      contents: read
+      pull-requests: write
+      issues: write
+    uses: richkuo/rk-skills/.github/workflows/claude-run.yml@main
+    with:
+      mode: review
+      flow: ''
+      model_id: ${{ needs.classify.outputs.model_id }}
+      effort: ${{ needs.classify.outputs.effort }}
+    secrets: inherit
+
+  # Implementation runs legitimately commit and push (issue workflow opens a PR;
+  # docs-sync opens a PR; create-release publishes), so they keep Claude App
+  # auth (id-token: write mints the app installation token) and contents: write
+  # for the checkout-side git operations.
+  implement:
+    needs: classify
+    if: needs.classify.outputs.invoked == 'true' && needs.classify.outputs.mode == 'implement'
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    uses: richkuo/rk-skills/.github/workflows/claude-run.yml@main
+    with:
+      mode: implement
+      flow: ${{ needs.classify.outputs.flow }}
+      model_id: ${{ needs.classify.outputs.model_id }}
+      effort: ${{ needs.classify.outputs.effort }}
+    secrets: inherit
+
+  # A fix-pr run edits the pull request's own branch in place and pushes to it
+  # (e.g. addressing review feedback), so it needs contents: write + Claude App
+  # auth like implement. Unlike a review run it does NOT read an untrusted
+  # author's diff: classify routes here ONLY for an issue_comment on a PR whose
+  # author is trusted (owner/member/collaborator, or claude[bot]). The `if`
+  # below RE-ASSERTS that trust from the event payload, independent of classify's
+  # output — classify runs with zero permissions and this job holds
+  # contents: write, so this second, independent gate ensures a classify bug can
+  # never grant push over an untrusted-author PR (the trust check is the sole
+  # security boundary here, since contents: write makes the allowlist bypassable
+  # through allowed interpreters). Trust is anchored on the PR author, not the
+  # commenter: the job-level trigger already requires an OWNER/MEMBER/COLLABORATOR
+  # commenter, so both the human asking and the diff being edited are trusted.
+  fix-pr:
+    needs: classify
+    if: >
+      needs.classify.outputs.invoked == 'true' &&
+      needs.classify.outputs.mode == 'fix-pr' &&
+      (
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association) ||
+        github.event.issue.user.login == 'claude[bot]'
+      )
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    uses: richkuo/rk-skills/.github/workflows/claude-run.yml@main
+    with:
+      mode: fix-pr
+      flow: ''
+      model_id: ${{ needs.classify.outputs.model_id }}
+      effort: ${{ needs.classify.outputs.effort }}
+    secrets: inherit
+
+  # The "@claude fix-pr" keyword route: same push capability and the same
+  # independent trusted-PR-author re-assertion as fix-pr (see the comment
+  # above), but runs the review-fixing playbook prompt — fetch all review
+  # feedback, validate each finding against the code, fix what survives, post
+  # a per-finding disposition comment, and trigger a fresh @claude review.
+  fix-pr-review:
+    needs: classify
+    if: >
+      needs.classify.outputs.invoked == 'true' &&
+      needs.classify.outputs.mode == 'fix-pr-review' &&
+      (
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association) ||
+        github.event.issue.user.login == 'claude[bot]'
+      )
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    uses: richkuo/rk-skills/.github/workflows/claude-run.yml@main
+    with:
+      mode: fix-pr-review
+      flow: ''
+      model_id: ${{ needs.classify.outputs.model_id }}
+      effort: ${{ needs.classify.outputs.effort }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Copies `templates/claude-workflow/workflows/claude.yml` to `.github/workflows/claude.yml`, byte-identical (verified with `diff`). The template's call sites already point at `richkuo/rk-skills/.github/workflows/claude-run.yml@main`, so @claude review / fix-pr / implement comments now work in this repo, dogfooding the published workflow on every change to it. Defaults (ubuntu-latest, 45-minute timeout, no Go, no extra tools) suit this repo, so no inputs are passed.

## Manual follow-ups after merge (repo settings, not code)

1. Add the `CLAUDE_CODE_OAUTH_TOKEN` secret (currently absent — only `NPM_TOKEN` exists).
2. Confirm the Claude GitHub App is installed on this repo.
3. Smoke-test with `@claude review` on a test PR.

Closes #13.

---
Created with LLM: Fable 5 | medium | Harness: Claude Code

https://claude.ai/code/session_01RCjSkFmes3abQRRZarweF5