### PR TITLE
ci(#30): run Bun tests for pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Bun tests
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - run: bun run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 

--- a/tests/ci-workflow.test.js
+++ b/tests/ci-workflow.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test'
+
+const workflowUrl = new URL('../.github/workflows/test.yml', import.meta.url)
+const readWorkflow = () => Bun.file(workflowUrl).text()
+
+describe('Bun test workflow contract', () => {
+  test('runs for pull request revisions and pushes to main', async () => {
+    const workflow = await readWorkflow()
+
+    expect(workflow).toMatch(/on:\n  pull_request:\n    types: \[opened, reopened, synchronize\]\n  push:\n    branches: \[main\]/)
+  })
+
+  test('uses read-only permissions and the event-default checkout', async () => {
+    const workflow = await readWorkflow()
+
+    expect(workflow).toContain('permissions:\n  contents: read')
+    expect(workflow).toContain('uses: actions/checkout@v4')
+    expect(workflow).not.toMatch(/^\s+ref:/m)
+    expect(workflow).not.toMatch(/:\s*write$/m)
+  })
+
+  test('pins Bun and runs the repository test command', async () => {
+    const workflow = await readWorkflow()
+
+    expect(workflow).toContain('uses: oven-sh/setup-bun@v2')
+    expect(workflow).toContain('bun-version: 1.3.14')
+    expect(workflow).toContain('run: bun run test')
+  })
+
+  test('cancels only superseded runs for the same workflow ref', async () => {
+    const workflow = await readWorkflow()
+
+    expect(workflow).toContain('group: ${{ github.workflow }}-${{ github.ref }}')
+    expect(workflow).toContain('cancel-in-progress: true')
+  })
+})

--- a/tests/ci-workflow.test.js
+++ b/tests/ci-workflow.test.js
@@ -52,6 +52,12 @@ describe('Bun test workflow contract', () => {
     expect(workflow).toContain('run: bun run test')
   })
 
+  test('bounds hung test runs', async () => {
+    const workflow = await readWorkflow()
+
+    expect(workflow).toContain('timeout-minutes: 5')
+  })
+
   test('cancels only superseded runs for the same workflow ref', async () => {
     const workflow = await readWorkflow()
 

--- a/tests/ci-workflow.test.js
+++ b/tests/ci-workflow.test.js
@@ -2,6 +2,17 @@ import { describe, expect, test } from 'bun:test'
 
 const workflowUrl = new URL('../.github/workflows/test.yml', import.meta.url)
 const readWorkflow = () => Bun.file(workflowUrl).text()
+const readOnlyPermissions = 'permissions:\n  contents: read'
+
+function topLevelBlock(source, key) {
+  const lines = source.split('\n')
+  const start = lines.findIndex((line) => line.startsWith(`${key}:`))
+  if (start === -1) return null
+
+  let end = start + 1
+  while (end < lines.length && (lines[end] === '' || /^\s/.test(lines[end]))) end += 1
+  return lines.slice(start, end).join('\n').trimEnd()
+}
 
 describe('Bun test workflow contract', () => {
   test('runs for pull request revisions and pushes to main', async () => {
@@ -13,10 +24,24 @@ describe('Bun test workflow contract', () => {
   test('uses read-only permissions and the event-default checkout', async () => {
     const workflow = await readWorkflow()
 
-    expect(workflow).toContain('permissions:\n  contents: read')
+    expect(topLevelBlock(workflow, 'permissions')).toBe(readOnlyPermissions)
     expect(workflow).toContain('uses: actions/checkout@v4')
     expect(workflow).not.toMatch(/^\s+ref:/m)
-    expect(workflow).not.toMatch(/:\s*write$/m)
+  })
+
+  test('rejects every permission grant beyond contents read', async () => {
+    const workflow = await readWorkflow()
+    const unsafePermissions = [
+      'permissions: write-all',
+      'permissions:\n  contents: write-all',
+      'permissions:\n  contents: read\n  packages: write # note',
+      'permissions:\n  contents: read\n  packages: write   ',
+    ]
+
+    for (const permissions of unsafePermissions) {
+      const mutated = workflow.replace(readOnlyPermissions, permissions)
+      expect(topLevelBlock(mutated, 'permissions')).not.toBe(readOnlyPermissions)
+    }
   })
 
   test('pins Bun and runs the repository test command', async () => {


### PR DESCRIPTION
## Summary

- Run the Bun test suite on pull request merge revisions and pushes to `main` with read-only permissions.
- Pin Bun 1.3.14 and cancel superseded runs only within the same workflow ref.
- Add contract tests for triggers, permissions, checkout behavior, runtime pinning, command execution, and concurrency.

## Verification

- `bun run test` — 41 passed, 0 failed
- `actionlint .github/workflows/test.yml` — passed
- Regression proof before implementation — 0 passed, 4 failed because the workflow was absent

Closes #30

---
Created with LLM: GPT-5 | high | Harness: Codex
