### PR TITLE
feat(#39): band-encode complexity score for model and effort routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@
 - Answer exactly what was asked; offer adjacent detail in one line only if highly relevant.
 - Spell out acronyms on first use — "pull request (PR)".
 - No stylistic tics: em-dashes for emphasis, "not X; it's Y", payoff lines, metaphor labels ("knob", "lever").
-- Never give time/effort estimates ("2–4 days") — describe complexity as scope and risk.
+- Never give time/effort estimates ("2–4 days") — complexity scores are a model + effort routing signal (Capability band + Volume), not a duration.
 - No follow-up-question menus; ask at most one, only when needed to proceed.
 
 ## Who You're Working With

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ flowchart LR
     C -- LGTM --> E([issue complete])
 ```
 
-Several skills mention a **complexity score** (`C0`–`C100`): a rough 0–100 rating of how hard an issue is to implement, put right in the issue title. "Fable" skills hand part of the work to a subagent running on the Fable 5 model — a second Claude instance that plans, validates, or drafts while your main session does the building.
+Several skills mention a **complexity score** (`C0`–`C100`): a model + effort routing signal in the issue title. **Capability** (which LLM / whether a Fable plan runs first) lives in the score band; **Volume** (how hard to push) lives in the depth inside the band — see `validate-issue` step 6. "Fable" skills hand part of the work to a subagent running on the Fable 5 model — a second Claude instance that plans, validates, or drafts while your main session does the building.
 
 ### Issue skills
 
@@ -57,9 +57,9 @@ Several skills mention a **complexity score** (`C0`–`C100`): a rough 0–100 r
 | `fable-new-issue` | Like `new-issue`, but a read-only Fable 5 subagent researches and drafts the issue; your main session spot-checks and files it. |
 | `fable-new-issue-loop` | Runs `fable-new-issue`, then drives the new issue all the way to a reviewed PR automatically. |
 | `fable-validate` | Like `validate-issue`, but the fact-checking runs on a Fable 5 subagent; your main session presents the verdict and acts on it. |
-| `fable-validate-loop` | Runs `fable-validate`, applies issue fixes, gets a Fable plan (only for issues scored C50+ or touching safety-critical code), then drives to a reviewed PR. |
+| `fable-validate-loop` | Runs `fable-validate`, applies issue fixes, gets a Fable plan (only when Capability ≥ 2 / score ≥ 50, or touching safety-critical code), then drives to a reviewed PR. |
 | `fable-validate-fableplan-loop` | Same as above, but the Fable plan is unconditional — every issue gets a posted plan before implementation, no matter how simple. |
-| `validate-fableplan-loop` | The hybrid: validates on your session's own model, but still brings in Fable for planning when the issue is C50+ or safety-flagged, then drives to a reviewed PR. |
+| `validate-fableplan-loop` | The hybrid: validates on your session's own model, but still brings in Fable for planning when Capability ≥ 2 / score ≥ 50 or safety-flagged, then drives to a reviewed PR. |
 | `fableplan-work-on-issue` | The trimmed chain: Fable 5 plans the issue and posts the plan, then `work-on-issue` builds it and opens a PR. No validation, no review loop — stops at the open PR. |
 | `fableplan-loop` | Same as above, plus the review loop: after the Fable plan is posted, `work-on-issue-loop` builds it, opens the PR, and keeps fixing review findings until approval. No validation. |
 

--- a/skills/execution-plan-review/SKILL.md
+++ b/skills/execution-plan-review/SKILL.md
@@ -18,12 +18,12 @@ Fetch every issue in the milestone (`gh issue list --milestone ... --json number
 
 (Validate effort defaults to high when an issue's block omits the line — show the effective value. Display an absent ordering field as `missing`, not `none`, so legacy prose inference is not silently discarded.)
 
-Follow with 2–3 sentences on the pattern (which issues run on the top model and why, where fableplan bridges, what the review trigger is) — enough for the user to sanity-check the logic, not a lecture.
+Follow with 2–3 sentences on the pattern (which Capability bands dominate, where fableplan bridges Capability 2, what the review trigger is) — enough for the user to sanity-check against the `prd-to-issues` / `validate-issue` band table, not a lecture.
 
 ### 2. Take revisions
 
 - The user revises in shorthand ("11 should be medium", "12 depends on 8 and 9", "13 runs after 12", "clear 14's dependencies"). Resolve ambiguous references (row position vs issue number) against the table just shown; when genuinely ambiguous, confirm in half a sentence.
-- **Push back once when a revision conflicts with the heuristics** — e.g. adding a fableplan step to an issue too small to benefit, or dropping the top model from a money path. One recommendation with the reason, then the user decides. Money/security/irreversible-deletion issues dropping below the top model deserve an explicit warning.
+- **Push back once when a revision conflicts with the score band** (canonical table in `validate-issue` step 6 / `prd-to-issues`) — e.g. fableplan on Capability 0–1, or dropping below Fable/Opus on a money/security/irreversible-deletion issue (high Risk → Capability 2–3). One recommendation with the reason, then the user decides. Money/security/irreversible-deletion issues dropping below the top model deserve an explicit warning.
 - Batch multiple revisions; don't round-trip to GitHub per message.
 - Preserve the edge kind exactly: a `Depends on` revision remains a hard prerequisite, while a `Runs after` revision remains ordering-only. Never move an issue between the fields merely to simplify the graph.
 - Before writing, verify every referenced issue exists, reject self-references, deduplicate each list, and reject a predecessor present in both fields. Recursively fetch referenced issues outside the milestone until the explicit ordering graph closes so every reachable typed edge participates in validation.
@@ -41,7 +41,7 @@ Re-render the final table once after all revisions land. This table is what the 
 
 | Situation | Do this |
 |---|---|
-| An issue lacks an Execution block | Add one using the prd-to-issues heuristics, flag it in the table |
+| An issue lacks an Execution block | Add one by deriving model/effort/fableplan from the `[C..]` band per `prd-to-issues`, flag it in the table |
 | An issue lacks one or both ordering fields | Backfill from the approved prd-to-issues graph when available; otherwise infer from Approach/Problem, mark the value as inferred in the table, and confirm it before write-back |
 | User revision references a row that doesn't exist | Show the table again, ask which issue they meant |
 | A revision creates a cycle across either edge kind | Reject the batch without editing any issue and show the cycle path |

--- a/skills/fable-validate-fableplan-loop/SKILL.md
+++ b/skills/fable-validate-fableplan-loop/SKILL.md
@@ -22,7 +22,7 @@ Same defaults as fable-validate: issue URL, `#<N>` / `<N>` / `owner/repo#N`, or 
 Invoke the `fable-validate` skill for the target issue (Skill tool, `skill: fable-validate`). Let it run fully — Fable 5 subagent validation, spot-check, verdict — producing the standard verdict block:
 
 ```
-**#<N>: Update issue description? <Yes|No>**  ·  Complexity: <score>/100 — <driver>  ·  Scope: <OK | too large — split/umbrella/narrow>
+**#<N>: Update issue description? <Yes|No>**  ·  Complexity: <score>/100 — Capability <k> (<driver>); Volume <v>  ·  Scope: <OK | too large — split/umbrella/narrow>
 ```
 
 Treat the verdict as structured output to parse yourself, not a prompt to wait on. Record the resolved issue number — every later step targets exactly this issue.

--- a/skills/fable-validate-fableplan-loop/SKILL.md
+++ b/skills/fable-validate-fableplan-loop/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: fable-validate-fableplan-loop
-description: Use when the user asks to validate a GitHub issue with Fable 5, always plan it with Fable 5, and autonomously drive it to a reviewed PR in one shot — "fable-validate-fableplan-loop", "fable validate, fable plan, and work on #N", "fully automate #N with fable validation and an unconditional fable plan". Runs fable-validate, auto-applies its update-issue edits when the verdict calls for it, has fableplan produce and post a Fable 5 implementation plan for EVERY issue (no complexity gate — unlike fable-validate-loop, which skips planning below C50), then hands off to work-on-issue-loop — stopping instead when validation flags the issue as too large, architecturally infeasible, or already addressed by an existing PR.
+description: Use when the user asks to validate a GitHub issue with Fable 5, always plan it with Fable 5, and autonomously drive it to a reviewed PR in one shot — "fable-validate-fableplan-loop", "fable validate, fable plan, and work on #N", "fully automate #N with fable validation and an unconditional fable plan". Runs fable-validate, auto-applies its update-issue edits when the verdict calls for it, has fableplan produce and post a Fable 5 implementation plan for EVERY issue (no Capability gate — unlike fable-validate-loop, which skips planning when Capability < 2 / score < 50), then hands off to work-on-issue-loop — stopping instead when validation flags the issue as too large, architecturally infeasible, or already addressed by an existing PR.
 ---
 
 # fable-validate-fableplan-loop
 
 Chain fable-validate → (conditional) update issue → fableplan → work-on-issue-loop into one autonomous run: Fable 5 validates the issue, the main agent fixes the issue description if needed, Fable 5 plans the implementation (plan posted to the issue), and work-on-issue-loop implements the plan and drives the PR through review to convergence.
 
-This is **fable-validate-loop with the complexity gate removed** — the only difference is that fableplan **always runs**, regardless of the validated complexity score; there is no "skip below C50" rule. Reach for this when even simple issues should get a posted, Fable-vetted plan before implementation (e.g. the plan comment doubles as documentation, or the repo's simple-looking issues have a history of hiding traps). If skipping the plan for trivial issues is fine, use `fable-validate-loop` instead — it's the cheaper default.
+This is **fable-validate-loop with the Capability gate removed** — the only difference is that fableplan **always runs**, regardless of the validated complexity score; there is no "skip when Capability < 2 / score < 50" rule. Reach for this when even simple issues should get a posted, Fable-vetted plan before implementation (e.g. the plan comment doubles as documentation, or the repo's simple-looking issues have a history of hiding traps). If skipping the plan for low-capability-band issues is fine, use `fable-validate-loop` instead — it's the cheaper default.
 
 **Do not skip or reorder the chain.** Validation gates planning (a plan built on refuted claims is wrong), and the plan gates implementation (that's the point of routing through fableplan). There is **no sanctioned skip** in this variant — every step runs; only the "wait for the user's reply" moments are replaced by the decision rules below.
 
@@ -50,7 +50,7 @@ If **No**, skip straight to step 4.
 
 ### 4. Run fableplan — planning phase only, always
 
-**No complexity gate:** fableplan runs for every issue that passed the step-2 scope gate, whatever the validated score — that's the difference from fable-validate-loop. Do not skip planning for low-complexity issues.
+**No Capability gate:** fableplan runs for every issue that passed the step-2 scope gate, whatever the validated score — that's the difference from fable-validate-loop. Do not skip planning for low-capability-band issues.
 
 Invoke the `fableplan` skill for the same issue number (Skill tool, `skill: fableplan`), and **scope it to its planning phase — steps 1 through 5 only**: fetch the issue, dispatch the Fable 5 Plan subagent, sanity-check the plan against the code, post the vetted plan as an issue comment, and relay it. Instruct fableplan to use the harness suffix `fable-validate-fableplan-loop` (not `fableplan`) in the posted comment's attribution footer, so the comment records the actual entry point. **Do NOT execute fableplan's steps 6–7 (worktree + build)** — implementation belongs to work-on-issue-loop in step 5, which owns the implement → PR → review chain; building here would duplicate it outside that chain.
 
@@ -75,7 +75,7 @@ Relay work-on-issue-loop's final summary (PR URL, review cycles, final verdict),
 | Situation | Action |
 |---|---|
 | Tempted to skip validation or planning and jump to implementation | Never reorder — validate-then-plan-then-build is the point of this skill, and this variant has no sanctioned skip at all |
-| Tempted to skip fableplan because the issue scored below C50 | Don't — that gate belongs to fable-validate-loop; here fableplan always runs, that's the point of this variant |
+| Tempted to skip fableplan because the issue scored below 50 (Capability < 2) | Don't — that gate belongs to fable-validate-loop; here fableplan always runs, that's the point of this variant |
 | `Scope: too large`, Architecture ❌ Infeasible, or a PR already addressing the issue | Stop and report per step 2 — the cases the loop can't safely auto-resolve |
 | Tempted to wait for a literal user reply to fable-validate's or fableplan's prompt | Parse the output yourself and proceed per the step rules |
 | Verdict says Update issue description? Yes | Apply the edits **before** fableplan runs, so the plan targets the corrected issue |

--- a/skills/fable-validate-loop/SKILL.md
+++ b/skills/fable-validate-loop/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: fable-validate-loop
-description: Use when the user asks to validate a GitHub issue with Fable 5 and then autonomously drive it to a reviewed PR in one shot — "fable-validate-loop", "fable validate and work on #N", "fully automate issue #N with fable". Runs fable-validate, auto-applies its update-issue edits when the verdict calls for it, has fableplan produce and post a Fable 5 implementation plan (skipped for issues below C50 with no safety flags), then hands off to work-on-issue-loop — stopping instead when validation flags the issue as too large, architecturally infeasible, or already addressed by an existing PR.
+description: Use when the user asks to validate a GitHub issue with Fable 5 and then autonomously drive it to a reviewed PR in one shot — "fable-validate-loop", "fable validate and work on #N", "fully automate issue #N with fable". Runs fable-validate, auto-applies its update-issue edits when the verdict calls for it, has fableplan produce and post a Fable 5 implementation plan (skipped when Capability < 2 / score < 50 with no safety flags), then hands off to work-on-issue-loop — stopping instead when validation flags the issue as too large, architecturally infeasible, or already addressed by an existing PR.
 ---
 
 # fable-validate-loop
 
 Chain fable-validate → (conditional) update issue → fableplan → work-on-issue-loop into one autonomous run: Fable 5 validates the issue, the main agent fixes the issue description if needed, Fable 5 plans the implementation (plan posted to the issue), and work-on-issue-loop implements the plan and drives the PR through review to convergence. This is fable-validate's interactive handoff made unattended — the loop reads its own verdicts and proceeds, instead of waiting for the user to reply.
 
-**Do not skip or reorder the chain.** Validation gates planning (a plan built on refuted claims is wrong), and the plan gates implementation (that's the point of routing through fableplan). The only sanctioned skip is the step-4 complexity gate (low-complexity issues bypass fableplan). Every other step of each skill still runs; only the "wait for the user's reply" moments are replaced by the decision rules below.
+**Do not skip or reorder the chain.** Validation gates planning (a plan built on refuted claims is wrong), and the plan gates implementation (that's the point of routing through fableplan). The only sanctioned skip is the step-4 Capability gate (Capability < 2 / score < 50 bypasses fableplan). Every other step of each skill still runs; only the "wait for the user's reply" moments are replaced by the decision rules below.
 
 ## Input
 
@@ -46,9 +46,9 @@ If **No**, skip straight to step 4.
 
 **Order matters:** the edits land before fableplan runs, so the Fable 5 planner fetches and plans against the corrected issue, not the flawed original.
 
-### 4. Run fableplan — planning phase only (skip below C50)
+### 4. Run fableplan — planning phase only (skip when Capability < 2)
 
-**Complexity gate:** if the verdict's validated complexity score is **below 50**, skip fableplan and go straight to step 5 — work-on-issue-loop plans adequately for low-complexity changes on its own. **Safety carve-out (overrides the gate):** if the validation flags money, data integrity, security, or an auto-protective mechanism anywhere in its findings, run fableplan regardless of score. (If the user wants a plan unconditionally, that's `fable-validate-fableplan-loop` — this same chain with the gate removed.)
+**Capability gate:** if the verdict's validated complexity score is **below 50** (Capability < 2 under the `validate-issue` band encoding), skip fableplan and go straight to step 5 — work-on-issue-loop plans adequately for low-capability-band changes on its own. **Safety carve-out (overrides the gate):** if the validation flags money, data integrity, security, or an auto-protective mechanism anywhere in its findings, run fableplan regardless of score. (If the user wants a plan unconditionally, that's `fable-validate-fableplan-loop` — this same chain with the gate removed.)
 
 Otherwise, invoke the `fableplan` skill for the same issue number (Skill tool, `skill: fableplan`), and **scope it to its planning phase — steps 1 through 5 only**: fetch the issue, dispatch the Fable 5 Plan subagent, sanity-check the plan against the code, post the vetted plan as an issue comment, and relay it. **Do NOT execute fableplan's steps 6–7 (worktree + build)** — implementation belongs to work-on-issue-loop in step 5, which owns the implement → PR → review chain; building here would duplicate it outside that chain.
 
@@ -58,13 +58,13 @@ Keep the vetted plan's scratchpad file — step 5 passes it through. If fablepla
 
 ### 5. Hand off to work-on-issue-loop
 
-Invoke the `work-on-issue-loop` skill for the same issue number (Skill tool, `skill: work-on-issue-loop`). Pass the issue number through explicitly — don't let it re-resolve "latest issue" — and instruct it that the implementation must follow the Fable 5 plan: point it at the plan's scratchpad file and the posted issue comment (`## Implementation plan (Fable 5)`), and tell it deviations from the plan are allowed only when the code contradicts the plan, and must be named in the PR body. (If step 4 was skipped by the complexity gate, there is no plan — hand off the issue alone and note the skip.)
+Invoke the `work-on-issue-loop` skill for the same issue number (Skill tool, `skill: work-on-issue-loop`). Pass the issue number through explicitly — don't let it re-resolve "latest issue" — and instruct it that the implementation must follow the Fable 5 plan: point it at the plan's scratchpad file and the posted issue comment (`## Implementation plan (Fable 5)`), and tell it deviations from the plan are allowed only when the code contradicts the plan, and must be named in the PR body. (If step 4 was skipped by the Capability gate, there is no plan — hand off the issue alone and note the skip.)
 
 It runs its full loop: work-on-issue implements in a worktree and opens the PR, the loop triggers `@claude` review, and fix-pr-review cycles until convergence.
 
 ### 6. Report
 
-Relay work-on-issue-loop's final summary (PR URL, review cycles, final verdict), prefixed with one line covering the head of the chain: scope gate passed, issue updated or not, plan posted (comment URL) or skipped by the complexity gate. 
+Relay work-on-issue-loop's final summary (PR URL, review cycles, final verdict), prefixed with one line covering the head of the chain: scope gate passed, issue updated or not, plan posted (comment URL) or skipped by the Capability gate. 
 
 **Cap the whole report at 55 words, ELI18** — plain language, no jargon, as if explaining the outcome to a smart 18-year-old with no context on this codebase.
 
@@ -72,7 +72,7 @@ Relay work-on-issue-loop's final summary (PR URL, review cycles, final verdict),
 
 | Situation | Action |
 |---|---|
-| Tempted to skip validation or planning and jump to implementation | Never reorder — validate-then-plan-then-build is the point of this skill; the only sanctioned skip is the step-4 complexity gate (<C50, no safety flags) |
+| Tempted to skip validation or planning and jump to implementation | Never reorder — validate-then-plan-then-build is the point of this skill; the only sanctioned skip is the step-4 Capability gate (score < 50 / Capability < 2, no safety flags) |
 | `Scope: too large`, Architecture ❌ Infeasible, or a PR already addressing the issue | Stop and report per step 2 — the cases the loop can't safely auto-resolve |
 | Tempted to wait for a literal user reply to fable-validate's or fableplan's prompt | Parse the output yourself and proceed per the step rules |
 | Verdict says Update issue description? Yes | Apply the edits **before** fableplan runs, so the plan targets the corrected issue |

--- a/skills/fable-validate-loop/SKILL.md
+++ b/skills/fable-validate-loop/SKILL.md
@@ -20,7 +20,7 @@ Same defaults as fable-validate: issue URL, `#<N>` / `<N>` / `owner/repo#N`, or 
 Invoke the `fable-validate` skill for the target issue (Skill tool, `skill: fable-validate`). Let it run fully — Fable 5 subagent validation, spot-check, verdict — producing the standard verdict block:
 
 ```
-**#<N>: Update issue description? <Yes|No>**  ·  Complexity: <score>/100 — <driver>  ·  Scope: <OK | too large — split/umbrella/narrow>
+**#<N>: Update issue description? <Yes|No>**  ·  Complexity: <score>/100 — Capability <k> (<driver>); Volume <v>  ·  Scope: <OK | too large — split/umbrella/narrow>
 ```
 
 Treat the verdict as structured output to parse yourself, not a prompt to wait on. Record the resolved issue number — every later step targets exactly this issue.

--- a/skills/fableplan-loop/SKILL.md
+++ b/skills/fableplan-loop/SKILL.md
@@ -7,9 +7,9 @@ description: Use when the user wants a GitHub issue planned by Fable 5 and then 
 
 Chain fableplan → work-on-issue-loop into one autonomous run: Fable 5 plans the implementation for a GitHub issue (plan posted to the issue), then work-on-issue-loop implements that plan in an isolated worktree, opens a PR that closes the issue, and drives the PR through `@claude` review to convergence.
 
-This is **fableplan-work-on-issue with the review loop added back** — the handoff goes to `work-on-issue-loop` (implement → PR → trigger `@claude` → fix-pr-review cycles until LGTM) instead of `work-on-issue` (single-shot, ends at the open PR). Equivalently, it's **validate-fableplan-loop with the validation stage removed**: no `validate-issue`, no update-issue edits, and no complexity gate — fableplan always runs. Reach for this when you already trust the issue, want a Fable-vetted plan, and want the PR reviewed to convergence without coming back.
+This is **fableplan-work-on-issue with the review loop added back** — the handoff goes to `work-on-issue-loop` (implement → PR → trigger `@claude` → fix-pr-review cycles until LGTM) instead of `work-on-issue` (single-shot, ends at the open PR). Equivalently, it's **validate-fableplan-loop with the validation stage removed**: no `validate-issue`, no update-issue edits, and no Capability gate — fableplan always runs. Reach for this when you already trust the issue, want a Fable-vetted plan, and want the PR reviewed to convergence without coming back.
 
-**Do not skip or reorder the chain.** The plan gates implementation — that's the point of routing through fableplan. There is no complexity gate here: unlike validate-fableplan-loop, this skill has no validation step to produce a score, so fableplan always runs. Every step of each skill still runs; only the "wait for the user's reply" moments are replaced by the handoff below.
+**Do not skip or reorder the chain.** The plan gates implementation — that's the point of routing through fableplan. There is no Capability gate here: unlike validate-fableplan-loop, this skill has no validation step to produce a score, so fableplan always runs. Every step of each skill still runs; only the "wait for the user's reply" moments are replaced by the handoff below.
 
 ## Input
 
@@ -48,7 +48,7 @@ Relay work-on-issue-loop's final summary (PR URL, number of review cycles, final
 
 | Situation | Action |
 |---|---|
-| Tempted to skip planning and jump straight to implementation | Never reorder — plan-then-build is the point of this skill; there is no complexity gate, fableplan always runs |
+| Tempted to skip planning and jump straight to implementation | Never reorder — plan-then-build is the point of this skill; there is no Capability gate, fableplan always runs |
 | Tempted to run validate-issue first | Not part of this skill — that's validate-fableplan-loop; this variant deliberately skips validation |
 | fableplan about to enter its build steps (6–7) | Don't — stop it at step 5; work-on-issue-loop owns implementation |
 | fableplan's sanity-check finds the plan structurally wrong | Stop and report — don't hand a broken plan to work-on-issue-loop, and don't silently re-plan |

--- a/skills/fableplan-work-on-issue/SKILL.md
+++ b/skills/fableplan-work-on-issue/SKILL.md
@@ -9,7 +9,7 @@ Chain fableplan → work-on-issue into one autonomous run: Fable 5 plans the imp
 
 This is **validate-fableplan-loop with the validation and review-loop stages removed** — no `validate-issue` before planning, and the handoff is to `work-on-issue` (single-shot, ends at the open PR) rather than `work-on-issue-loop` (which triggers `@claude` and cycles through review). Reach for this when you already trust the issue and just want a Fable-vetted plan built and shipped as a PR, without paying for validation or driving review to convergence.
 
-**Do not skip or reorder the chain.** The plan gates implementation — that's the point of routing through fableplan. There is no complexity gate here: unlike validate-fableplan-loop, this skill has no validation step to produce a score, so fableplan always runs. Every step of each skill still runs; only the "wait for the user's reply" moments are replaced by the handoff below.
+**Do not skip or reorder the chain.** The plan gates implementation — that's the point of routing through fableplan. There is no Capability gate here: unlike validate-fableplan-loop, this skill has no validation step to produce a score, so fableplan always runs. Every step of each skill still runs; only the "wait for the user's reply" moments are replaced by the handoff below.
 
 ## Input
 
@@ -48,7 +48,7 @@ Relay work-on-issue's final summary (the worktree/branch, what was implemented, 
 
 | Situation | Action |
 |---|---|
-| Tempted to skip planning and jump straight to implementation | Never reorder — plan-then-build is the point of this skill; there is no complexity gate, fableplan always runs |
+| Tempted to skip planning and jump straight to implementation | Never reorder — plan-then-build is the point of this skill; there is no Capability gate, fableplan always runs |
 | Tempted to run validate-issue first | Not part of this skill — that's validate-fableplan-loop; this trimmed variant deliberately skips validation |
 | fableplan about to enter its build steps (6–7) | Don't — stop it at step 5; work-on-issue owns implementation |
 | fableplan's sanity-check finds the plan structurally wrong | Stop and report — don't hand a broken plan to work-on-issue, and don't silently re-plan |

--- a/skills/github-issue-format/SKILL.md
+++ b/skills/github-issue-format/SKILL.md
@@ -7,8 +7,8 @@ description: Required format for creating or editing any GitHub issue — [C<sco
 
 - **Never create a placeholder, stub, or empty-bodied issue.** Every issue gets a complete body at creation — complexity rationale line, concrete problem statement, goal, approach/acceptance criteria — even in a batch. If a follow-up isn't ready to spec, track it in the parent issue or notes until it is.
 - Title format: `[C<score>] <title>` — a plain-language sentence understandable to an average 18-year-old, precise about component and behavior, e.g. `[C70] Orders can be filled twice when two fills arrive at the same moment`.
-- **Complexity score (0–100)** approximates implementation complexity, NOT time/effort, from: **Scope** (files/layers/surfaces touched), **Risk** (blast radius; money, data integrity, security, auto-protective mechanisms weigh heaviest), **Uncertainty** (unknowns/research needed).
+- **Complexity score (0–100)** is a **model + effort routing signal**, not a time estimate. Canonical formula lives in `validate-issue` step 6: five axes → **Capability** band (which LLM / whether fableplan) + **Volume** (effort inside the band) → `score = 25 × Capability + Volume`. Axes: Scope, Coupling, Risk, Uncertainty, Verification.
 - First line of the body is a one-line rationale matching the title prefix:
-  `**Complexity: 70/100** — scope: medium; risk: high (touches order-fill path); uncertainty: exchange API behavior unverified`
+  `**Complexity: 70/100** — Capability 2 (risk high on order-fill path); Volume 20 — Opus + fableplan, xhigh`
 - End the body with the **LLM Attribution Footer** — `Created` (or `Updated` when editing).
 - **Project precedence:** a repo CLAUDE.md issue/footer format overrides this default.

--- a/skills/github-issue-format/SKILL.md
+++ b/skills/github-issue-format/SKILL.md
@@ -6,9 +6,9 @@ description: Required format for creating or editing any GitHub issue — [C<sco
 # GitHub issue format
 
 - **Never create a placeholder, stub, or empty-bodied issue.** Every issue gets a complete body at creation — complexity rationale line, concrete problem statement, goal, approach/acceptance criteria — even in a batch. If a follow-up isn't ready to spec, track it in the parent issue or notes until it is.
-- Title format: `[C<score>] <title>` — a plain-language sentence understandable to an average 18-year-old, precise about component and behavior, e.g. `[C70] Orders can be filled twice when two fills arrive at the same moment`.
+- Title format: `[C<score>] <title>` — a plain-language sentence understandable to an average 18-year-old, precise about component and behavior, e.g. `[C95] Orders can be filled twice when two fills arrive at the same moment`.
 - **Complexity score (0–100)** is a **model + effort routing signal**, not a time estimate. Canonical formula lives in `validate-issue` step 6: five axes → **Capability** band (which LLM / whether fableplan) + **Volume** (effort inside the band) → `score = 25 × Capability + Volume`. Axes: Scope, Coupling, Risk, Uncertainty, Verification.
 - First line of the body is a one-line rationale matching the title prefix:
-  `**Complexity: 70/100** — Capability 2 (risk high on order-fill path); Volume 20 — Opus + fableplan, xhigh`
+  `**Complexity: 95/100** — Capability 3 (Risk 4 — money/data-integrity on order-fill path); Volume 20 — Fable 5, xhigh`
 - End the body with the **LLM Attribution Footer** — `Created` (or `Updated` when editing).
 - **Project precedence:** a repo CLAUDE.md issue/footer format overrides this default.

--- a/skills/new-issue/SKILL.md
+++ b/skills/new-issue/SKILL.md
@@ -61,7 +61,7 @@ Title: `[C<score>] <title>` — the title is a clear, plain-language sentence un
 Body structure:
 
 ```
-**Complexity: <score>/100** — scope: <…>; risk: <…>; uncertainty: <…>
+**Complexity: <score>/100** — Capability <k> (<driver>); Volume <v> — <model/effort from band>
 
 ## Problem
 <Current behavior, grounded with file:line citations from step 2. What's wrong or missing and why it matters.>
@@ -80,7 +80,7 @@ Body structure:
 Created with LLM: <current model> | <effort> | Harness: <harness>
 ```
 
-The complexity rationale is the **first line** of the body and matches the title prefix. The footer is the final lines, preceded by `---` on its own line — **Created** verb, `<effort>` one of `medium`/`high`/`xhigh` (default `high`, never low), `<harness>` = `Claude Code` for an interactive session. No `Co-authored-by`. **Project precedence:** a repo `CLAUDE.md` that defines its own issue/footer format overrides this default.
+The complexity rationale is the **first line** of the body and matches the title prefix — same Capability/Volume form as `github-issue-format` (round-trips with the `[C<score>]` band, e.g. `[C58]` → `Capability 2 (…); Volume 8`). The footer is the final lines, preceded by `---` on its own line — **Created** verb, `<effort>` one of `medium`/`high`/`xhigh` (default `high`, never low), `<harness>` = `Claude Code` for an interactive session. No `Co-authored-by`. **Project precedence:** a repo `CLAUDE.md` that defines its own issue/footer format overrides this default.
 
 File it:
 

--- a/skills/new-issue/SKILL.md
+++ b/skills/new-issue/SKILL.md
@@ -48,7 +48,7 @@ Include **acceptance criteria** an implementer can verify: observable behavior, 
 
 ### 4. Score complexity
 
-Score the work to implement the fix **correctly, including tests** — five axes 0–4 (Scope, Coupling, Risk, Uncertainty, Verification), sum ×5 for a 0–100 base, risk floor: Risk 4 → ≥60, Risk 3 → ≥45. Derive the axes from the concrete touch-set in step 3, not vibes; count the surface that hides from the diff (tests, parity/offline paths, migrations, docs). This is complexity, **not** a time or effort estimate — never put durations in the issue.
+Score the work to implement the fix **correctly, including tests** using the **canonical formula in `validate-issue` step 6** (load that skill or mirror it exactly): five axes 0–4 → **Capability** (0–3 from Risk/Uncertainty + Coupling≥3 bump) and **Volume** (0–24 from Scope+Coupling+Verification) → `score = 25 × Capability + Volume`. The score is a **model + effort routing signal**, not a time estimate — never put durations in the issue. Derive axes from the concrete touch-set in step 3, not vibes; count the surface that hides from the diff (tests, parity/offline paths, migrations, docs).
 
 ### 5. Scope check — one issue or several?
 
@@ -105,5 +105,5 @@ Terse: issue URL, number, one-line summary of what it covers, complexity score, 
 | An existing open issue/PR already covers it | Stop; surface it and offer to update/comment instead |
 | The cheap design and the correct design diverge | Spec the correct one; cost, effort, and blast radius are not factors — only correctness and safety constrain |
 | Touches money / data integrity / security / auto-protective logic | Spec the safest correct design from first principles; surface the risk in the body and Risk axis |
-| Tempted to include a time/effort estimate | Don't — complexity score only, described via scope/risk/uncertainty |
+| Tempted to include a time/effort estimate | Don't — complexity score only (Capability band + Volume), described via the axes |
 | Repo has its own issue template or `CLAUDE.md` issue format | Follow the repo's format; it overrides this default |

--- a/skills/prd-to-issues/SKILL.md
+++ b/skills/prd-to-issues/SKILL.md
@@ -56,25 +56,22 @@ Ordering-field rules:
 - **Runs after** means the issues must not overlap but the later issue does not need the earlier issue's code; for example, two otherwise-independent issues editing the same package.
 - A same-package exclusion is `Runs after`, not `Depends on`. If an edge is genuinely hard, record it only in `Depends on`; never list one predecessor in both fields.
 
-Assignment heuristics:
+Assignment — **derive from the complexity score band** (canonical formula in `validate-issue` step 6: `score = 25 × Capability + Volume`). Score each issue with that formula first, then stamp Execution from the band:
 
-| Signal | Assignment |
-|---|---|
-| Money, pricing, payments | Fable 5; xhigh if it's a pure boundary-heavy module |
-| Auth / security surface | Fable 5, high |
-| The product's core promise (e.g. sealing, privacy) | Fable 5; xhigh when atomicity/enforcement is the issue |
-| Foundational schema everything builds on | Fable 5, xhigh |
-| Irreversible deletion paths | Fable 5, high |
-| Small-but-load-bearing (privacy serializers) | Fable 5, medium — vigilance beats planning here |
-| Mechanical scaffolding, config plumbing | Opus 4.8, high |
-| CRUD flows, contained components on known APIs | Opus 4.8, high |
-| Design-heavy but routine to code | Opus 4.8 + **fableplan: Yes** — the bridge tier |
-| Design work with no correctness risk (landing pages) | Fable 5, medium; use the frontend-design skill |
+| Capability | Score band | Build model | fableplan first | Effort from Volume (0–7 / 8–15 / 16–24) |
+|---|---|---|---|---|
+| 0 | 0–24 | Sonnet (or the repo's cheap/fast builder) | No | high / high / xhigh |
+| 1 | 25–49 | Opus 4.8 | No | high / high / xhigh |
+| 2 | 50–74 | Opus 4.8 | **Yes** | high / high / xhigh |
+| 3 | 75–99 | Fable 5 | No (planning is inherent) | medium / high / xhigh |
 
-- **fableplan is for issues where the design is the hard part and the code is routine.** Never on Fable-built issues (planning is inherent) or on issues so small the plan would just be the implementation in prose.
-- **Validate effort** (the pre-build Fable validation pass): **only ever medium or high — never xhigh.** Default high; drop to medium for small contained issues.
-- Effort floor is **medium** — never low, and medium is Fable-only: **Opus 4.8 builds run at high or xhigh, never medium.** When unsure between two tiers, take the higher (best-solution rule).
+Axes already encode the old parallel heuristics (money/security → high Risk; design-heavy → high Uncertainty; mechanical grind → high Scope/Volume at Capability 0). Do **not** override the band with a separate signal table unless a safety carve-out is explicit in the PRD and Risk was under-scored — then raise Risk and re-score, don't bypass the formula.
+
+- **fableplan first: Yes** means Capability 2 (Opus builds against a posted Fable plan). Never on Fable-built issues (Capability 3 — planning is inherent) and never on Capability 0–1.
+- **Validate effort** (the pre-build Fable validation pass): **only ever medium or high — never xhigh.** Default high; drop to medium for Capability 0 issues with Volume ≤ 7.
+- Effort floor is **medium** — never low, and medium is Fable-only: **Opus/Sonnet builds run at high or xhigh, never medium.** When unsure between two tiers, take the higher (best-solution rule).
 - PR review is always the standard `@claude` review trigger — no model routing in the review line.
+- Scores filed before the band-encoding change are **not comparable** — re-score if routing matters.
 
 ### 5. Report
 

--- a/skills/validate-fableplan-loop/SKILL.md
+++ b/skills/validate-fableplan-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validate-fableplan-loop
-description: Use when the user asks to validate a GitHub issue (without Fable), conditionally plan it with fableplan, then autonomously drive it to a reviewed PR in one shot — "validate-fableplan-loop", "validate, plan, and work on #N", "validate and fableplan and fully automate #N". Runs validate-issue on your session model (not a Fable subagent), auto-applies its update-issue edits when the verdict calls for it, has fableplan produce and post a Fable 5 implementation plan (skipped for issues below C50 with no safety flags), then hands off to work-on-issue-loop — stopping instead when validation flags the issue as too large, architecturally infeasible, or already addressed by an existing PR. The non-Fable-validation counterpart to fable-validate-loop.
+description: Use when the user asks to validate a GitHub issue (without Fable), conditionally plan it with fableplan, then autonomously drive it to a reviewed PR in one shot — "validate-fableplan-loop", "validate, plan, and work on #N", "validate and fableplan and fully automate #N". Runs validate-issue on your session model (not a Fable subagent), auto-applies its update-issue edits when the verdict calls for it, has fableplan produce and post a Fable 5 implementation plan (skipped when Capability < 2 / score < 50 with no safety flags), then hands off to work-on-issue-loop — stopping instead when validation flags the issue as too large, architecturally infeasible, or already addressed by an existing PR. The non-Fable-validation counterpart to fable-validate-loop.
 ---
 
 # validate-fableplan-loop
@@ -9,7 +9,7 @@ Chain validate-issue → (conditional) update issue → (conditional) fableplan 
 
 This is **validate-issue-loop with a Fable 5 planning phase inserted before implementation** — identical to fable-validate-loop except validation runs through the plain `validate-issue` (your session model) instead of a Fable 5 subagent. Only the *planning* is delegated to Fable 5, and only when the issue is complex enough to warrant it. Reach for this over fable-validate-loop when you want cheaper, session-model validation but still want a Fable-vetted plan for the harder issues.
 
-**Do not skip or reorder the chain.** Validation gates planning (a plan built on refuted claims is wrong), and the plan gates implementation (that's the point of routing through fableplan). The only sanctioned skip is the step-4 complexity gate (low-complexity issues bypass fableplan). Every other step of each skill still runs; only the "wait for the user's reply" moments are replaced by the decision rules below.
+**Do not skip or reorder the chain.** Validation gates planning (a plan built on refuted claims is wrong), and the plan gates implementation (that's the point of routing through fableplan). The only sanctioned skip is the step-4 Capability gate (Capability < 2 / score < 50 bypasses fableplan). Every other step of each skill still runs; only the "wait for the user's reply" moments are replaced by the decision rules below.
 
 ## Input
 
@@ -48,9 +48,9 @@ If **No**, skip straight to step 4.
 
 **Order matters:** the edits land before fableplan runs, so the Fable 5 planner fetches and plans against the corrected issue, not the flawed original.
 
-### 4. Run fableplan — planning phase only (skip below C50)
+### 4. Run fableplan — planning phase only (skip when Capability < 2)
 
-**Complexity gate:** if the verdict's validated complexity score is **below 50**, skip fableplan and go straight to step 5 — work-on-issue-loop plans adequately for low-complexity changes on its own. **Safety carve-out (overrides the gate):** if the validation flags money, data integrity, security, or an auto-protective mechanism anywhere in its findings, run fableplan regardless of score.
+**Capability gate:** if the verdict's validated complexity score is **below 50** (Capability < 2 under the `validate-issue` band encoding), skip fableplan and go straight to step 5 — work-on-issue-loop plans adequately for low-capability-band changes on its own. **Safety carve-out (overrides the gate):** if the validation flags money, data integrity, security, or an auto-protective mechanism anywhere in its findings, run fableplan regardless of score.
 
 Otherwise, invoke the `fableplan` skill for the same issue number (Skill tool, `skill: fableplan`), and **scope it to its planning phase — steps 1 through 5 only**: fetch the issue, dispatch the Fable 5 Plan subagent, sanity-check the plan against the code, post the vetted plan as an issue comment, and relay it. **Do NOT execute fableplan's steps 6–7 (worktree + build)** — implementation belongs to work-on-issue-loop in step 5, which owns the implement → PR → review chain; building here would duplicate it outside that chain.
 
@@ -60,13 +60,13 @@ Keep the vetted plan's scratchpad file — step 5 passes it through. If fablepla
 
 ### 5. Hand off to work-on-issue-loop
 
-Invoke the `work-on-issue-loop` skill for the same issue number (Skill tool, `skill: work-on-issue-loop`). Pass the issue number through explicitly — don't let it re-resolve "latest issue" — and instruct it that the implementation must follow the Fable 5 plan: point it at the plan's scratchpad file and the posted issue comment (`## Implementation plan (Fable 5)`), and tell it deviations from the plan are allowed only when the code contradicts the plan, and must be named in the PR body. (If step 4 was skipped by the complexity gate, there is no plan — hand off the issue alone and note the skip.)
+Invoke the `work-on-issue-loop` skill for the same issue number (Skill tool, `skill: work-on-issue-loop`). Pass the issue number through explicitly — don't let it re-resolve "latest issue" — and instruct it that the implementation must follow the Fable 5 plan: point it at the plan's scratchpad file and the posted issue comment (`## Implementation plan (Fable 5)`), and tell it deviations from the plan are allowed only when the code contradicts the plan, and must be named in the PR body. (If step 4 was skipped by the Capability gate, there is no plan — hand off the issue alone and note the skip.)
 
 It runs its full loop: work-on-issue implements in a worktree and opens the PR, the loop triggers `@claude` review, and fix-pr-review cycles until convergence.
 
 ### 6. Report
 
-Relay work-on-issue-loop's final summary (PR URL, review cycles, final verdict), prefixed with one line covering the head of the chain: scope gate passed, issue updated or not, plan posted (comment URL) or skipped by the complexity gate.
+Relay work-on-issue-loop's final summary (PR URL, review cycles, final verdict), prefixed with one line covering the head of the chain: scope gate passed, issue updated or not, plan posted (comment URL) or skipped by the Capability gate.
 
 **Cap the whole report at 55 words, ELI18** — plain language, no jargon, as if explaining the outcome to a smart 18-year-old with no context on this codebase.
 
@@ -74,10 +74,10 @@ Relay work-on-issue-loop's final summary (PR URL, review cycles, final verdict),
 
 | Situation | Action |
 |---|---|
-| Tempted to skip validation or planning and jump to implementation | Never reorder — validate-then-plan-then-build is the point of this skill; the only sanctioned skip is the step-4 complexity gate (<C50, no safety flags) |
+| Tempted to skip validation or planning and jump to implementation | Never reorder — validate-then-plan-then-build is the point of this skill; the only sanctioned skip is the step-4 Capability gate (score < 50 / Capability < 2, no safety flags) |
 | `Scope: too large`, Architecture ❌ Infeasible, or a PR already addressing the issue | Stop and report per step 2 — the cases the loop can't safely auto-resolve |
 | Tempted to wait for a literal user reply to validate-issue's or fableplan's prompt | Parse the output yourself and proceed per the step rules |
 | Verdict says Update issue description? Yes | Apply the edits **before** fableplan runs, so the plan targets the corrected issue |
 | fableplan about to enter its build steps (6–7) | Don't — stop it at step 5; work-on-issue-loop owns implementation |
 | fableplan's sanity-check finds the plan structurally wrong | Stop and report — don't hand a broken plan to work-on-issue-loop, and don't silently re-plan |
-| Issue scored below C50 with no safety flags | Skip fableplan and hand the issue straight to work-on-issue-loop — note the skip in the report |
+| Issue scored below 50 (Capability < 2) with no safety flags | Skip fableplan and hand the issue straight to work-on-issue-loop — note the skip in the report |

--- a/skills/validate-fableplan-loop/SKILL.md
+++ b/skills/validate-fableplan-loop/SKILL.md
@@ -22,7 +22,7 @@ Same defaults as validate-issue: issue URL, `#<N>` / `<N>` / `owner/repo#N`, or 
 Invoke the `validate-issue` skill for the target issue (Skill tool, `skill: validate-issue`). Let it run its full process — steps 0 through 7 — and produce its verdict block:
 
 ```
-**#<N>: Update issue description? <Yes|No>**  ·  Complexity: <score>/100 — <driver>  ·  Scope: <OK | too large — split/umbrella/narrow>
+**#<N>: Update issue description? <Yes|No>**  ·  Complexity: <score>/100 — Capability <k> (<driver>); Volume <v>  ·  Scope: <OK | too large — split/umbrella/narrow>
 ```
 
 Treat the verdict block as structured output to parse yourself, not the interactive `→ Reply "work on issue"` prompt to wait on. Don't ask the user to confirm; decide from the table in step 2. Record the resolved issue number — every later step targets exactly this issue.

--- a/skills/validate-issue-loop/SKILL.md
+++ b/skills/validate-issue-loop/SKILL.md
@@ -20,7 +20,7 @@ Same defaults as validate-issue: issue URL, `#<N>` / `<N>` / `owner/repo#N`, or 
 Invoke the `validate-issue` skill for the target issue (Skill tool, `skill: validate-issue`). Let it run its full process — steps 0 through 7 — and produce its verdict block:
 
 ```
-**#<N>: Update issue description? <Yes|No>**  ·  Complexity: <score>/100 — <driver>  ·  Scope: <OK | too large — split/umbrella/narrow>
+**#<N>: Update issue description? <Yes|No>**  ·  Complexity: <score>/100 — Capability <k> (<driver>); Volume <v>  ·  Scope: <OK | too large — split/umbrella/narrow>
 ```
 
 Its final `→ Reply "work on issue"...` line is written for interactive use — in this loop, treat the verdict block as structured output to parse yourself, not a prompt to wait on. Don't ask the user to confirm; decide from the table in step 2.

--- a/skills/validate-issue/SKILL.md
+++ b/skills/validate-issue/SKILL.md
@@ -298,7 +298,7 @@ Scope: (omit unless the issue is too large per step 6.5)
   - <part 1 — one-line scope>
   - <part 2 — one-line scope>
 
-**#<N>: Update issue description? <Yes | No>**  ·  Complexity: <0-100>/100 — <main driver>  ·  Scope: <OK | too large — split/umbrella/narrow>
+**#<N>: Update issue description? <Yes | No>**  ·  Complexity: <0-100>/100 — Capability <k> (<driver>); Volume <v>  ·  Scope: <OK | too large — split/umbrella/narrow>
 
 <If Yes: a short bulleted list of specific edits the author should make to the title and/or description — wrong file:line, incorrect behavior, missing repro, ambiguous scope, a title that misstates the bug or scope, etc. One line each, phrased as edits ("Change X to Y", "Add Z", "Remove claim about W", "Retitle to …").>
 

--- a/skills/validate-issue/SKILL.md
+++ b/skills/validate-issue/SKILL.md
@@ -226,7 +226,7 @@ Judgment-heavy work must raise **Uncertainty** or **Coupling** — never score a
 
 1. **Capability** (0–3): map `max(Risk, Uncertainty)` with `0–1 → 0`, `2 → 1`, `3 → 2`, `4 → 3`. If **Coupling ≥ 3**, set Capability = `max(Capability, 2)`. Coupling does **not** bump to band 3 by itself.
 2. **Volume** (0–24): `(Scope + Coupling + Verification) × 2`.
-3. **Final score** = `25 × Capability + Volume` (0–99; cap at 100 if needed). No Risk/Uncertainty floors and no hard ceilings — the band *is* the floor.
+3. **Final score** = `25 × Capability + Volume` (0–99 under current axis bounds: Capability ≤ 3, Volume ≤ 24). No Risk/Uncertainty floors and no hard ceilings — the band *is* the floor.
 
 #### Band → model / effort
 

--- a/skills/validate-issue/SKILL.md
+++ b/skills/validate-issue/SKILL.md
@@ -204,25 +204,52 @@ Any **❌** or material **⚠️** → **Update issue description? Yes** (same a
 
 ### 6. Score complexity
 
-Rate the work to implement the fix **correctly, including tests** — not the happy-path diff, not the author's estimate. Score five axes 0–4, sum ×5 for a 0–100 base, then apply the risk floor.
+Rate the work to implement the fix **correctly, including tests** — not the happy-path diff, not the author's estimate. The `[C0]`–`[C100]` score is a **model + effort routing signal**: the **band** selects which LLM (and whether fableplan runs first); **depth inside the band** selects effort. Do **not** sum the axes into one mushy difficulty number.
 
-**Derive the axes from the change surface you traced, not the issue's prose.** List the concrete edits steps 3–5 imply — files/functions, configs/migrations, tests to add or rewrite — and size the axes from that list; a score not backed by it is a vibe. If a path is unresolved (5a/5c ⚠️/❌), raise **Uncertainty**, give a range (e.g. 55–75) not a point, and name the single unknown driving the spread.
+**Derive the axes from the change surface you traced, not the issue's prose.** List the concrete edits steps 3–5 imply — files/functions, configs/migrations, tests to add or rewrite — and size the axes from that list; a score not backed by it is a vibe. If a path is unresolved (5a/5c ⚠️/❌), raise **Uncertainty**, give a Capability-band range (e.g. 50–74) not a point, and name the single unknown driving the spread.
 
 **Count the surface that hides from the diff.** The usual undercount is Scope and Verification — account for tests to add/rewrite, parity/offline paths that must match, migrations or schema/config-version bumps, init/wizard/generate surfaces, probe/startup argv, and docs the change invalidates. A "one-file" fix often drags three of these.
 
-**Cross-check against your own step-5 verdicts.** If architecture is ❌ (5a) or several checks are ⚠️ (5c), the work includes redesign and can't land low — a low score next to an ❌ verdict is self-contradiction.
+**Cross-check against your own step-5 verdicts.** If architecture is ❌ (5a) or several checks are ⚠️ (5c), the work includes redesign and can't land in Capability 0–1 — a low band next to an ❌ verdict is self-contradiction.
 
 | Axis (0–4) | 0 | 2 | 4 |
 |---|---|---|---|
 | **Scope** — files/layers/languages; new abstraction vs localized | one file, localized | a few files, one layer/language | many files across layers + a new abstraction |
 | **Coupling** — state/locking, migration, hot-reload, config↔runtime parity, dual-language SSoT, IPC across process/machine | none; pure/local | one shared mechanism touched | multiple interacting subsystems / cross-boundary coordination |
 | **Risk** — money, data integrity, security, irreversible or live side effects; regression on recently-changed code | read-only / offline | reversible writes, contained blast radius | live-exec / money / data-integrity / irreversible |
-| **Uncertainty** — is the approach known? | spec'd, or a hard decision-gate over existing tooling | mechanism known, params/shape to be found | needs design; step 5a ⚠️/❌ |
+| **Uncertainty** — is the approach known? | spec'd; approach known end-to-end | mechanism known, params/shape to be found | needs design; open judgment; step 5a ⚠️/❌ |
 | **Verification** — test/repro surface to prove it | pure helper, unit-testable | several units + fixtures | integration/parity/subprocess, or hard-to-reproduce state |
 
-**Base** = sum × 5. **Risk floor (safety outranks effort):** Risk = 4 → final ≥ 60; Risk = 3 → final ≥ 45. Take `max(base, floor)`, cap 100 — irreversible/live-exec work is never low-complexity to ship correctly, however tiny the diff.
+Judgment-heavy work must raise **Uncertainty** or **Coupling** — never score a hard decision as Uncertainty 0.
 
-The axes encode the two calls a flat score botches: **bounded research** scores low even when sophisticated (the "code" is existing tooling), and a **tiny diff on a money/state path** is caught by the Risk floor. Work the axes in scratch; **report only** `N/100 — <highest axis> is the driver` with the traced edit list.
+#### Formula (canonical — every scorer/consumer must match)
+
+1. **Capability** (0–3): map `max(Risk, Uncertainty)` with `0–1 → 0`, `2 → 1`, `3 → 2`, `4 → 3`. If **Coupling ≥ 3**, set Capability = `max(Capability, 2)`. Coupling does **not** bump to band 3 by itself.
+2. **Volume** (0–24): `(Scope + Coupling + Verification) × 2`.
+3. **Final score** = `25 × Capability + Volume` (0–99; cap at 100 if needed). No Risk/Uncertainty floors and no hard ceilings — the band *is* the floor.
+
+#### Band → model / effort
+
+| Capability | Score band | Model / planning | Effort from Volume tertiles (0–7 / 8–15 / 16–24) |
+|---|---|---|---|
+| 0 | 0–24 | Cheap/fast (Sonnet-class) | high / high / xhigh |
+| 1 | 25–49 | Opus-class | high / high / xhigh (never medium on Opus) |
+| 2 | 50–74 | Opus-class **+ fableplan first** | high / high / xhigh |
+| 3 | 75–99 | Fable 5 | medium / high / xhigh (medium is Fable-only) |
+
+Safety carve-outs (money, data integrity, security, auto-protective) remain absolute overrides in consumers that already have them — they force the capable path when flagged even if Risk was under-scored.
+
+#### Golden examples (consistency checklist)
+
+| Axes (S,C,R,U,V) | Capability | Volume | Score | Band meaning |
+|---|---|---|---|---|
+| (4,0,0,0,0) | 0 | 8 | **8** | Large mechanical grind → Sonnet-class, high |
+| (0,0,0,4,0) | 3 | 0 | **75** | Hard design, tiny surface → Fable 5 |
+| (0,4,1,1,0) | 2 (Coupling bump) | 8 | **58** | Heavy coordination, low R/U → Opus + fableplan |
+| (0,0,4,0,0) | 3 | 0 | **75** | Tiny money/security path → Fable 5 |
+| (0,0,3,0,0) | 2 | 0 | **50** | Elevated blast radius → Opus + fableplan |
+
+Work the axes in scratch; **report only** `N/100 — Capability <k> (<driver>); Volume <v>` with the traced edit list.
 
 ### 6.5. Scope disposition — is the issue too large to be ONE issue?
 
@@ -310,7 +337,7 @@ Verb tracks the action: `Created` for the original body, `Updated` for title/des
 
 Rules:
 - Close with the update-or-not decision, placed after the findings that justify it. That is the deliverable; the complexity score sits on the same line, after a `·` separator.
-- Always include the complexity score, even when the verdict is **No** — it tells the user how much work the fix is.
+- Always include the complexity score, even when the verdict is **No** — it is the model + effort routing signal for the fix.
 - No restatement of the issue title or body.
 - Each claim/concern fits on one line. If you need more, the claim is too broad — split it.
 - Drop the Concerns section entirely when there are none. Don't write "None."

--- a/tests/complexity-score.test.js
+++ b/tests/complexity-score.test.js
@@ -19,7 +19,7 @@ export function volumeFromAxes({ scope, coupling, verification }) {
 export function complexityScore(axes) {
   const capability = capabilityFromAxes(axes)
   const volume = volumeFromAxes(axes)
-  return { capability, volume, score: Math.min(100, 25 * capability + volume) }
+  return { capability, volume, score: 25 * capability + volume }
 }
 
 const root = new URL('../', import.meta.url)
@@ -74,6 +74,8 @@ describe('complexity score band encoding', () => {
 
   test('skills document the band formula and drop the old sum×5 / Risk floor', () => {
     expect(validateIssue).toContain('25 × Capability + Volume')
+    expect(validateIssue).toContain('0–99 under current axis bounds')
+    expect(validateIssue).not.toContain('cap at 100 if needed')
     expect(validateIssue).toContain('If **Coupling ≥ 3**')
     expect(validateIssue).toContain('#### Golden examples (consistency checklist)')
     expect(validateIssue).not.toContain('sum × 5')

--- a/tests/complexity-score.test.js
+++ b/tests/complexity-score.test.js
@@ -92,4 +92,19 @@ describe('complexity score band encoding', () => {
     expect(validateFableplanLoop).toContain('below 50')
     expect(readme).toContain('Capability ≥ 2 / score ≥ 50')
   })
+
+  test('verdict templates and consumers use Capability/Volume wording', async () => {
+    const [executionPlanReview, claudeMd, validateIssueLoop] = await Promise.all([
+      read('skills/execution-plan-review/SKILL.md'),
+      read('CLAUDE.md'),
+      read('skills/validate-issue-loop/SKILL.md'),
+    ])
+    expect(validateIssue).toContain('Capability <k> (<driver>); Volume <v>')
+    expect(validateIssueLoop).toContain('Capability <k> (<driver>); Volume <v>')
+    expect(fableValidateLoop).toContain('Capability <k> (<driver>); Volume <v>')
+    expect(executionPlanReview).toContain('conflicts with the score band')
+    expect(executionPlanReview).not.toContain('conflicts with the heuristics')
+    expect(claudeMd).toContain('model + effort routing signal')
+    expect(claudeMd).not.toContain('describe complexity as scope and risk')
+  })
 })

--- a/tests/complexity-score.test.js
+++ b/tests/complexity-score.test.js
@@ -96,10 +96,11 @@ describe('complexity score band encoding', () => {
   })
 
   test('verdict templates and consumers use Capability/Volume wording', async () => {
-    const [executionPlanReview, claudeMd, validateIssueLoop] = await Promise.all([
+    const [executionPlanReview, claudeMd, validateIssueLoop, githubIssueFormat] = await Promise.all([
       read('skills/execution-plan-review/SKILL.md'),
       read('CLAUDE.md'),
       read('skills/validate-issue-loop/SKILL.md'),
+      read('skills/github-issue-format/SKILL.md'),
     ])
     expect(validateIssue).toContain('Capability <k> (<driver>); Volume <v>')
     expect(validateIssueLoop).toContain('Capability <k> (<driver>); Volume <v>')
@@ -108,5 +109,10 @@ describe('complexity score band encoding', () => {
     expect(executionPlanReview).not.toContain('conflicts with the heuristics')
     expect(claudeMd).toContain('model + effort routing signal')
     expect(claudeMd).not.toContain('describe complexity as scope and risk')
+    // Money double-fill example must round-trip Risk 4 → Capability 3 → Fable 5 (not Opus).
+    expect(githubIssueFormat).toContain('[C95] Orders can be filled twice')
+    expect(githubIssueFormat).toContain('Capability 3 (Risk 4 — money/data-integrity on order-fill path); Volume 20 — Fable 5, xhigh')
+    expect(githubIssueFormat).not.toContain('[C70] Orders can be filled twice')
+    expect(githubIssueFormat).not.toContain('Capability 2 (risk high on order-fill path)')
   })
 })

--- a/tests/complexity-score.test.js
+++ b/tests/complexity-score.test.js
@@ -37,32 +37,39 @@ const [validateIssue, newIssue, githubIssueFormat, prdToIssues, fableValidateLoo
   ])
 
 describe('complexity score band encoding', () => {
-  test('golden examples from validate-issue', () => {
-    expect(complexityScore({ scope: 4, coupling: 0, risk: 0, uncertainty: 0, verification: 0 })).toEqual({
-      capability: 0,
-      volume: 8,
-      score: 8,
-    })
-    expect(complexityScore({ scope: 0, coupling: 0, risk: 0, uncertainty: 4, verification: 0 })).toEqual({
-      capability: 3,
-      volume: 0,
-      score: 75,
-    })
-    expect(complexityScore({ scope: 0, coupling: 4, risk: 1, uncertainty: 1, verification: 0 })).toEqual({
-      capability: 2,
-      volume: 8,
-      score: 58,
-    })
-    expect(complexityScore({ scope: 0, coupling: 0, risk: 4, uncertainty: 0, verification: 0 })).toEqual({
-      capability: 3,
-      volume: 0,
-      score: 75,
-    })
-    expect(complexityScore({ scope: 0, coupling: 0, risk: 3, uncertainty: 0, verification: 0 })).toEqual({
-      capability: 2,
-      volume: 0,
-      score: 50,
-    })
+  /** Parse golden rows from validate-issue prose so table drift fails CI. */
+  function parseGoldenExamples(markdown) {
+    const section = markdown.split('#### Golden examples (consistency checklist)')[1]
+    expect(section).toBeTruthy()
+    const rows = []
+    const rowRe =
+      /^\| \((\d+),(\d+),(\d+),(\d+),(\d+)\) \| (\d+)[^|]*\| (\d+) \| \*\*(\d+)\*\* \|/gm
+    for (const m of section.matchAll(rowRe)) {
+      rows.push({
+        axes: {
+          scope: Number(m[1]),
+          coupling: Number(m[2]),
+          risk: Number(m[3]),
+          uncertainty: Number(m[4]),
+          verification: Number(m[5]),
+        },
+        documented: {
+          capability: Number(m[6]),
+          volume: Number(m[7]),
+          score: Number(m[8]),
+        },
+      })
+    }
+    return rows
+  }
+
+  test('golden examples in validate-issue prose match the executable formula', () => {
+    const rows = parseGoldenExamples(validateIssue)
+    expect(rows.length).toBeGreaterThanOrEqual(5)
+    for (const { axes, documented } of rows) {
+      const computed = complexityScore(axes)
+      expect(documented).toEqual(computed)
+    }
   })
 
   test('skills document the band formula and drop the old sum×5 / Risk floor', () => {

--- a/tests/complexity-score.test.js
+++ b/tests/complexity-score.test.js
@@ -74,6 +74,8 @@ describe('complexity score band encoding', () => {
     expect(validateIssue).not.toContain('hard decision-gate over existing tooling')
 
     expect(newIssue).toContain('25 × Capability + Volume')
+    expect(newIssue).toContain('**Complexity: <score>/100** — Capability <k> (<driver>); Volume <v>')
+    expect(newIssue).not.toContain('scope: <…>; risk:')
     expect(newIssue).not.toContain('sum ×5')
     expect(newIssue).not.toContain('risk floor')
 

--- a/tests/complexity-score.test.js
+++ b/tests/complexity-score.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'bun:test'
+
+/**
+ * Canonical complexity score — mirrors validate-issue step 6.
+ * Kept as executable golden examples so a reviewer can verify the routing
+ * formula without re-deriving it from prose.
+ */
+export function capabilityFromAxes({ risk, uncertainty, coupling }) {
+  const map = (n) => (n <= 1 ? 0 : n === 2 ? 1 : n === 3 ? 2 : 3)
+  let capability = map(Math.max(risk, uncertainty))
+  if (coupling >= 3) capability = Math.max(capability, 2)
+  return capability
+}
+
+export function volumeFromAxes({ scope, coupling, verification }) {
+  return (scope + coupling + verification) * 2
+}
+
+export function complexityScore(axes) {
+  const capability = capabilityFromAxes(axes)
+  const volume = volumeFromAxes(axes)
+  return { capability, volume, score: Math.min(100, 25 * capability + volume) }
+}
+
+const root = new URL('../', import.meta.url)
+const read = (path) => Bun.file(new URL(path, root)).text()
+
+const [validateIssue, newIssue, githubIssueFormat, prdToIssues, fableValidateLoop, validateFableplanLoop, readme] =
+  await Promise.all([
+    read('skills/validate-issue/SKILL.md'),
+    read('skills/new-issue/SKILL.md'),
+    read('skills/github-issue-format/SKILL.md'),
+    read('skills/prd-to-issues/SKILL.md'),
+    read('skills/fable-validate-loop/SKILL.md'),
+    read('skills/validate-fableplan-loop/SKILL.md'),
+    read('README.md'),
+  ])
+
+describe('complexity score band encoding', () => {
+  test('golden examples from validate-issue', () => {
+    expect(complexityScore({ scope: 4, coupling: 0, risk: 0, uncertainty: 0, verification: 0 })).toEqual({
+      capability: 0,
+      volume: 8,
+      score: 8,
+    })
+    expect(complexityScore({ scope: 0, coupling: 0, risk: 0, uncertainty: 4, verification: 0 })).toEqual({
+      capability: 3,
+      volume: 0,
+      score: 75,
+    })
+    expect(complexityScore({ scope: 0, coupling: 4, risk: 1, uncertainty: 1, verification: 0 })).toEqual({
+      capability: 2,
+      volume: 8,
+      score: 58,
+    })
+    expect(complexityScore({ scope: 0, coupling: 0, risk: 4, uncertainty: 0, verification: 0 })).toEqual({
+      capability: 3,
+      volume: 0,
+      score: 75,
+    })
+    expect(complexityScore({ scope: 0, coupling: 0, risk: 3, uncertainty: 0, verification: 0 })).toEqual({
+      capability: 2,
+      volume: 0,
+      score: 50,
+    })
+  })
+
+  test('skills document the band formula and drop the old sum×5 / Risk floor', () => {
+    expect(validateIssue).toContain('25 × Capability + Volume')
+    expect(validateIssue).toContain('If **Coupling ≥ 3**')
+    expect(validateIssue).toContain('#### Golden examples (consistency checklist)')
+    expect(validateIssue).not.toContain('sum × 5')
+    expect(validateIssue).not.toContain('Risk floor')
+    expect(validateIssue).not.toContain('hard decision-gate over existing tooling')
+
+    expect(newIssue).toContain('25 × Capability + Volume')
+    expect(newIssue).not.toContain('sum ×5')
+    expect(newIssue).not.toContain('risk floor')
+
+    expect(githubIssueFormat).toContain('model + effort routing signal')
+    expect(githubIssueFormat).toContain('25 × Capability + Volume')
+
+    expect(prdToIssues).toContain('derive from the complexity score band')
+    expect(prdToIssues).toContain('25 × Capability + Volume')
+  })
+
+  test('fableplan gates key off Capability ≥ 2 / score ≥ 50', () => {
+    expect(fableValidateLoop).toContain('Capability < 2')
+    expect(fableValidateLoop).toContain('below 50')
+    expect(fableValidateLoop).not.toMatch(/below C50/)
+    expect(validateFableplanLoop).toContain('Capability < 2')
+    expect(validateFableplanLoop).toContain('below 50')
+    expect(readme).toContain('Capability ≥ 2 / score ≥ 50')
+  })
+})


### PR DESCRIPTION
## Summary
- Replaces sum×5 + Risk floor with Capability/Volume band encoding so `[C..]` routes LLM tier and effort without collapsing opposite work into one number.
- Updates scorers (`validate-issue`, `new-issue`, `github-issue-format`), fableplan gates, `prd-to-issues` Execution assignment, and README to the same contract.
- Adds golden-example unit tests that lock the formula and skill wording.

Closes #39

## Test plan
- [x] `bun test` (48 pass)
- [ ] Spot-check: Scope-only vs Uncertainty-only examples land in different bands
- [ ] Spot-check: Coupling≥3 bumps to Capability ≥ 2

---
Created with LLM: Grok 4.5 | high | Harness: Cursor