### PR TITLE
ci(claude-workflow): default the template to self-hosted; document the runs-on/runs_on split [C5, Sonnet 5, medium]

### DIFF
--- a/templates/claude-workflow/README.md
+++ b/templates/claude-workflow/README.md
@@ -48,8 +48,26 @@ rk-skills at run time by the reusable workflow. Then:
 
 ## Customization inputs
 
+The vendored `claude.yml` ships with `classify` on `runs-on: self-hosted` and
+`runs_on: self-hosted` passed to every route (`review`/`implement`/`fix-pr`).
+If your repo has no self-hosted runner registered, switch all four back to
+`ubuntu-latest` (or your own label) before installing.
+
+**These four settings are independent — changing one does NOT change the
+others.** `classify`'s `runs-on:` is a plain job field; each route's
+`runs_on:` is a separate `with:` input to the reusable workflow, defaulted to
+`ubuntu-latest` *inside claude-run.yml itself* when omitted. A repo that
+edits only `classify` (e.g. to move it onto a self-hosted runner) without
+also setting `runs_on: self-hosted` on `review`/`implement`/`fix-pr` will
+have those three routes silently fall back to `ubuntu-latest` — which is how
+a hosted-runner billing hold took down `@claude review`/`implement`/`fix-pr`
+on a consumer repo while `classify` (correctly on self-hosted) kept working.
+Grep the file for `runs-on` and `runs_on` and confirm all four agree before
+relying on a non-default runner.
+
 Each call site in `claude.yml` can pass these optional `with:` inputs to the
-reusable workflow (defaults shown):
+reusable workflow (defaults shown are `claude-run.yml`'s own, used only when
+a call site omits the input):
 
 | Input | Default | Purpose |
 |-------|---------|---------|

--- a/templates/claude-workflow/workflows/claude.yml
+++ b/templates/claude-workflow/workflows/claude.yml
@@ -40,7 +40,7 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 5
     permissions: {}
     outputs:
@@ -296,6 +296,7 @@ jobs:
       flow: ''
       model_id: ${{ needs.classify.outputs.model_id }}
       effort: ${{ needs.classify.outputs.effort }}
+      runs_on: self-hosted
     secrets: inherit
 
   # Implementation runs legitimately commit and push (issue workflow opens a PR;
@@ -316,6 +317,7 @@ jobs:
       flow: ${{ needs.classify.outputs.flow }}
       model_id: ${{ needs.classify.outputs.model_id }}
       effort: ${{ needs.classify.outputs.effort }}
+      runs_on: self-hosted
     secrets: inherit
 
   # A fix-pr run edits the pull request's own branch in place and pushes to it:
@@ -354,4 +356,5 @@ jobs:
       flow: ''
       model_id: ${{ needs.classify.outputs.model_id }}
       effort: ${{ needs.classify.outputs.effort }}
+      runs_on: self-hosted
     secrets: inherit


### PR DESCRIPTION
## Summary
- Default the vendored `claude.yml` template to `runs-on: self-hosted` for `classify` and `runs_on: self-hosted` for `review`/`implement`/`fix-pr` — all current consumer repos (`leave-a-message`, `scene-cut-ai`, `scenecut-front`) already run self-hosted, so future repos copying the template get it by default.
- Document in the README that these four runner settings are independent: `classify`'s `runs-on:` is a plain job field, while each route's `runs_on:` is a separate `with:` input to `claude-run.yml` that defaults to `ubuntu-latest` on its own when omitted. A repo that only edits `classify` silently leaves the other three on `ubuntu-latest` — exactly what happened on `leave-a-message`, where a GitHub-hosted-runner billing hold took down `@claude review`/`implement`/`fix-pr` while `classify` (correctly self-hosted) kept working.
- Repos without a self-hosted runner should flip all four back to `ubuntu-latest` (or their own label) before installing — called out explicitly in the README now.

## Test plan
- [x] `python3 -m unittest discover -s templates/claude-workflow/scripts -p 'test_*.py'` — 73 tests pass.
- [ ] New repos copying the template pick up a working self-hosted `@claude` bundle without needing to separately edit all four runner settings.

---
Created with LLM: Sonnet 5 | medium | Harness: Claude Code