### PR TITLE
feat: add dependency-aware milestone scheduling (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ flowchart LR
 | `prd-questions` | "Ask me all questions": sweeps the PRD for every open question and ambiguity, asks them in batched multiple-choice form with a recommended option, folds each answer into the owning spec section, and empties the Open Questions list. |
 | `prd-to-issues` | Breaks the refined PRD into dependency-ordered milestones and 15–25 complete, complexity-scored issues, each stamped with an `## Execution` block: build model, effort, whether a Fable plan comes first, and the `@claude` review trigger. |
 | `execution-plan-review` | Renders the per-issue model/effort/fableplan table from the issues themselves, takes your revisions ("11 should be medium"), pushes back once when a revision fights the heuristics, and writes changes back to the issues. |
-| `milestone-workflow` | Builds the dependency tracks for a milestone, presents the run plan for approval (mandatory), then runs the `milestone-pipeline` workflow and reports PRs and review-loop outcomes. |
+| `milestone-workflow` | Builds typed dependency tracks for a milestone, presents the run plan for approval (mandatory), then runs `milestone-pipeline` and reports PRs, blocked descendants, and review outcomes. |
 
-The `workflows/milestone-pipeline.js` dynamic workflow does the execution: per-issue model and effort read from the Execution blocks, a Fable validation pass against the current code as each issue starts (staleness check — earlier PRs change the ground truth), an optional Fable planning stage, isolated-worktree implementation agents, `@claude` review loops until LGTM — parallel across dependency tracks, sequential within.
+The `workflows/milestone-pipeline.js` dynamic workflow validates the full dependency graph before starting. Typed tracks use `after` for hard prerequisites and `runsAfter` for ordering-only predecessors. Unrelated tracks run concurrently; both successor types wait for stable predecessor review results. Hard successors build from verified predecessor heads, including a checked integration base for multiple heads, while ordering-only successors inherit no code. Legacy array tracks remain compatible and treat serial edges as hard dependencies. Bun regression tests execute the workflow through its async harness.
 
 ### Review bot prerequisite
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.7.0",
   "description": "Installer for Claude Code workflow skills — GitHub issue/PR/release automation and Fable-driven planning.",
   "type": "module",
+  "scripts": {
+    "test": "bun test"
+  },
   "bin": {
     "rk-skills": "bin/install.mjs"
   },

--- a/skills/milestone-workflow/SKILL.md
+++ b/skills/milestone-workflow/SKILL.md
@@ -5,21 +5,23 @@ description: Use when the user wants a milestone of Execution-block-stamped GitH
 
 # milestone-workflow
 
-Turn a reviewed milestone into a running multi-agent pipeline. Static plan, dynamic dispatch: the dependency graph is decided here with the user; execution reacts to reviews and merges as they land.
+Turn a reviewed milestone into a running multi-agent pipeline. Static plan, dependency-aware dispatch: the dependency graph is decided here with the user; execution waits for stable predecessor results and builds hard-dependent work from their reviewed code.
 
 ## Steps
 
 ### 1. Build the dependency tracks
 
-Fetch the milestone's issues. From their Approach/Problem sections, derive **tracks**: an array of issue-number arrays where tracks run in parallel and issues within a track run sequentially.
+Fetch the milestone's issues and build a typed dependency graph before grouping them into tracks.
 
-- The **spine** (scaffold → schema → auth) is the first track — or, when everything depends on it, run the spine as its own Workflow invocation first and fan out in a second invocation after it merges. Cross-track dependencies cannot be expressed inside one invocation; chain invocations per phase instead, staying in the loop between them.
-- Dependency-free islands (pure modules, landing pages) get single-issue tracks.
-- Two issues touching the same package never sit in different tracks.
+- Read `**Depends on:**` first for hard code/product prerequisites and `**Runs after:**` for ordering-only constraints. For older issues missing either field, infer only from Approach/Problem prose and label every inferred edge in the plan.
+- Reject missing issue references and cycles across the union of both edge kinds. A hard edge means the successor needs predecessor code; an ordering edge only prevents overlapping work.
+- Express each track as `{ issues: [...], after: [<track index>...], runsAfter: [<track index>...] }`. Dependency-free islands have neither predecessor list. Combine issues into one `issues` array only when every serial edge is truly hard; untyped serial edges are treated as hard by the workflow, so ordering-only chains must remain separate tracks joined by `runsAfter`.
+- Preserve concurrency: unrelated tracks start together. Multiple hard predecessors remain separate `after` entries so the runtime can create and verify one integration base containing every head.
+- Use separate workflow invocations only when repository policy requires prerequisites to merge to the default branch before successors can start.
 
 ### 2. Present the run plan — review before beginning (mandatory)
 
-Show: the tracks with issue titles, each issue's model/effort/fableplan from its Execution block, the review-loop behavior, and merge-order expectations. **Do not invoke the Workflow tool until the user approves this plan** — the approval is both the safety checkpoint and the explicit multi-agent opt-in the Workflow tool requires.
+Show: numbered tracks with issue titles; hard `after` edges separately from ordering-only `runsAfter` edges; which edges were inferred; each issue's model/effort/fableplan; the stable readiness boundary; and merge-order expectations. **Do not invoke the Workflow tool until the user approves this plan** — the approval is both the safety checkpoint and the explicit multi-agent opt-in the Workflow tool requires.
 
 ### 3. Preflight the repo
 
@@ -29,17 +31,18 @@ Show: the tracks with issue titles, each issue's model/effort/fableplan from its
 
 ### 4. Run
 
-Invoke the Workflow tool with `{name: 'milestone-pipeline', args: {tracks: [[...], ...], reviewLoop: true, maxReviewCycles: 5}}`. The workflow:
+Invoke the Workflow tool with `{name: 'milestone-pipeline', args: {tracks: [{issues:[2,3]}, {issues:[9], after:[0]}, {issues:[12], runsAfter:[0]}], reviewLoop: true, maxReviewCycles: 5}}`. Legacy issue-array tracks remain accepted, but use typed objects for new plans. The workflow validates all assignments, predecessor indices, duplicates, and cycles before prep, then:
 
 1. **Prep** — one agent reads every issue's `[C..]` score and Execution block → per-issue model/effort/fableplan.
-2. **Validate** — immediately before each issue starts, a Fable agent runs the `validate-issue` procedure against the *current* code (issues go stale as earlier PRs land), at the issue's `Validate effort` (default high): verdict, issue-body corrections, hard implementation constraints. `INVALID` issues are skipped and reported, never built.
+2. **Validate** — immediately before each issue starts, a Fable agent runs the `validate-issue` procedure against the current dependency base, with deduplicated predecessor PRs/skips and hard base refs, at the issue's `Validate effort` (default high). `INVALID` issues are skipped and reported, never built.
 3. **Plan** — issues flagged `fableplan: Yes` get a Fable 5 planning agent (validation-aware) whose plan is posted to the issue; the builder implements against it.
-4. **Implement** — per-issue agent on its assigned model/effort applies the validation corrections to the issue, then isolated worktree, `work-on-issue` procedure, opens the PR, triggers `@claude review`.
-5. **Review Loop** — `fix-pr-review-loop` per PR until LGTM, concurrent with later issues in the track; validation constraints outrank reviewer suggestions. Re-review triggers follow fix-pr-review's routing: `@claude review`, or `@claude sonnet review` when only non-blocking items were addressed.
+4. **Implement** — per-issue agent on its assigned model/effort applies validation corrections, invokes `work-on-issue` with the verified hard `baseRefs`, creates a deterministic integration base for multiple heads, opens the PR, and triggers `@claude review` when review loops are enabled.
+5. **Review readiness** — `fix-pr-review-loop` runs until LGTM before any hard or ordering successor starts, preventing review fixes from racing same-package work. Unrelated tracks and their review loops stay concurrent. With `reviewLoop: false`, implementation completion is the readiness boundary.
+6. **Failure propagation** — failed, blocked, or non-LGTM hard predecessors block descendants. Ordering-only skips without a PR do not; an unresolved predecessor PR does. Integration conflicts block before product changes.
 
 ### 5. Monitor and close out
 
-Relay meaningful progress (PRs opened, review loops finishing, blockers) — not raw logs. On completion, report a results table: issue → PR → review status, plus flags the agents raised. Recommend the merge order (track order). If a later phase was deferred pending this one's merges, offer to chain the next invocation.
+Relay meaningful progress (PRs opened, review loops finishing, blockers) — not raw logs. On completion, report a results table: issue → PR → review status, plus flags the agents raised. Recommend dependency order, with every hard prerequisite before its descendants. If a later phase was deferred pending merges, offer to chain the next invocation.
 
 ## Context discipline
 
@@ -51,6 +54,8 @@ The orchestrating session holds no implementation detail — issues and PRs are 
 |---|---|
 | An issue lacks an Execution block at run time | Stop before running; send it through execution-plan-review |
 | No `@claude` review workflow in the repo | Install from templates first, or run with `reviewLoop: false` and say what that forfeits |
-| A track's issue hard-depends on an unmerged earlier PR | The workflow passes in-flight context; implementers may branch off the dependency's PR branch and must note merge order in the PR body |
+| A successor hard-depends on unmerged predecessor PRs | Use `after`; the workflow waits for stable heads and `work-on-issue` verifies/integrates every base before implementation |
+| A same-package predecessor is ordering-only | Use `runsAfter`; the successor waits but does not inherit code |
+| A dependency integration conflicts | The affected track and hard descendants stop blocked before product changes; report the conflicting heads |
 | Workflow returns empty/odd results | Read the run's `journal.jsonl` before re-running; resume with `resumeFromRunId` rather than restarting |
 | User asks to start without reviewing the plan | Present the plan anyway — step 2 is not skippable |

--- a/skills/work-on-issue/SKILL.md
+++ b/skills/work-on-issue/SKILL.md
@@ -16,8 +16,9 @@ Take a GitHub issue from "validated" to "PR open", autonomously and end-to-end: 
 The user provides one of:
 - Nothing — **default to the issue just validated this session**, else the latest open issue (`gh issue list --limit 1`).
 - `#<N>` / `<N>` / full URL / `owner/repo#N`.
+- `{ issue: <N>, baseRefs: [{ pr: <PR number>, ref: "<head branch>", sha: "<head commit>" }, ...] }` — orchestration-only form for hard dependencies. `baseRefs` is optional; when present, its order is authoritative and deterministic (upstream track order), and every entry pins a predecessor pull request's reviewed readiness head.
 
-The steps assume the issue belongs to the repo of the current checkout. If `owner/repo#N` or the URL points at a different repo, do not proceed against the local checkout — locate a local clone of that repo and work there, or stop and tell the user which repo needs to be checked out. (`gh issue view`/`gh pr create` accept `-R owner/repo`, but the implementation itself needs the matching working tree.)
+The steps assume the issue belongs to the repo of the current checkout. If `owner/repo#N` or the URL points at a different repo, do not proceed against the local checkout — locate a local clone of that repo and work there, or stop and tell the user which repo needs to be checked out. (`gh issue view`/`gh pr create` accept `-R owner/repo`, but the implementation itself needs the matching working tree.) Standalone calls have no `baseRefs` and retain the latest default branch as their base.
 
 ## Steps
 
@@ -35,9 +36,9 @@ Two gates, checked while no worktree or code exists yet:
 - **The issue must still be open.** If it's closed, stop and report — don't implement a resolved issue.
 - **No existing PR may already address it** — discovering one later wastes the entire cycle, splits review, and orphans a branch. Inspect any search hit: a PR that merely mentions `#<N>` in passing doesn't count, one that fixes it does. If a genuine PR exists, surface it and stop (or, if it's this session's own branch, continue on it).
 
-### 1. Ensure an isolated worktree off the latest default branch
+### 1. Resolve and verify the worktree base
 
-All implementation happens in a fresh worktree branched from the repo's current default branch — never on the default branch itself, never on a divergent checked-out branch. Detect the default branch; don't assume `main` (repos use `master`, `develop`, etc.):
+All implementation happens in a fresh worktree — never on the default branch itself or a divergent checked-out branch. Detect and fetch the default branch even when dependencies are supplied because it remains the pull request base:
 
 ```bash
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
@@ -45,33 +46,50 @@ git fetch origin "$DEFAULT_BRANCH"
 git branch --show-current   # where am I now?
 ```
 
+If `baseRefs` is absent, the resolved worktree base is `origin/<default>` as before. If it is present, validate the complete list **before creating a worktree**:
+
+- Reject an empty list; duplicate PR numbers, refs, or SHAs; non-positive integer PR numbers; the default branch; refs that fail `git check-ref-format --branch "$ref"`; and SHAs that are not 40–64 hexadecimal characters. Never interpolate or execute an unvalidated field.
+- Preserve caller order. For each entry, verify `gh pr view <pr> --json headRefName,headRefOid,headRepository` belongs to this repository and exactly matches both `ref` and `sha`. Any mismatch means the reviewed head changed after readiness and is a blocker; never silently use the new head.
+- Fetch the pull request's GitHub ref explicitly into a namespaced local ref (`pull/<pr>/head:refs/rk-skills/dependencies/pr-<pr>`), verify that fetched ref resolves exactly to `sha`, and record that commit. A missing, ambiguous, cross-repository, or changed head is a blocker; never fall back to the default branch.
+- The first verified SHA is the initial worktree base. Remaining SHAs are integrated in caller order after worktree creation.
+
+### 1.1 Create the isolated worktree
+
 - **If validate-issue already entered a worktree for this issue this session** (cwd is under `.claude/worktrees/<prefix>/issue-<N>-…`), confirm with `pwd` / `git branch --show-current` and proceed — do not create a second one.
-- **On Claude Code**, create and switch into one with the native `EnterWorktree` tool (it creates under `.claude/worktrees/` — base ref verified below — AND switches the session cwd in one step — a bare `git worktree add` + `cd` leaves the session's tracked cwd on the old checkout, so always use the tool):
+- **On Claude Code**, create and switch into one with the native `EnterWorktree` tool (it creates under `.claude/worktrees/` and switches the session cwd in one step):
 
 ```
 EnterWorktree(name: "cc/issue-<N>-<slug>")
 ```
 
-Pass the name **with** the `cc/` prefix — `EnterWorktree` uses it verbatim as the branch/worktree name, it does not add one itself. `<slug>` = the issue title kebab-cased to ≤5 words (drop filler, strip punctuation) — e.g. issue 873 "Scale-in / pyramiding support for open positions" → `cc/issue-873-scale-in-pyramiding`.
+Pass the name **with** the `cc/` prefix — `EnterWorktree` uses it verbatim as the branch/worktree name, it does not add one itself. `<slug>` = the issue title kebab-cased to ≤5 words (drop filler, strip punctuation) — e.g. issue 873 "Scale-in / pyramiding support for open positions" → `cc/issue-873-scale-in-pyramiding`. EnterWorktree starts from its configured base; when `baseRefs` is present, immediately move the brand-new, commit-free branch to the first verified SHA with an anchored `git -C <worktree-path> reset --hard <resolved-first-sha>`. Never do this to a re-entered worktree.
 
 - **On Cursor or Codex** (no `EnterWorktree` tool available), create the worktree with a raw `git worktree add`, prefixing the branch by hand — `cursor/` or `codex/` respectively:
 
 ```bash
-DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)   # re-detect inline — shell state doesn't persist between Bash calls
-git worktree add .claude/worktrees/cursor/issue-<N>-<slug> -b cursor/issue-<N>-<slug> "origin/$DEFAULT_BRANCH"
+git worktree add .claude/worktrees/cursor/issue-<N>-<slug> -b cursor/issue-<N>-<slug> <resolved-base>
 ```
 
 (swap `cursor/` for `codex/` on Codex), then `cd` into it — remember the session's tracked cwd doesn't follow a bare `cd`, so re-verify `pwd` before later steps.
 
 If a worktree for this issue already exists, enter it by `path` (Claude Code) or `cd` into it (Cursor/Codex).
 
-After the call, confirm the switch (`pwd` / `git branch --show-current`), state the path, and **verify the base** — this applies to both paths. EnterWorktree branches from `origin/<default>` only when the `worktree.baseRef` setting is `fresh` (its default); set to `head`, it branches from the local HEAD, which may be stale or divergent. The manual `git worktree add` bases on `origin/$DEFAULT_BRANCH` (freshly fetched in step 1) — still confirm:
+After the call, confirm the switch (`pwd` / `git branch --show-current`), state the path, and verify that `HEAD` exactly matches the resolved base commit. Anchor every command with `-C <worktree-path>` because shell state does not persist. If a brand-new worktree differs, reset only that commit-free worktree to the resolved base; never reset a re-entered worktree.
 
 ```bash
-git -C .claude/worktrees/<prefix>/issue-<N>-<slug> rev-parse HEAD "origin/$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)"   # the two SHAs must match
+git -C <worktree-path> rev-parse HEAD <resolved-base-sha>   # the two SHAs must match
 ```
 
-Anchor the check with `-C <worktree-path>` — shell state (including cwd) doesn't persist between Bash calls, so an unanchored `git rev-parse` in a fresh shell may run against the original checkout and report a spurious mismatch. If the SHAs differ on a worktree you **just created**, move it onto the fetched default with `git -C <worktree-path> reset --hard origin/<default>` — anchored for the same reason (an unanchored reset in the original checkout would destroy uncommitted work there), and safe only because the brand-new branch carries no commits. Never reset a re-entered worktree that already has work on it. Do every later step from inside the worktree.
+### 1.2 Integrate multiple hard prerequisites
+
+When `baseRefs` contains more than one ref, create one deterministic integration base **before reading or changing product files**:
+
+1. From the worktree based on the first ref, merge all remaining recorded remote-tracking commits in caller order with one `git merge --no-commit --no-ff` invocation.
+2. If Git reports any conflict or cannot form the integration, abort the merge and return blocked with the conflicting refs. Do not resolve product conflicts speculatively, implement the issue, or open a pull request.
+3. If a merge is pending, commit it with a concise dependency-integration message and the repository's required LLM attribution footer. If every remaining ref was already contained, no integration commit is needed.
+4. For **every** recorded predecessor commit, run `git -C <worktree-path> merge-base --is-ancestor <sha> HEAD`. Any failure blocks implementation. Record the verified refs and their order for the pull request body.
+
+The resulting `HEAD` is the only authorized base for validation and implementation. A single `baseRefs` entry needs no merge but still needs the ancestry check. Do every later step from inside this verified worktree.
 
 ### 2. Understand the issue and the code
 
@@ -125,6 +143,7 @@ gh pr create --base "$(gh repo view --json defaultBranchRef -q .defaultBranchRef
 
 - **Title:** match the repo's PR-title convention (the commit-title style is usually right).
 - **Body must close the issue:** include `Closes #<N>` so merging the PR resolves it. Summarize what changed and how it was verified; keep it scannable. Don't restate the whole issue.
+- **Dependency base:** when `baseRefs` was supplied, list every predecessor pull request and verified head in integration order, state that they must merge first, and keep the PR base set to the repository's default branch.
 - **Footer:** same convention as the commit — **Created** verb, repo footer format (global default `Created with LLM: <current model> | <effort> | Harness: <harness>`, harness resolved per step 5: `Claude Code` interactively, the Action identifier in CI). No `Co-authored-by` trailer.
 
 Capture the PR number/URL from the command output.
@@ -144,7 +163,9 @@ Terse summary: the worktree/branch, what you implemented (one or two lines), the
 | Situation | Action |
 |-----------|--------|
 | About to implement on the default branch or a divergent checked-out branch | Stop — enter the isolated worktree first (step 1) |
-| Fresh worktree's HEAD doesn't match `origin/<default>` | `worktree.baseRef` may be `head` — reset the just-created, commit-free branch onto `origin/<default>` before implementing |
+| Caller supplies invalid, duplicate, missing, ambiguous, cross-repository, or changed `baseRefs` | Stop blocked — never fall back to the default branch or guess a replacement |
+| Fresh worktree's HEAD doesn't match the resolved base | Reset only the just-created, commit-free worktree to the verified base; never reset a re-entered worktree |
+| Multiple bases conflict or any verified predecessor is not an ancestor of the integration base | Abort the merge and return blocked before product changes |
 | Worktree for this issue already exists | Enter it by `path`; don't create a duplicate |
 | Issue lives in a different repo than the current checkout | Stop — work in a clone of that repo, or tell the user which repo to check out |
 | Issue is already closed | Stop and report — don't implement a resolved issue |
@@ -152,7 +173,7 @@ Terse summary: the worktree/branch, what you implemented (one or two lines), the
 | Issue description conflicts with what the code actually does | Trust the traced code; implement the real fix, note the discrepancy in the PR body |
 | Issue's proposed sketch was ⚠️/❌ in validation | Implement the optimal direction for this repo, not the original sketch |
 | Fix touches money / data integrity / security / auto-protective logic | Implement the safest correct design from first principles; verify the invariant isn't violated |
-| Anywhere the default branch is needed (fetch, worktree base, `--base`) | Detect it (`gh repo view --json defaultBranchRef`), re-detecting inline where used — shell variables don't persist between commands |
+| Anywhere the default branch is needed (fetch or PR `--base`) | Detect it (`gh repo view --json defaultBranchRef`), re-detecting inline where used — shell variables don't persist between commands |
 | Tempted to skip or soften tests because "it's a small change" | Small changes break too; write the regression test and watch it fail on the unfixed code (red → green) |
 | Tests/build/lint fail locally | Fix or surface it — never commit, push, or claim success on a failing tree |
 | `git status` shows files unrelated to the change | Don't `git add -A` — stage the intended files by name |

--- a/skills/work-on-issue/SKILL.md
+++ b/skills/work-on-issue/SKILL.md
@@ -48,7 +48,7 @@ git branch --show-current   # where am I now?
 
 If `baseRefs` is absent, the resolved worktree base is `origin/<default>` as before. If it is present, validate the complete list **before creating a worktree**:
 
-- Reject an empty list; duplicate PR numbers, refs, or SHAs; non-positive integer PR numbers; the default branch; refs that fail `git check-ref-format --branch "$ref"`; and SHAs that are not 40–64 hexadecimal characters. Never interpolate or execute an unvalidated field.
+- Reject an empty list; duplicate PR numbers, refs, or SHAs; non-positive integer PR numbers; and SHAs that are not 40–64 hexadecimal characters. Before any field reaches a shell command, validate each ref as plain data against `^[A-Za-z0-9][A-Za-z0-9._/@+-]*$`; this rejects leading-dash values (`-h`, `--normalize`), whitespace, semicolons, quotes, backticks, and shell expansions. Only after that static allowlist passes, reject the default branch and refs that fail `git check-ref-format --branch "$ref"`.
 - Preserve caller order. For each entry, verify `gh pr view <pr> --json headRefName,headRefOid,headRepository` belongs to this repository and exactly matches both `ref` and `sha`. Any mismatch means the reviewed head changed after readiness and is a blocker; never silently use the new head.
 - Fetch the pull request's GitHub ref explicitly into a namespaced local ref (`pull/<pr>/head:refs/rk-skills/dependencies/pr-<pr>`), verify that fetched ref resolves exactly to `sha`, and record that commit. A missing, ambiguous, cross-repository, or changed head is a blocker; never fall back to the default branch.
 - The first verified SHA is the initial worktree base. Remaining SHAs are integrated in caller order after worktree creation.

--- a/tests/milestone-pipeline.test.js
+++ b/tests/milestone-pipeline.test.js
@@ -1,0 +1,323 @@
+import { describe, expect, test } from 'bun:test'
+
+const workflowSource = await Bun.file(new URL('../workflows/milestone-pipeline.js', import.meta.url)).text()
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
+const workflowBody = workflowSource.replace('export const meta =', 'const meta =')
+
+function issueNumbers(args) {
+  const parsed = typeof args === 'string' ? JSON.parse(args) : args
+  return parsed.tracks.flatMap((track) => Array.isArray(track) ? track : track.issues)
+}
+
+function issueFromLabel(label) {
+  return Number(label.match(/#(\d+)/)?.[1])
+}
+
+function headSha(issue, fill = '0') {
+  return issue.toString(16).padStart(40, fill)
+}
+
+function deferred() {
+  let resolve
+  let reject
+  const promise = new Promise((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+async function waitFor(predicate) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return
+    await Promise.resolve()
+  }
+  throw new Error('condition was not reached')
+}
+
+async function executeWorkflow(args, handlers = {}) {
+  const events = []
+  const logs = []
+  const agent = async (prompt, options) => {
+    const event = { label: options.label, phase: options.phase, prompt }
+    events.push({ ...event, state: 'started' })
+
+    const custom = handlers[options.label] || handlers[options.phase]
+    let result
+    if (custom) {
+      result = await custom(event)
+    } else if (options.phase === 'Prep') {
+      result = {
+        issues: issueNumbers(args).map((number) => ({
+          number,
+          title: `Issue ${number}`,
+          complexity: 20,
+          model: 'fable',
+          effort: 'high',
+          validate_effort: 'high',
+          fableplan: false,
+          missing_block: false,
+        })),
+      }
+    } else if (options.phase === 'Validate') {
+      result = { verdict: 'VALID', summary: 'valid', corrections: [], implementation_constraints: [] }
+    } else if (options.phase === 'Implement') {
+      const issue = issueFromLabel(options.label)
+      result = {
+        pr_number: 1000 + issue,
+        pr_url: `https://example.test/pr/${1000 + issue}`,
+        head_ref: `codex/issue-${issue}`,
+        head_sha: headSha(issue),
+        summary: 'implemented',
+        tests_passed: true,
+        flags: [],
+      }
+    } else if (options.phase === 'Review Loop') {
+      const issue = Number(options.label.match(/PR#(\d+)/)?.[1]) - 1000
+      result = {
+        final_status: 'lgtm',
+        cycles_run: 1,
+        summary: 'approved',
+        head_ref: `codex/issue-${issue}`,
+        head_sha: headSha(issue),
+      }
+    } else {
+      throw new Error(`unexpected phase: ${options.phase}`)
+    }
+
+    events.push({ ...event, state: 'finished', result })
+    return result
+  }
+  const parallel = async (tasks) => Promise.all(tasks.map((task) => task()))
+  const run = new AsyncFunction('args', 'agent', 'parallel', 'log', workflowBody)
+  const output = await run(args, agent, parallel, (message) => logs.push(message))
+  return { output, events, logs }
+}
+
+function started(events, label) {
+  return events.some((event) => event.state === 'started' && event.label === label)
+}
+
+function promptFor(events, label) {
+  return events.find((event) => event.state === 'started' && event.label === label)?.prompt
+}
+
+describe('milestone-pipeline dependency scheduling', () => {
+  test('waits for reviewed hard prerequisites while independent tracks start immediately', async () => {
+    const review = deferred()
+    let independentStarted = false
+    let dependentStarted = false
+    const running = executeWorkflow({
+      tracks: [
+        { issues: [2] },
+        { issues: [9], after: [0] },
+        { issues: [12] },
+      ],
+      reviewLoop: true,
+    }, {
+      'review-loop:PR#1002': () => review.promise,
+      'validate:#9': () => {
+        dependentStarted = true
+        return { verdict: 'VALID', summary: 'valid', corrections: [], implementation_constraints: [] }
+      },
+      'validate:#12': () => {
+        independentStarted = true
+        return { verdict: 'VALID', summary: 'valid', corrections: [], implementation_constraints: [] }
+      },
+    })
+
+    await waitFor(() => independentStarted)
+    expect(dependentStarted).toBeFalse()
+
+    review.resolve({
+      final_status: 'lgtm',
+      cycles_run: 1,
+      summary: 'approved',
+      head_ref: 'codex/issue-2',
+      head_sha: headSha(2, 'a'),
+    })
+    const result = await running
+    const reviewFinished = result.events.findIndex((event) => event.state === 'finished' && event.label === 'review-loop:PR#1002')
+    const dependentStartIndex = result.events.findIndex((event) => event.state === 'started' && event.label === 'validate:#9')
+    const independentStartIndex = result.events.findIndex((event) => event.state === 'started' && event.label === 'validate:#12')
+
+    expect(independentStartIndex).toBeGreaterThan(-1)
+    expect(dependentStartIndex).toBeGreaterThan(reviewFinished)
+    expect(promptFor(result.events, 'implement:#9 (fable/high)')).toContain(`"sha":"${headSha(2, 'a')}"`)
+  })
+
+  test('keeps legacy arrays and treats their serial edges as hard dependencies', async () => {
+    const { output, events } = await executeWorkflow({ tracks: [[2, 3]], reviewLoop: false })
+
+    expect(output.results.map((result) => result.issue)).toEqual([2, 3])
+    expect(promptFor(events, 'implement:#3 (fable/high)')).toContain(`baseRefs: [{"pr":1002,"ref":"codex/issue-2","sha":"${headSha(2)}"}]`)
+    expect(events.filter((event) => event.phase === 'Review Loop')).toHaveLength(0)
+  })
+
+  test('keeps string-encoded legacy arguments compatible', async () => {
+    const { output } = await executeWorkflow(JSON.stringify({ tracks: [[2]], reviewLoop: false }))
+
+    expect(output.results).toHaveLength(1)
+    expect(output.results[0].status).toBe('pr_open')
+  })
+
+  test.each([
+    ['empty track', { tracks: [[]] }, /track 1.*non-empty issues/i],
+    ['duplicate issue', { tracks: [[2], [2]] }, /issue #2.*more than once/i],
+    ['invalid predecessor', { tracks: [{ issues: [2], after: [1] }] }, /track 1.*invalid predecessor/i],
+    ['self dependency', { tracks: [{ issues: [2], runsAfter: [0] }] }, /track 1.*itself/i],
+    ['duplicate predecessor', { tracks: [{ issues: [2] }, { issues: [3], after: [0, 0] }] }, /track 2.*duplicate predecessor/i],
+    ['conflicting edge types', { tracks: [{ issues: [2] }, { issues: [3], after: [0], runsAfter: [0] }] }, /track 2.*duplicate predecessor/i],
+    ['cycle', { tracks: [{ issues: [2], after: [1] }, { issues: [3], runsAfter: [0] }] }, /cycle.*track/i],
+  ])('rejects %s before prep', async (_name, args, message) => {
+    let prepStarted = false
+    const running = executeWorkflow(args, {
+      Prep: () => {
+        prepStarted = true
+        return { issues: [] }
+      },
+    })
+
+    await expect(running).rejects.toThrow(message)
+    expect(prepStarted).toBeFalse()
+  })
+
+  test('blocks hard descendants when a prerequisite is skipped', async () => {
+    const { output, events } = await executeWorkflow({
+      tracks: [{ issues: [2] }, { issues: [9], after: [0] }],
+      reviewLoop: false,
+    }, {
+      'validate:#2': () => ({
+        verdict: 'INVALID',
+        summary: 'invalid',
+        invalid_reason: 'missing contract',
+        corrections: [],
+        implementation_constraints: [],
+      }),
+    })
+
+    expect(started(events, 'validate:#9')).toBeFalse()
+    expect(output.results.find((result) => result.issue === 9)?.status).toBe('dependency_blocked')
+  })
+
+  test('allows ordering-only descendants when a predecessor produced no pull request', async () => {
+    const { output, events } = await executeWorkflow({
+      tracks: [{ issues: [2] }, { issues: [9], runsAfter: [0] }],
+      reviewLoop: false,
+    }, {
+      'validate:#2': () => ({
+        verdict: 'INVALID',
+        summary: 'invalid',
+        invalid_reason: 'not applicable',
+        corrections: [],
+        implementation_constraints: [],
+      }),
+    })
+
+    expect(started(events, 'implement:#9 (fable/high)')).toBeTrue()
+    expect(output.results.find((result) => result.issue === 9)?.status).toBe('pr_open')
+  })
+
+  test('blocks ordering successors when an implementation failure leaves pull request state unknown', async () => {
+    const { output, events } = await executeWorkflow({
+      tracks: [{ issues: [2] }, { issues: [9], runsAfter: [0] }],
+      reviewLoop: false,
+    }, {
+      'implement:#2 (fable/high)': () => { throw new Error('agent disconnected') },
+    })
+
+    expect(started(events, 'validate:#9')).toBeFalse()
+    expect(output.results.find((result) => result.issue === 9)?.status).toBe('dependency_blocked')
+  })
+
+  test('deduplicates transitive context and passes deterministic hard base refs', async () => {
+    const { events } = await executeWorkflow({
+      tracks: [
+        { issues: [2] },
+        { issues: [3], after: [0] },
+        { issues: [9], after: [0, 1] },
+      ],
+      reviewLoop: false,
+    })
+    const prompt = promptFor(events, 'implement:#9 (fable/high)')
+
+    expect(prompt).toContain(`baseRefs: [{"pr":1002,"ref":"codex/issue-2","sha":"${headSha(2)}"},{"pr":1003,"ref":"codex/issue-3","sha":"${headSha(3)}"}]`)
+    expect(prompt.match(/Issue #2/g)).toHaveLength(1)
+    expect(prompt.match(/Issue #3/g)).toHaveLength(1)
+  })
+
+  test('blocks ordering and hard descendants behind an unresolved review', async () => {
+    const { output, events } = await executeWorkflow({
+      tracks: [
+        { issues: [2] },
+        { issues: [9], after: [0] },
+        { issues: [12], runsAfter: [0] },
+      ],
+      reviewLoop: true,
+    }, {
+      'review-loop:PR#1002': () => ({
+        final_status: 'blocked',
+        cycles_run: 1,
+        summary: 'review failed',
+        head_ref: 'codex/issue-2',
+        head_sha: headSha(2, 'b'),
+      }),
+    })
+
+    expect(started(events, 'validate:#9')).toBeFalse()
+    expect(started(events, 'validate:#12')).toBeFalse()
+    expect(output.results.filter((result) => result.status === 'dependency_blocked')).toHaveLength(2)
+  })
+
+  test('rejects an LGTM boundary that omits its verified head', async () => {
+    const { output, events } = await executeWorkflow({
+      tracks: [{ issues: [2] }, { issues: [9], after: [0] }],
+      reviewLoop: true,
+    }, {
+      'review-loop:PR#1002': () => ({ final_status: 'lgtm', cycles_run: 1, summary: 'approved' }),
+    })
+
+    expect(output.results.find((result) => result.issue === 2)?.status).toBe('review_invalid_head')
+    expect(output.results.find((result) => result.issue === 9)?.status).toBe('dependency_blocked')
+    expect(started(events, 'validate:#9')).toBeFalse()
+  })
+
+  test('contains thrown track failures and reports blocked descendants', async () => {
+    const { output } = await executeWorkflow({
+      tracks: [{ issues: [2] }, { issues: [9], after: [0] }, { issues: [12] }],
+      reviewLoop: false,
+    }, {
+      'validate:#2': () => { throw new Error('validator crashed') },
+    })
+
+    expect(output.results.find((result) => result.issue === 2)?.status).toBe('validation_failed')
+    expect(output.results.find((result) => result.issue === 9)?.status).toBe('dependency_blocked')
+    expect(output.results.find((result) => result.issue === 12)?.status).toBe('pr_open')
+  })
+
+  test('stops hard descendants when dependency-base integration fails', async () => {
+    const { output, events } = await executeWorkflow({
+      tracks: [
+        { issues: [2] },
+        { issues: [3] },
+        { issues: [9], after: [0, 1] },
+        { issues: [12], after: [2] },
+      ],
+      reviewLoop: false,
+    }, {
+      'implement:#9 (fable/high)': () => ({
+        pr_number: 0,
+        pr_url: '',
+        head_ref: '',
+        head_sha: '',
+        summary: 'blocked',
+        tests_passed: false,
+        blocker: 'dependency-base merge conflict',
+      }),
+    })
+
+    expect(promptFor(events, 'implement:#9 (fable/high)')).toContain(`baseRefs: [{"pr":1002,"ref":"codex/issue-2","sha":"${headSha(2)}"},{"pr":1003,"ref":"codex/issue-3","sha":"${headSha(3)}"}]`)
+    expect(output.results.find((result) => result.issue === 9)?.blocker).toContain('merge conflict')
+    expect(output.results.find((result) => result.issue === 12)?.status).toBe('dependency_blocked')
+  })
+})

--- a/tests/milestone-pipeline.test.js
+++ b/tests/milestone-pipeline.test.js
@@ -168,6 +168,8 @@ describe('milestone-pipeline dependency scheduling', () => {
     ['self dependency', { tracks: [{ issues: [2], runsAfter: [0] }] }, /track 1.*itself/i],
     ['duplicate predecessor', { tracks: [{ issues: [2] }, { issues: [3], after: [0, 0] }] }, /track 2.*duplicate predecessor/i],
     ['conflicting edge types', { tracks: [{ issues: [2] }, { issues: [3], after: [0], runsAfter: [0] }] }, /track 2.*duplicate predecessor/i],
+    ['misspelled ordering key', { tracks: [{ issues: [2] }, { issues: [9], runAfter: [0] }] }, /track 2.*unknown key.*runAfter/i],
+    ['capitalized hard-edge key', { tracks: [{ issues: [2] }, { issues: [9], After: [0] }] }, /track 2.*unknown key.*After/i],
     ['cycle', { tracks: [{ issues: [2], after: [1] }, { issues: [3], runsAfter: [0] }] }, /cycle.*track/i],
   ])('rejects %s before prep', async (_name, args, message) => {
     let prepStarted = false

--- a/workflows/milestone-pipeline.js
+++ b/workflows/milestone-pipeline.js
@@ -1,35 +1,100 @@
 export const meta = {
   name: 'milestone-pipeline',
-  description: 'Implement a milestone of Execution-block-stamped GitHub issues — Fable-validate each issue against the current code, optional Fable plan, build on the assigned model/effort, open PRs, @claude review loops until LGTM — parallel across dependency tracks, sequential within',
-  whenToUse: 'When the user has approved a milestone-workflow run plan over issues that already carry ## Execution blocks (build model, effort, fableplan). args: { tracks: [[2,3,4],[9],[12]], reviewLoop?: true, maxReviewCycles?: 5 }',
+  description: 'Implement a dependency graph of Execution-block-stamped GitHub issues — validate, plan, build from verified prerequisite heads, and review each pull request to a stable readiness boundary',
+  whenToUse: 'When the user has approved a milestone-workflow run plan. args: { tracks: [[2,3]] } or { tracks: [{issues:[2,3]}, {issues:[9], after:[0]}, {issues:[12], runsAfter:[0]}], reviewLoop?: true, maxReviewCycles?: 5 }',
   phases: [
     { title: 'Prep', detail: 'read every issue\'s [C..] score and Execution block' },
-    { title: 'Validate', detail: 'Fable validates each issue against the current code right before it starts', model: 'fable' },
+    { title: 'Validate', detail: 'Fable validates each issue against its exact dependency base right before it starts', model: 'fable' },
     { title: 'Plan', detail: 'Fable plans the issues flagged fableplan: Yes; plans posted to the issues', model: 'fable' },
     { title: 'Implement', detail: 'build each issue on its assigned model/effort in a worktree, open PR, trigger @claude review' },
-    { title: 'Review Loop', detail: 'fix-pr-review cycles per PR until LGTM; runs concurrently with later issues in the track' },
+    { title: 'Review Loop', detail: 'fix-pr-review cycles per PR until LGTM; unrelated tracks stay concurrent while successors wait' },
   ],
 }
 
-// args.tracks: array of tracks; each track is an ordered array of issue numbers.
-// Tracks run in parallel; issues within a track run sequentially (later issues
-// get earlier issues' PR numbers as in-flight context). Cross-track dependencies
-// are NOT expressible here — chain separate workflow invocations per phase.
+// args.tracks accepts legacy issue-number arrays and dependency-aware objects.
+// `after` is a hard code dependency; `runsAfter` is ordering only. Serial issues
+// within every track are conservative hard dependencies because their edge kind
+// is not explicit. The full graph is validated before any agent starts.
 // Unlike issue-pipeline, there is no complexity-threshold model routing:
 // model/effort/fableplan come from each issue's ## Execution block (stamped by
 // prd-to-issues, revised by execution-plan-review). Validation still runs as the
-// first step of every issue — even freshly-authored issues go stale as earlier
-// PRs in the milestone change the ground truth, so each issue is re-checked
-// against the current code immediately before it starts.
+// first step of every issue. Predecessor PRs change the ground truth, so each
+// issue is re-checked against its pinned dependency heads immediately before it
+// starts.
 // Some harness paths deliver args as a JSON string — normalize before validating.
 const ARGS = typeof args === 'string' ? JSON.parse(args) : args
 if (!ARGS || !Array.isArray(ARGS.tracks) || ARGS.tracks.length === 0) {
-  throw new Error('milestone-pipeline requires args.tracks: an array of issue-number arrays, e.g. { tracks: [[2,3,4],[9],[12]] }')
+  throw new Error('milestone-pipeline requires a non-empty args.tracks array')
 }
-const TRACKS = ARGS.tracks
+
+function assertIndexList(value, field, trackIndex) {
+  if (!Array.isArray(value)) {
+    throw new Error(`track ${trackIndex + 1} requires ${field} to be an array of track indices`)
+  }
+  return [...value]
+}
+
+const issueOwners = new Map()
+const TRACKS = ARGS.tracks.map((input, trackIndex) => {
+  const legacy = Array.isArray(input)
+  if (!legacy && (!input || typeof input !== 'object' || Array.isArray(input))) {
+    throw new Error(`track ${trackIndex + 1} must be an issue array or { issues, after?, runsAfter? }`)
+  }
+
+  const issues = legacy ? input : input.issues
+  if (!Array.isArray(issues) || issues.length === 0) {
+    throw new Error(`track ${trackIndex + 1} requires a non-empty issues array`)
+  }
+  for (const issue of issues) {
+    if (!Number.isInteger(issue) || issue <= 0) {
+      throw new Error(`track ${trackIndex + 1} has invalid issue number ${String(issue)}`)
+    }
+    if (issueOwners.has(issue)) {
+      throw new Error(`issue #${issue} is assigned more than once (tracks ${issueOwners.get(issue) + 1} and ${trackIndex + 1})`)
+    }
+    issueOwners.set(issue, trackIndex)
+  }
+
+  const after = legacy ? [] : assertIndexList(input.after ?? [], 'after', trackIndex)
+  const runsAfter = legacy ? [] : assertIndexList(input.runsAfter ?? [], 'runsAfter', trackIndex)
+  const predecessors = new Set()
+  for (const predecessor of [...after, ...runsAfter]) {
+    if (!Number.isInteger(predecessor) || predecessor < 0 || predecessor >= ARGS.tracks.length) {
+      throw new Error(`track ${trackIndex + 1} has invalid predecessor index ${String(predecessor)}`)
+    }
+    if (predecessor === trackIndex) {
+      throw new Error(`track ${trackIndex + 1} cannot depend on itself`)
+    }
+    if (predecessors.has(predecessor)) {
+      throw new Error(`track ${trackIndex + 1} has duplicate predecessor index ${predecessor}`)
+    }
+    predecessors.add(predecessor)
+  }
+
+  return { issues: [...issues], after, runsAfter, legacy }
+})
+
+const visitState = TRACKS.map(() => 0)
+function visitTrack(trackIndex, path) {
+  if (visitState[trackIndex] === 2) return
+  if (visitState[trackIndex] === 1) {
+    const cycle = [...path, trackIndex].map((index) => `track ${index + 1}`).join(' → ')
+    throw new Error(`dependency cycle detected: ${cycle}`)
+  }
+  visitState[trackIndex] = 1
+  const nextPath = [...path, trackIndex]
+  for (const predecessor of [...TRACKS[trackIndex].after, ...TRACKS[trackIndex].runsAfter]) {
+    visitTrack(predecessor, nextPath)
+  }
+  visitState[trackIndex] = 2
+}
+TRACKS.forEach((_track, trackIndex) => visitTrack(trackIndex, []))
+
 const REVIEW_LOOP = ARGS.reviewLoop ?? true
 const MAX_REVIEW_CYCLES = ARGS.maxReviewCycles ?? 5
-const ALL_ISSUES = TRACKS.flat()
+if (typeof REVIEW_LOOP !== 'boolean') throw new Error('reviewLoop must be a boolean')
+if (!Number.isInteger(MAX_REVIEW_CYCLES) || MAX_REVIEW_CYCLES <= 0) throw new Error('maxReviewCycles must be a positive integer')
+const ALL_ISSUES = TRACKS.flatMap((track) => track.issues)
 
 const MODEL_IDS = { 'fable': 'fable', 'opus': 'opus', 'sonnet': 'sonnet', 'haiku': 'haiku' }
 const MODEL_NAMES = { fable: 'Fable 5', opus: 'Opus 4.8', sonnet: 'Sonnet 5', haiku: 'Haiku 4.5' }
@@ -81,10 +146,12 @@ const PLAN_SCHEMA = {
 
 const IMPLEMENT_SCHEMA = {
   type: 'object',
-  required: ['pr_number', 'pr_url', 'summary', 'tests_passed'],
+  required: ['pr_number', 'pr_url', 'head_ref', 'head_sha', 'summary', 'tests_passed'],
   properties: {
     pr_number: { type: 'integer', description: '0 if blocked / no PR opened' },
     pr_url: { type: 'string' },
+    head_ref: { type: 'string', description: 'Verified pull request head branch; empty if blocked / no PR opened' },
+    head_sha: { type: 'string', description: 'Verified pull request head commit at implementation completion; empty if blocked / no PR opened' },
     summary: { type: 'string' },
     tests_passed: { type: 'boolean' },
     blocker: { type: 'string', description: 'Only if blocked: what stopped you' },
@@ -94,22 +161,35 @@ const IMPLEMENT_SCHEMA = {
 
 const REVIEW_LOOP_SCHEMA = {
   type: 'object',
-  required: ['final_status', 'cycles_run', 'summary'],
+  required: ['final_status', 'cycles_run', 'summary', 'head_ref', 'head_sha'],
   properties: {
     final_status: { type: 'string', enum: ['lgtm', 'lgtm_with_nonblocking', 'max_cycles_exhausted', 'blocked'] },
     cycles_run: { type: 'integer' },
     summary: { type: 'string', description: 'Per-cycle findings fixed/rejected, and why the loop stopped' },
+    head_ref: { type: 'string', description: 'Exact pull request head branch at the review readiness boundary' },
+    head_sha: { type: 'string', description: 'Exact pull request head commit at the review readiness boundary' },
     blocker: { type: 'string', description: 'Only when final_status is blocked' },
   },
 }
 
-function validatePrompt(issue, trackContext, skippedContext) {
+function completedContext(completed) {
+  return completed.map((record) => `- Issue #${record.issue} → PR #${record.prNumber} (head: ${record.head.ref} @ ${record.head.sha})`).join('\n')
+}
+
+function skippedContext(skipped) {
+  return skipped.map((record) => `- Issue #${record.issue}: ${record.reason}`).join('\n')
+}
+
+function validatePrompt(issue, completed, skipped, baseRefs) {
+  const predecessorContext = completedContext(completed)
+  const missingContext = skippedContext(skipped)
   return [
     `You are a read-only validation agent in this repo. Invoke the \`validate-issue\` skill with args \`${issue}\` and follow its procedure exactly:`,
     `fetch GitHub issue #${issue} with \`gh issue view ${issue}\`, verify every factual claim (including PRD section references) against the actual code and PRD with file:line citations,`,
     `check architectural feasibility and self-consistency of the approach, and check for staleness: whether code merged since the issue was filed changes its best approach.`,
-    trackContext ? `\nRelevant in-flight context from earlier issues in this dependency chain (account for these landing first):\n${trackContext}` : '',
-    skippedContext ? `\nEarlier issues in this track were SKIPPED (blocked or invalid) — their code does NOT exist anywhere:\n${skippedContext}\nDetermine whether issue #${issue} hard-depends on any skipped issue's work (would build on code that was never written). If it does, return verdict INVALID with invalid_reason naming the unmet dependency (e.g. "unmet in-track dependency #N: <why>"). If it is independent of the skipped work (e.g. merely same-package), proceed normally.` : '',
+    predecessorContext ? `\nStable predecessor results (deduplicated):\n${predecessorContext}` : '',
+    missingContext ? `\nSkipped predecessor results whose code does not exist:\n${missingContext}` : '',
+    baseRefs.length ? `\nHard dependency base refs, ordered by predecessor track and pinned to the reviewed pull request commits: ${JSON.stringify(baseRefs)}. Verify each PR/ref/SHA tuple and validate against those exact commits, not only the default branch, before returning a valid verdict.` : '',
     `\nDo NOT modify any files, do NOT comment on the issue, do NOT start implementing.`,
     `Return via StructuredOutput: verdict (VALID / VALID_WITH_CORRECTIONS / INVALID), a verdict summary, the concrete issue-body corrections needed,`,
     `and the implementation constraints an implementer must honor (repo invariants at risk, refuted approaches, the preferred approach, merge-order notes).`,
@@ -134,21 +214,26 @@ Post the plan as a comment on issue #${issue} (footer: \`Created with LLM: Fable
 Return via StructuredOutput: the plan text, and the distilled hard constraints the builder must honor.`
 }
 
-function implementPrompt(issue, ex, validation, plan, trackContext, skippedContext) {
+function implementPrompt(issue, ex, validation, plan, completed, skipped, baseRefs) {
   const footerModel = MODEL_NAMES[ex.model]
   const corrections = validation.corrections.length
     ? validation.corrections.map((c) => `- ${c}`).join('\n')
     : ''
   const constraints = (validation.implementation_constraints || []).concat(plan ? plan.constraints : [])
+  const predecessorContext = completedContext(completed)
+  const missingContext = skippedContext(skipped)
+  const workOnIssueArgs = baseRefs.length
+    ? `{ issue: ${issue}, baseRefs: ${JSON.stringify(baseRefs)} }`
+    : `{ issue: ${issue} }`
   return `You are an implementation agent in this repo. Your job: implement GitHub issue #${issue} end-to-end and open a PR.
 
 Validation summary (from a Fable review of the issue against the current code): ${validation.summary}
-${trackContext ? `\nIn-flight context from earlier issues in this dependency chain (their PRs are open, not merged — branch off the dependency's PR branch when your work hard-requires its code, and note merge order in your PR body):\n${trackContext}\n` : ''}${skippedContext ? `\nEarlier issues in this track were SKIPPED (blocked or invalid) — their code does NOT exist anywhere:\n${skippedContext}\nIf during implementation you find issue #${issue} hard-requires a skipped issue's work, STOP and return blocked (pr_number 0) with the unmet dependency as the blocker — never improvise the missing base yourself.\n` : ''}${corrections ? `\nStep 1 — Update the issue body first. Load the \`github-issue-format\` skill BEFORE editing (mandatory), then apply these validation corrections to issue #${issue} (preserve the rest of the body — including the ## Execution block — and the [C..] title unless a correction says otherwise):\n${corrections}\nFooter: \`Updated with LLM: ${footerModel} | ${ex.effort} | Harness: milestone-pipeline\`.\n` : ''}${plan ? `\nA Fable 5 implementation plan was posted on the issue — implement against it. Deviating is allowed only with a stated reason in the PR body.\n` : ''}${constraints.length ? `\nHard requirements from validation${plan ? ' and the plan' : ''} (violating any is a correctness failure):\n${constraints.map((c) => `- ${c}`).join('\n')}\n` : ''}
-Invoke the \`work-on-issue\` skill with args \`${issue}\`: isolated worktree off latest origin/main, implement per the ${corrections ? 'corrected ' : ''}issue body (its Acceptance criteria are the contract — including the negative ones), follow repo conventions in CLAUDE.md. Add tests for every behavior you introduce. Run the project's full test and build suites; if a test fails, verify whether it also fails on unmodified main before dismissing it as pre-existing, and say so. Commit + open a PR closing #${issue}, footer \`Created with LLM: ${footerModel} | ${ex.effort} | Harness: milestone-pipeline\`.
+${predecessorContext ? `\nStable predecessor results (deduplicated):\n${predecessorContext}\n` : ''}${missingContext ? `\nSkipped predecessor results whose code does not exist:\n${missingContext}\n` : ''}${corrections ? `\nStep 1 — Update the issue body first. Load the \`github-issue-format\` skill BEFORE editing (mandatory), then apply these validation corrections to issue #${issue} (preserve the rest of the body — including the ## Execution block — and the [C..] title unless a correction says otherwise):\n${corrections}\nFooter: \`Updated with LLM: ${footerModel} | ${ex.effort} | Harness: milestone-pipeline\`.\n` : ''}${plan ? `\nA Fable 5 implementation plan was posted on the issue — implement against it. Deviating is allowed only with a stated reason in the PR body.\n` : ''}${constraints.length ? `\nHard requirements from validation${plan ? ' and the plan' : ''} (violating any is a correctness failure):\n${constraints.map((c) => `- ${c}`).join('\n')}\n` : ''}
+Invoke the \`work-on-issue\` skill with args \`${workOnIssueArgs}\`. When baseRefs are present, validate them and prepare the dependency base exactly as that skill requires before changing product files; never fall back to the default branch or omit a ref after an integration conflict. Implement per the ${corrections ? 'corrected ' : ''}issue body (its Acceptance criteria are the contract — including the negative ones), follow repo conventions in CLAUDE.md, and note dependency merge order in the PR body. Add tests for every behavior you introduce. Run the project's full test and build suites; if a test fails, verify whether it also fails on the unmodified base before dismissing it as pre-existing, and say so. Commit + open a PR closing #${issue}, footer \`Created with LLM: ${footerModel} | ${ex.effort} | Harness: milestone-pipeline\`.
 
-After the PR is open, trigger the review bot with its own one-line comment, no footer: \`gh pr comment <num> --body "@claude review"\`. (If the repo's .github/workflows/claude.yml uses a different trigger phrase, match it.)
+${REVIEW_LOOP ? 'After the PR is open, trigger the review bot with its own one-line comment, no footer: `gh pr comment <num> --body "@claude review"`. (If the repo\'s .github/workflows/claude.yml uses a different trigger phrase, match it.)' : 'This run has reviewLoop disabled: do not trigger the review bot.'}
 
-Return via StructuredOutput: pr_number, pr_url, summary, tests_passed, any blocker, and flags the operator should know about. If blocked, return the blocker instead of guessing.`
+Verify the opened PR with \`gh pr view <num> --json headRefName,headRefOid\`. Return via StructuredOutput: pr_number, pr_url, head_ref (exact headRefName), head_sha (exact headRefOid), summary, tests_passed, any blocker, and flags the operator should know about. If blocked, return pr_number 0, empty head fields, and the blocker instead of guessing.`
 }
 
 function reviewLoopPrompt(issue, prNumber, ex, validation, plan) {
@@ -164,7 +249,7 @@ ${constraints.length ? constraints.map((c) => `- ${c}`).join('\n') + '\n' : ''}
 
 Work ONLY in the PR branch's existing worktree (or add a worktree for the branch if missing) — never the main checkout.
 
-Return via StructuredOutput: final_status (lgtm / lgtm_with_nonblocking / max_cycles_exhausted / blocked), cycles_run, a per-cycle summary of findings fixed vs rejected, and any blocker.`
+At the stopping boundary, verify \`gh pr view ${prNumber} --json headRefName,headRefOid\`. Return via StructuredOutput: final_status (lgtm / lgtm_with_nonblocking / max_cycles_exhausted / blocked), cycles_run, a per-cycle summary, the exact head_ref and head_sha at that boundary, and any blocker.`
 }
 
 // ---- Prep: one agent reads every issue's Execution block ----
@@ -184,42 +269,135 @@ const EX = new Map(prep.issues.map((i) => [i.number, i]))
 const missing = prep.issues.filter((i) => i.missing_block).map((i) => `#${i.number}`)
 if (missing.length) log(`WARNING: no Execution block on ${missing.join(', ')} — running them on conservative defaults (fable/high)`)
 
-// ---- Tracks: parallel across, sequential within ----
+// ---- Dependency graph: unrelated tracks run concurrently; every successor
+// waits for its predecessors' stable readiness boundary. ----
 const results = []
-const reviewLoops = []
+const recordedIssues = new Set()
 
-await parallel(
-  TRACKS.map((track, ti) => async () => {
-    const done = [] // { issue, prNumber }
-    const skipped = [] // { issue, reason } — in-track issues that never produced a PR
-    for (const issue of track) {
-      const ex = EX.get(issue) || { number: issue, title: `#${issue}`, complexity: 0, model: 'fable', effort: 'high', fableplan: false }
-      const modelId = MODEL_IDS[ex.model] || 'fable'
-      const trackContext = done.map((d) => `- Issue #${d.issue} → PR #${d.prNumber} (open, not yet merged)`).join('\n')
-      const skippedContext = skipped.map((s) => `- Issue #${s.issue}: ${s.reason}`).join('\n')
+function addResult(result) {
+  if (recordedIssues.has(result.issue)) throw new Error(`internal error: duplicate result for issue #${result.issue}`)
+  recordedIssues.add(result.issue)
+  results.push(result)
+}
 
-      const validation = await agent(validatePrompt(issue, trackContext, skippedContext), {
+function dedupeRecords(records) {
+  const seen = new Set()
+  return records.filter((record) => {
+    if (seen.has(record.issue)) return false
+    seen.add(record.issue)
+    return true
+  })
+}
+
+function dedupeBaseRefs(values) {
+  const seen = new Set()
+  return values.filter((base) => {
+    if (!base || seen.has(base.pr)) return false
+    seen.add(base.pr)
+    return true
+  })
+}
+
+function verifiedHead(pr, ref, sha) {
+  if (!Number.isInteger(pr) || pr <= 0) return null
+  if (typeof ref !== 'string' || ref.length === 0) return null
+  if (typeof sha !== 'string' || !/^[0-9a-f]{40,64}$/i.test(sha)) return null
+  return { pr, ref, sha: sha.toLowerCase() }
+}
+
+function blockIssues(track, startIndex, reason, skipped) {
+  for (const issue of track.issues.slice(startIndex)) {
+    addResult({ issue, status: 'dependency_blocked', blocker: reason })
+    skipped.push({ issue, reason })
+    log(`#${issue}: blocked — ${reason}`)
+  }
+}
+
+function trackOutcome(status, completed, skipped, head, unresolved, blocker) {
+  return {
+    status,
+    completed: dedupeRecords(completed),
+    skipped: dedupeRecords(skipped),
+    head,
+    unresolved,
+    blocker,
+  }
+}
+
+async function executeTrack(trackIndex) {
+  const track = TRACKS[trackIndex]
+  const hardPredecessors = await Promise.all(track.after.map(async (index) => ({ index, outcome: await runTrack(index) })))
+  const orderingPredecessors = await Promise.all(track.runsAfter.map(async (index) => ({ index, outcome: await runTrack(index) })))
+  const predecessorOutcomes = [...hardPredecessors, ...orderingPredecessors].map((entry) => entry.outcome)
+  const inheritedCompleted = dedupeRecords(predecessorOutcomes.flatMap((outcome) => outcome.completed))
+  const inheritedSkipped = dedupeRecords(predecessorOutcomes.flatMap((outcome) => outcome.skipped))
+
+  const failedHard = hardPredecessors.find(({ outcome }) => outcome.status !== 'ready' || !outcome.head)
+  if (failedHard) {
+    const reason = `hard prerequisite track ${failedHard.index + 1} did not reach a stable code head: ${failedHard.outcome.blocker || failedHard.outcome.status}`
+    const localSkipped = []
+    blockIssues(track, 0, reason, localSkipped)
+    return trackOutcome('blocked', inheritedCompleted, [...inheritedSkipped, ...localSkipped], null, false, reason)
+  }
+
+  const unresolvedOrdering = orderingPredecessors.find(({ outcome }) => outcome.unresolved)
+  if (unresolvedOrdering) {
+    const reason = `ordering prerequisite track ${unresolvedOrdering.index + 1} has an unresolved pull request: ${unresolvedOrdering.outcome.blocker || unresolvedOrdering.outcome.status}`
+    const localSkipped = []
+    blockIssues(track, 0, reason, localSkipped)
+    return trackOutcome('blocked', inheritedCompleted, [...inheritedSkipped, ...localSkipped], null, false, reason)
+  }
+
+  const localCompleted = []
+  const localSkipped = []
+  let baseRefs = dedupeBaseRefs(hardPredecessors.map(({ outcome }) => outcome.head))
+  let head = null
+  let status = 'ready'
+  let blocker = null
+  let unresolved = false
+
+  for (let issueIndex = 0; issueIndex < track.issues.length; issueIndex += 1) {
+    const issue = track.issues[issueIndex]
+    const ex = EX.get(issue) || { number: issue, title: `#${issue}`, complexity: 0, model: 'fable', effort: 'high', fableplan: false }
+    const modelId = MODEL_IDS[ex.model] || 'fable'
+    const completed = dedupeRecords([...inheritedCompleted, ...localCompleted])
+    const skipped = dedupeRecords([...inheritedSkipped, ...localSkipped])
+
+    let validation
+    try {
+      validation = await agent(validatePrompt(issue, completed, skipped, baseRefs), {
         model: 'fable',
         effort: ex.validate_effort || 'high',
         schema: VALIDATION_SCHEMA,
         phase: 'Validate',
         label: `validate:#${issue}`,
       })
-      if (!validation) {
-        log(`#${issue}: validation agent failed — skipping issue, continuing track ${ti + 1}`)
-        results.push({ issue, status: 'validation_failed' })
-        skipped.push({ issue, reason: 'validation agent failed — issue never validated or implemented' })
-        continue
-      }
-      if (validation.verdict === 'INVALID') {
-        log(`#${issue}: INVALID — ${validation.invalid_reason || validation.summary}; not implementing, continuing track ${ti + 1}`)
-        results.push({ issue, status: 'invalid', reason: validation.invalid_reason || validation.summary })
-        skipped.push({ issue, reason: `validated INVALID — ${validation.invalid_reason || validation.summary}` })
-        continue
-      }
+    } catch (error) {
+      validation = null
+      blocker = `validation threw: ${error?.message || error}`
+    }
+    if (!validation) {
+      blocker ||= 'validation agent failed'
+      log(`#${issue}: ${blocker}; blocking later issues in track ${trackIndex + 1}`)
+      addResult({ issue, status: 'validation_failed', blocker })
+      localSkipped.push({ issue, reason: `${blocker} — issue never implemented` })
+      status = 'blocked'
+      blockIssues(track, issueIndex + 1, `unmet in-track hard prerequisite #${issue}: ${blocker}`, localSkipped)
+      break
+    }
+    if (validation.verdict === 'INVALID') {
+      blocker = validation.invalid_reason || validation.summary
+      log(`#${issue}: INVALID — ${blocker}; blocking later issues in track ${trackIndex + 1}`)
+      addResult({ issue, status: 'invalid', reason: blocker })
+      localSkipped.push({ issue, reason: `validated INVALID — ${blocker}` })
+      status = 'blocked'
+      blockIssues(track, issueIndex + 1, `unmet in-track hard prerequisite #${issue}: ${blocker}`, localSkipped)
+      break
+    }
 
-      let plan = null
-      if (ex.fableplan) {
+    let plan = null
+    if (ex.fableplan) {
+      try {
         plan = await agent(planPrompt(issue, validation), {
           model: 'fable',
           effort: 'high',
@@ -227,58 +405,125 @@ await parallel(
           phase: 'Plan',
           label: `plan:#${issue}`,
         })
-        if (!plan) log(`#${issue}: fableplan agent failed — building without a posted plan`)
+      } catch (error) {
+        log(`#${issue}: fableplan threw — ${error?.message || error}; building without a posted plan`)
       }
+      if (!plan) log(`#${issue}: fableplan agent failed — building without a posted plan`)
+    }
 
-      log(`#${issue} (C${ex.complexity}): ${validation.verdict} → implementing on ${MODEL_NAMES[modelId]} @ ${ex.effort}${plan ? ' (against Fable plan)' : ''}`)
-      const impl = await agent(implementPrompt(issue, ex, validation, plan, trackContext, skippedContext), {
+    log(`#${issue} (C${ex.complexity}): ${validation.verdict} → implementing on ${MODEL_NAMES[modelId]} @ ${ex.effort}${plan ? ' (against Fable plan)' : ''}`)
+    let impl
+    try {
+      impl = await agent(implementPrompt(issue, ex, validation, plan, completed, skipped, baseRefs), {
         model: modelId,
         effort: ex.effort,
         schema: IMPLEMENT_SCHEMA,
         phase: 'Implement',
         label: `implement:#${issue} (${modelId}/${ex.effort})`,
       })
-      if (!impl || !impl.pr_number) {
-        log(`#${issue}: implementation ${impl ? `blocked — ${impl.blocker || 'no PR opened'}` : 'agent failed'}; continuing track ${ti + 1}`)
-        results.push({ issue, status: 'blocked', blocker: impl?.blocker })
-        skipped.push({ issue, reason: `implementation ${impl ? `blocked — ${impl.blocker || 'no PR opened'}` : 'agent failed'}` })
-        continue
+    } catch (error) {
+      impl = null
+      blocker = `implementation threw: ${error?.message || error}`
+    }
+
+    const implementationHead = impl ? verifiedHead(impl.pr_number, impl.head_ref, impl.head_sha) : null
+    if (!impl || !implementationHead) {
+      blocker ||= impl?.blocker || (impl?.pr_number ? 'opened pull request without a verified head ref and commit' : 'implementation agent failed or opened no pull request')
+      log(`#${issue}: blocked — ${blocker}; blocking later issues in track ${trackIndex + 1}`)
+      addResult({ issue, status: 'blocked', blocker })
+      localSkipped.push({ issue, reason: `implementation blocked — ${blocker}` })
+      status = 'blocked'
+      unresolved = !impl || Boolean(impl.pr_number)
+      blockIssues(track, issueIndex + 1, `unmet in-track hard prerequisite #${issue}: ${blocker}`, localSkipped)
+      break
+    }
+
+    head = implementationHead
+    const record = {
+      issue,
+      status: 'pr_open',
+      pr: impl.pr_number,
+      pr_url: impl.pr_url,
+      head_ref: impl.head_ref,
+      head_sha: impl.head_sha,
+      tests_passed: impl.tests_passed,
+      flags: impl.flags || [],
+    }
+    addResult(record)
+    log(`#${issue}: PR #${impl.pr_number} open on ${impl.head_ref}${REVIEW_LOOP ? '; waiting for review readiness' : ''}`)
+
+    if (REVIEW_LOOP) {
+      let review
+      try {
+        review = await agent(reviewLoopPrompt(issue, impl.pr_number, ex, validation, plan), {
+          model: modelId,
+          effort: ex.effort,
+          schema: REVIEW_LOOP_SCHEMA,
+          phase: 'Review Loop',
+          label: `review-loop:PR#${impl.pr_number}`,
+        })
+      } catch (error) {
+        review = { final_status: 'blocked', cycles_run: 0, summary: `review-loop threw: ${error?.message || error}` }
       }
-
-      log(`#${issue}: PR #${impl.pr_number} open, @claude review triggered`)
-      const rec = { issue, status: 'pr_open', pr: impl.pr_number, pr_url: impl.pr_url, tests_passed: impl.tests_passed, flags: impl.flags || [] }
-      results.push(rec)
-      done.push({ issue, prNumber: impl.pr_number })
-
-      // Review loop runs concurrently — the track moves on to its next issue
-      // while this PR is driven to LGTM. Same model/effort as the build.
-      if (REVIEW_LOOP) {
-        reviewLoops.push(
-          agent(reviewLoopPrompt(issue, impl.pr_number, ex, validation, plan), {
-            model: modelId,
-            effort: ex.effort,
-            schema: REVIEW_LOOP_SCHEMA,
-            phase: 'Review Loop',
-            label: `review-loop:PR#${impl.pr_number}`,
-          }).then(
-            (review) => review || { final_status: 'blocked', cycles_run: 0, summary: 'review-loop agent failed' },
-            // Catch throws (e.g. token-budget exhaustion) so one failed loop
-            // can't reject Promise.all below and discard every collected result.
-            (err) => ({ final_status: 'blocked', cycles_run: 0, summary: `review-loop threw: ${err?.message || err}` })
-          ).then((review) => {
-            rec.review = review
-            rec.status = review.final_status === 'lgtm' || review.final_status === 'lgtm_with_nonblocking' ? 'lgtm' : 'review_' + review.final_status
-            log(`PR #${impl.pr_number}: review loop ${review.final_status} after ${review.cycles_run} cycle(s)`)
-          })
-        )
+      review ||= { final_status: 'blocked', cycles_run: 0, summary: 'review-loop agent failed', head_ref: '', head_sha: '' }
+      record.review = review
+      const reviewApproved = review.final_status === 'lgtm' || review.final_status === 'lgtm_with_nonblocking'
+      const reviewHead = verifiedHead(impl.pr_number, review.head_ref, review.head_sha)
+      const reviewReady = reviewApproved && reviewHead?.ref === implementationHead.ref
+      if (reviewHead) {
+        head = reviewHead
+        record.head_ref = review.head_ref
+        record.head_sha = review.head_sha
+      }
+      record.status = reviewReady ? 'lgtm' : reviewApproved ? 'review_invalid_head' : `review_${review.final_status}`
+      log(`PR #${impl.pr_number}: review loop ${review.final_status} after ${review.cycles_run} cycle(s)`)
+      if (!reviewReady) {
+        blocker = reviewApproved
+          ? `PR #${impl.pr_number} review reached LGTM without a verified readiness head`
+          : `PR #${impl.pr_number} review did not reach LGTM: ${review.summary}`
+        localSkipped.push({ issue, reason: blocker })
+        status = 'blocked'
+        unresolved = true
+        blockIssues(track, issueIndex + 1, `unmet in-track hard prerequisite #${issue}: ${blocker}`, localSkipped)
+        break
       }
     }
-  })
-)
 
-if (reviewLoops.length) {
-  log(`all tracks done; waiting on ${reviewLoops.length} review loop(s)`)
-  await Promise.all(reviewLoops)
+    localCompleted.push({ issue, prNumber: impl.pr_number, prUrl: impl.pr_url, head })
+    baseRefs = [head]
+  }
+
+  return trackOutcome(
+    status,
+    [...inheritedCompleted, ...localCompleted],
+    [...inheritedSkipped, ...localSkipped],
+    head,
+    unresolved,
+    blocker,
+  )
 }
 
+const trackPromises = new Array(TRACKS.length)
+function runTrack(trackIndex) {
+  if (!trackPromises[trackIndex]) {
+    trackPromises[trackIndex] = executeTrack(trackIndex).catch((error) => {
+      const reason = `track ${trackIndex + 1} threw: ${error?.message || error}`
+      const skipped = []
+      const unresolved = REVIEW_LOOP && results.some((result) => TRACKS[trackIndex].issues.includes(result.issue) && result.pr && result.status !== 'lgtm')
+      for (const issue of TRACKS[trackIndex].issues) {
+        if (recordedIssues.has(issue)) continue
+        addResult({ issue, status: 'track_failed', blocker: reason })
+        skipped.push({ issue, reason })
+      }
+      log(reason)
+      return trackOutcome('blocked', [], skipped, null, unresolved, reason)
+    })
+  }
+  return trackPromises[trackIndex]
+}
+
+await parallel(TRACKS.map((_track, trackIndex) => () => runTrack(trackIndex)))
+
+const resultOrder = new Map(ALL_ISSUES.map((issue, index) => [issue, index]))
+results.sort((left, right) => resultOrder.get(left.issue) - resultOrder.get(right.issue))
 return { results }

--- a/workflows/milestone-pipeline.js
+++ b/workflows/milestone-pipeline.js
@@ -35,10 +35,17 @@ function assertIndexList(value, field, trackIndex) {
 }
 
 const issueOwners = new Map()
+const TRACK_KEYS = new Set(['issues', 'after', 'runsAfter'])
 const TRACKS = ARGS.tracks.map((input, trackIndex) => {
   const legacy = Array.isArray(input)
   if (!legacy && (!input || typeof input !== 'object' || Array.isArray(input))) {
     throw new Error(`track ${trackIndex + 1} must be an issue array or { issues, after?, runsAfter? }`)
+  }
+  if (!legacy) {
+    const unknownKey = Object.keys(input).find((key) => !TRACK_KEYS.has(key))
+    if (unknownKey) {
+      throw new Error(`track ${trackIndex + 1} has unknown key "${unknownKey}"; allowed keys are issues, after, runsAfter`)
+    }
   }
 
   const issues = legacy ? input : input.issues


### PR DESCRIPTION
## Summary

- validate legacy and typed milestone dependency graphs before any agent starts
- wait for stable predecessor review results and pin hard dependencies to exact pull request head commits
- add deterministic multi-head integration rules to `work-on-issue` and document the typed workflow contract
- add a Bun async-workflow harness covering scheduling, failures, skips, review readiness, and base selection

## Verification

- `bun run test` (18 passing)
- `git diff --check`

Closes #25

---
Created with LLM: GPT-5 | high | Harness: Codex
