### PR TITLE
scratch: probe gh pr checks exit code (will be closed, not merged)

### DIFF
--- a/.github/workflows/scratch-always-fail.yml
+++ b/.github/workflows/scratch-always-fail.yml
@@ -1,0 +1,12 @@
+name: scratch always fail
+on:
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  fail:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - run: exit 1


### PR DESCRIPTION
Disposable probe PR to observe gh pr checks --json exit-code behavior on a failing check. Will be closed and branch deleted immediately after.