### PR TITLE
Tolerate string-encoded args in milestone-pipeline

### DIFF
--- a/workflows/milestone-pipeline.js
+++ b/workflows/milestone-pipeline.js
@@ -21,12 +21,14 @@ export const meta = {
 // first step of every issue — even freshly-authored issues go stale as earlier
 // PRs in the milestone change the ground truth, so each issue is re-checked
 // against the current code immediately before it starts.
-if (!args || !Array.isArray(args.tracks) || args.tracks.length === 0) {
+// Some harness paths deliver args as a JSON string — normalize before validating.
+const ARGS = typeof args === 'string' ? JSON.parse(args) : args
+if (!ARGS || !Array.isArray(ARGS.tracks) || ARGS.tracks.length === 0) {
   throw new Error('milestone-pipeline requires args.tracks: an array of issue-number arrays, e.g. { tracks: [[2,3,4],[9],[12]] }')
 }
-const TRACKS = args.tracks
-const REVIEW_LOOP = args.reviewLoop ?? true
-const MAX_REVIEW_CYCLES = args.maxReviewCycles ?? 5
+const TRACKS = ARGS.tracks
+const REVIEW_LOOP = ARGS.reviewLoop ?? true
+const MAX_REVIEW_CYCLES = ARGS.maxReviewCycles ?? 5
 const ALL_ISSUES = TRACKS.flat()
 
 const MODEL_IDS = { 'fable': 'fable', 'opus': 'opus', 'sonnet': 'sonnet', 'haiku': 'haiku' }


### PR DESCRIPTION
## Problem

Two consecutive launches of the milestone-pipeline workflow failed immediately with the script's own error — `milestone-pipeline requires args.tracks: an array of issue-number arrays…` — despite `tracks` being passed correctly. The cause: some Workflow harness paths deliver the `args` global as a JSON *string* rather than a parsed object, so `args.tracks` is `undefined` and validation throws.

## Fix

Normalize `args` immediately before the validation block:

```js
// Some harness paths deliver args as a JSON string — normalize before validating.
const ARGS = typeof args === 'string' ? JSON.parse(args) : args
```

Validation and the derived constants (`TRACKS`, `REVIEW_LOOP`, `MAX_REVIEW_CYCLES`) now read from `ARGS`. No other code references `args`; the remaining mentions are meta/comment text and prompt template strings, which are untouched. This exact normalization was proven on today's live run's script copy.

## Verification

The file has a top-level `export const meta` plus a body using top-level `await`/`return`, so plain `node --check` on the raw file fails by design. Verified the way the Workflow runtime executes it: copied the body into a scratch file wrapped as `async function __body(agent, parallel, pipeline, log, phase, args, budget, workflow) { … }` — `node --check` passes.

---
Created with LLM: Fable 5 | high | Harness: Claude Code

https://claude.ai/code/session_01LAD6QBzjCrmzwNZcd5RUfo