### PR TITLE
feat(#57): inventory duplicated contracts and guard PR-review format [C72, Cursor Grok 4.5, high]

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Duplicated rules across skills, prompts, workflows, and globals are tracked in [
 | Complexity score formula / phrases | `skills/validate-issue/SKILL.md` step 6 | `tests/complexity-score.test.js` |
 | Execution block `Depends on` / `Runs after` | `skills/prd-to-issues/SKILL.md` | `tests/execution-block-contract.test.js` |
 | Shared CI prompt shell safety | `templates/claude-workflow/prompts/*.md` | `tests/prompt-shell-safety.test.js` |
+| Inventory / README guard citations | Paths named in `docs/contract-inventory.md` and READMEs | `tests/inventory-guard-citations.test.js` |
 
 When editing a guarded family, change every consumer in the inventory row in the same PR and keep prompt shell-safety rules.
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ Also included:
 - `CLAUDE.md` — an example set of global instructions these skills are tuned for (attribution footers, complexity scores, the worktree+PR workflow). Use it as a reference for your own `~/.claude/CLAUDE.md`.
 - `commands/commit.md` — a `/commit` slash command for creating well-formed git commits.
 
+## Guarded contracts
+
+Duplicated rules across skills, prompts, workflows, and globals are tracked in [`docs/contract-inventory.md`](./docs/contract-inventory.md) (parent [#57](https://github.com/richkuo/rk-skills/issues/57)). Semantic Bun tests under `tests/` fail when a **required shared** contract drifts; intentional runtime differences are allowed and documented per row.
+
+| Surface | Canonical owner | Guard (`bun test`) |
+|---------|-----------------|--------------------|
+| PR review format (skill + CI prompt + minimal workflow) | Shared semantic set (three paraphrased copies) | `tests/pr-review-format-contract.test.js` |
+| Complexity score formula / phrases | `skills/validate-issue/SKILL.md` step 6 | `tests/complexity-score.test.js` |
+| Execution block `Depends on` / `Runs after` | `skills/prd-to-issues/SKILL.md` | `tests/execution-block-contract.test.js` |
+| Shared CI prompt shell safety | `templates/claude-workflow/prompts/*.md` | `tests/prompt-shell-safety.test.js` |
+
+When editing a guarded family, change every consumer in the inventory row in the same PR and keep prompt shell-safety rules.
+
 ## Install (with npx)
 
 Copy every skill into your personal `~/.claude/skills/` with one command — no marketplace, no clone:

--- a/docs/contract-inventory.md
+++ b/docs/contract-inventory.md
@@ -10,6 +10,7 @@ This inventory records every duplicated repository contract: who owns it, who re
 2. Update every **consumer** listed for that row in the same change.
 3. Run `bun test` — semantic guards fail when required markers drift.
 4. For `templates/claude-workflow/prompts/*.md`, also satisfy shell safety: no `"`, backticks, or `$` (`tests/prompt-shell-safety.test.js`).
+5. If you rename or delete a guard test, update every inventory/README citation — `tests/inventory-guard-citations.test.js` fails on dangling `tests/*.test.js` paths.
 
 ## Inventory
 

--- a/docs/contract-inventory.md
+++ b/docs/contract-inventory.md
@@ -1,0 +1,50 @@
+# Contract inventory
+
+Parent tracking: [#57](https://github.com/richkuo/rk-skills/issues/57).
+
+This inventory records every duplicated repository contract: who owns it, who restates it, what must stay aligned, what may diverge, how it is guarded, and what to do next. Full-file equality is the wrong guard when wording intentionally differs by runtime; guards check **required shared semantics**.
+
+## How to update a guarded contract
+
+1. Edit the **canonical owner** (or every consumer when the owner is a shared semantic set with no generator).
+2. Update every **consumer** listed for that row in the same change.
+3. Run `bun test` — semantic guards fail when required markers drift.
+4. For `templates/claude-workflow/prompts/*.md`, also satisfy shell safety: no `"`, backticks, or `$` (`tests/prompt-shell-safety.test.js`).
+
+## Inventory
+
+| Family | Canonical owner | Consumers | Required shared semantics | Allowed divergence | Guard | Disposition |
+|---|---|---|---|---|---|---|
+| PR review format | Semantic set across three paraphrased copies (no single generated source yet) | `skills/pr-review-format/SKILL.md`; `templates/claude-workflow/prompts/pr-review-format.md`; `templates/claude-review.yml` (inline prompt) | Verdicts `LGTM` / `Needs Updates`; four H3 sections; blocking = Needs Fixing + Requires Human Review; materiality filter; safety carve-out overrides materiality; per-finding **Plain simple English:** (≤55 words); **Invariant:** + **Must survive:** on Needs Fixing / Recommended Optional; **Recommended proposed solution:** on Requires Human Review; follow-up and human-review as last-resort dispositions; field order Plain → (Invariant/Must survive or Recommended proposed solution) | Interactive skill may gate LGTM on CI inspection; CI copies must forbid executing project code and must not wait on CI; safety trigger lists may be project-flavored | `tests/pr-review-format-contract.test.js` (`bun test`) | **Guarded in parent PR** (non-negotiable for #57) |
+| Release version rules | `agents/create-release-runner.md` step 4 (manifest bump when version fields exist) | `skills/create-release/SKILL.md`; `templates/claude-workflow/prompts/sync-docs-release.md` (CI sync-release / publish modes); `.github/workflows/publish.yml` | When `package.json` / `.claude-plugin/plugin.json` (or other manifests) declare a version and publish keys off it, release paths must bump those versions before tagging/publishing so publish is not silently skipped | CI checkout may lack push to main; branch-shaped `docs-release/vX.Y.Z` publish path differs from interactive tag-on-main | Child issue (no guard yet) | **Child issue** — correct CI “no version file” claim, then guard |
+| Global guidelines body | Shared body of `CLAUDE.md` / `AGENTS.md` (tool-specific harness names and examples only) | `agents/sync-docs-runner.md` step 5 (mirror rule); skills that quote PR-body lead / footer | Integrity, response style, engineering, attribution footer shape, PR title convention, PR review format load rule, GitHub issue format load rule, worktree+PR workflow | Harness names (`Claude Code` vs `Codex`); `#` memory target file; worktree prefix examples; project-precedence filename | Child issue (no guard yet) | **Child issue** — add missing PR-body lead to `AGENTS.md`, then semantic guard |
+| LLM attribution footer | Global verb-based footer in `CLAUDE.md` / `AGENTS.md` | Skills (`work-on-issue`, `pr-review-format`, issue format, etc.); workflow comment composer (`templates/claude-workflow/scripts/compose_claude_comment.py` and related) | Durable artifacts end with `---` + verb/`LLM` attribution; verbs Created / Updated / Validated; effort never `low` | CI composer may emit `LLM: <model> \| <effort> \| Harness: …` without the `Created with LLM:` verb prefix when rewriting Action comments — document as intentional exception | Child issue | **Child issue** — one contract + explicit exceptions |
+| Fix-PR procedure | Shared goals across interactive + CI | `skills/fix-pr-review/SKILL.md` (+ loop); `templates/claude-workflow/prompts/fix-pr.md` | Fetch all unaddressed channels; re-validate before fixing; disposition comment; re-review trigger | Fork handling; test execution (interactive runs tests; CI must not); permissions; `@claude` vs `@claude sonnet` trigger rules | None yet | **Parent checklist** — inventory shared core before child |
+| Live vs template `claude.yml` | Template intended as vendored source: `templates/claude-workflow/workflows/claude.yml` | Live: `.github/workflows/claude.yml`; routing tests in `templates/claude-workflow/scripts/test_workflow_logic.py` | Fail-closed route classifier behavior; route → prompt mapping | Runner settings / timeouts / repo-local wiring | Partial: Python template tests | **Parent checklist** — classify shared core; decide live coverage |
+| Sync-docs procedure | Interactive: `agents/sync-docs-runner.md` + `skills/sync-docs/SKILL.md` | CI: `templates/claude-workflow/prompts/sync-docs-release.md` sync mode | Commit classification; mirror CLAUDE↔AGENTS when both exist; no inventing top-level docs | CI shallow clone / tag fetch; write permissions; release coupling in sync-release | None yet | **Parent checklist** |
+| Loop / validate skill families | Each base skill is owner of its step contract | `*-loop` wrappers; Fable variants | Pipeline handoffs named in base skill; Complexity band gates (Capability ≥ 2 / score ≥ 50) where documented | Model/harness routing; unconditional vs gated fableplan | Partial: `tests/complexity-score.test.js` phrase checks | **Parent checklist** — guard only identical contracts |
+| Capability bands | `skills/validate-issue/SKILL.md` step 6 formula + golden table | `new-issue`, `github-issue-format`, `prd-to-issues`, loop skills, README | Formula `25 × Capability + Volume`; Coupling ≥ 3 bump; golden examples | Consumer-specific prose around the formula | `tests/complexity-score.test.js` | **Guarded for formula/phrases**; extend only truly shared table rows later |
+| Package / plugin version parity | `package.json` `"version"` | `.claude-plugin/plugin.json` `"version"` | Exact string equality | Installer behavior: `install.sh` symlinks vs `bin/install.mjs` copy | None yet | **Parent checklist** — guard parity; document installer divergence |
+| Prompt shell safety | `templates/claude-workflow/prompts/*.md` | `.github/workflows/claude-run.yml` runtime reject | No `"`, backtick, or `$` in shared prompts | N/A | `tests/prompt-shell-safety.test.js` | **Guarded** |
+| Execution block ordering | `skills/prd-to-issues/SKILL.md` | `execution-plan-review`, `milestone-workflow`, README | `Depends on` / `Runs after` fields and graph rules | Presentation-only wording | `tests/execution-block-contract.test.js` | **Guarded** |
+
+## Child issues filed from ready rows
+
+| Row | Child |
+|---|---|
+| Release version rules | [#58](https://github.com/richkuo/rk-skills/issues/58) |
+| Global guidelines body | [#59](https://github.com/richkuo/rk-skills/issues/59) |
+| LLM attribution footer | [#60](https://github.com/richkuo/rk-skills/issues/60) |
+
+## Deferred (need more evidence before complete child specs)
+
+- Fix-PR shared core vs intentional divergence
+- Live vs template workflow + routing-shell coverage for live
+- Sync-docs interactive vs CI
+- Loop/validate identical-only contracts
+- Capability-band full table rows beyond formula/phrases
+- Version/install parity + installer docs
+- Any additional family found in a later audit
+
+---
+Created with LLM: Cursor Grok 4.5 | high | Harness: Cursor

--- a/templates/claude-workflow/README.md
+++ b/templates/claude-workflow/README.md
@@ -108,3 +108,12 @@ always stay read-only regardless of keyword.
   carry no interpreters; CI (if you have it) owns checks.
 - **Fail-closed routing:** anything ambiguous classifies as read-only review;
   untrusted PR authors never reach a push-capable route.
+
+## Contract guards
+
+`prompts/pr-review-format.md` is one of three paraphrased PR-review format
+copies (with `skills/pr-review-format/SKILL.md` and `templates/claude-review.yml`).
+Shared semantics are enforced by `tests/pr-review-format-contract.test.js` at
+the repo root (`bun test`). Prompt files must also stay free of `"`, backticks,
+and `$` (`tests/prompt-shell-safety.test.js`). Full inventory:
+[`docs/contract-inventory.md`](../../docs/contract-inventory.md).

--- a/tests/inventory-guard-citations.test.js
+++ b/tests/inventory-guard-citations.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Keep docs from citing renamed/deleted Bun guard tests.
+ * Inventory and READMEs list `tests/*.test.js` paths as the enforcement
+ * surface — a dangling citation silently defeats the anti-drift theme.
+ */
+
+const rootDir = new URL('../', import.meta.url)
+const rootPath = Bun.fileURLToPath(rootDir)
+const read = (path) => Bun.file(new URL(path, rootDir)).text()
+
+const sources = [
+  'docs/contract-inventory.md',
+  'README.md',
+  'templates/claude-workflow/README.md',
+]
+
+/** Match backtick or bare references to repo-root Bun tests. */
+const GUARD_PATH_RE = /(?:`|\b)(tests\/[A-Za-z0-9._/-]+\.test\.js)(?:`|\b)/g
+
+function citedGuardPaths(markdown) {
+  const found = new Set()
+  for (const match of markdown.matchAll(GUARD_PATH_RE)) {
+    found.add(match[1])
+  }
+  return [...found].sort()
+}
+
+describe('inventory guard path citations', () => {
+  test('every tests/*.test.js path cited in inventory/READMEs exists on disk', async () => {
+    const allCited = new Set()
+
+    for (const source of sources) {
+      const text = await read(source)
+      const cited = citedGuardPaths(text)
+      expect(cited.length, `${source} should cite at least one guard test`).toBeGreaterThan(0)
+      for (const rel of cited) {
+        allCited.add(rel)
+        const abs = join(rootPath, rel)
+        expect(existsSync(abs), `${source} cites missing guard ${rel}`).toBe(true)
+      }
+    }
+
+    // Sanity: the new PR-review guard must be among citations once documented.
+    expect([...allCited]).toContain('tests/pr-review-format-contract.test.js')
+  })
+})

--- a/tests/pr-review-format-contract.test.js
+++ b/tests/pr-review-format-contract.test.js
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test'
+
+/**
+ * Semantic synchronization for the PR-review format triple.
+ * Full-file equality is wrong: interactive and CI copies intentionally diverge
+ * (CI status gating, "never execute project code", safety trigger lists).
+ * This guard asserts the shared contract markers that must stay aligned.
+ */
+
+const root = new URL('../', import.meta.url)
+const read = (path) => Bun.file(new URL(path, root)).text()
+
+const [skill, ciPrompt, minimalYml] = await Promise.all([
+  read('skills/pr-review-format/SKILL.md'),
+  read('templates/claude-workflow/prompts/pr-review-format.md'),
+  read('templates/claude-review.yml'),
+])
+
+/** Collapse YAML / markdown wrapping so `**Must\n survive:**` matches the field. */
+const normalize = (text) => text.replace(/\s+/g, ' ')
+
+const copies = [
+  { name: 'skills/pr-review-format/SKILL.md', text: skill, flat: normalize(skill) },
+  {
+    name: 'templates/claude-workflow/prompts/pr-review-format.md',
+    text: ciPrompt,
+    flat: normalize(ciPrompt),
+  },
+  { name: 'templates/claude-review.yml', text: minimalYml, flat: normalize(minimalYml) },
+]
+
+/** Required markers every copy must satisfy (matched against whitespace-normalized text). */
+const sharedMarkers = [
+  { id: 'verdict-lgtm', re: /\bLGTM\b/ },
+  { id: 'verdict-needs-updates', re: /Needs Updates/ },
+  { id: 'section-needs-fixing', re: /### Needs Fixing/ },
+  { id: 'section-requires-human-review', re: /### Requires Human Review/ },
+  { id: 'section-recommended-optional', re: /### Recommended Optional/ },
+  { id: 'section-create-follow-up', re: /### Create Follow-up Issue/ },
+  {
+    id: 'blocking-rule',
+    re: /Needs Updates.{0,200}Needs Fixing.{0,120}Requires Human Review|Needs Fixing.{0,80}Requires Human Review.{0,200}Needs Updates/i,
+  },
+  { id: 'materiality-trivia', re: /trivia/i },
+  { id: 'materiality-nit', re: /\bnit\b/i },
+  { id: 'safety-carve-out', re: /Safety carve-out/i },
+  { id: 'safety-overrides-materiality', re: /overrides.{0,80}materiality/i },
+  { id: 'plain-simple-english-field', re: /\*\*Plain simple English:\*\*/ },
+  { id: 'plain-simple-english-word-cap', re: /55 words/ },
+  { id: 'invariant-field', re: /\*\*Invariant:\*\*/ },
+  { id: 'must-survive-field', re: /\*\*Must survive:\*\*/ },
+  { id: 'recommended-proposed-solution', re: /\*\*Recommended proposed solution:\*\*/ },
+  { id: 'follow-up-last-resort', re: /Create Follow-up Issue.{0,80}last resort/i },
+  { id: 'human-review-last-resort', re: /Requires Human Review.{0,80}last resort/i },
+  { id: 'numbered-list', re: /numbered list/i },
+]
+
+describe('PR review format shared semantics', () => {
+  for (const { name, flat } of copies) {
+    test(`${name} carries every required shared marker`, () => {
+      const missing = sharedMarkers.filter(({ re }) => !re.test(flat)).map(({ id }) => id)
+      expect(missing, `${name} missing: ${missing.join(', ')}`).toEqual([])
+    })
+  }
+
+  test('field order: Plain simple English before Invariant and Must survive', () => {
+    for (const { name, flat } of copies) {
+      const plain = flat.indexOf('**Plain simple English:**')
+      const invariant = flat.indexOf('**Invariant:**')
+      const mustSurvive = flat.indexOf('**Must survive:**')
+      expect(plain, `${name}: Plain simple English`).toBeGreaterThanOrEqual(0)
+      expect(invariant, `${name}: Invariant after Plain`).toBeGreaterThan(plain)
+      expect(mustSurvive, `${name}: Must survive after Invariant`).toBeGreaterThan(invariant)
+    }
+  })
+
+  test('field order: Plain simple English before Recommended proposed solution', () => {
+    for (const { name, flat } of copies) {
+      const plain = flat.indexOf('**Plain simple English:**')
+      const recommended = flat.indexOf('**Recommended proposed solution:**')
+      expect(recommended, `${name}: Recommended proposed solution after Plain`).toBeGreaterThan(plain)
+    }
+  })
+
+  test('Invariant and Must survive are tied to Needs Fixing and Recommended Optional', () => {
+    for (const { name, flat } of copies) {
+      expect(flat).toMatch(
+        /Needs Fixing.{0,200}Recommended Optional.{0,200}Invariant|Invariant.{0,200}Needs Fixing.{0,120}Recommended Optional/i,
+      )
+      expect(flat, `${name} mentions Must survive near Needs Fixing / Optional`).toMatch(
+        /Must survive.{0,300}Needs Fixing|Needs Fixing.{0,400}Must survive/i,
+      )
+    }
+  })
+})
+
+describe('PR review format intentional CI divergence', () => {
+  test('CI prompt and minimal workflow forbid executing project code', () => {
+    for (const flat of [normalize(ciPrompt), normalize(minimalYml)]) {
+      expect(flat).toMatch(/never execute|do NOT run test suites|Do NOT execute the project's code/i)
+    }
+  })
+
+  test('CI copies must not gate the verdict on CI status', () => {
+    for (const flat of [normalize(ciPrompt), normalize(minimalYml)]) {
+      expect(flat).toMatch(/Do NOT gate the verdict on CI/i)
+    }
+  })
+
+  test('interactive skill keeps CI inspection in the LGTM precondition', () => {
+    expect(normalize(skill)).toMatch(/check CI status/i)
+  })
+})


### PR DESCRIPTION
## Plain simple English

This change maps every place the same repo rules are copied, adds a test so the pull-request review format cannot silently drift across its three copies, and files follow-up issues for the remaining must-fix families. Parent tracking issue #57 stays open until those children finish.

## Summary

- Added `docs/contract-inventory.md` with owner / consumers / shared semantics / allowed divergence / guard / disposition for each duplicated-contract family.
- Added `tests/pr-review-format-contract.test.js` semantic guard for the PR-review format triple (skill + CI prompt + minimal workflow), preserving intentional CI-only constraints.
- Documented guarded surfaces in root and template READMEs.
- Filed children: #58 (release versions), #59 (CLAUDE/AGENTS lockstep), #60 (attribution footer).
- Updated #57 checklist progress; **does not close #57** (umbrella closes only after children complete or are deferred).

Part of #57

## Verification

- `bun test` — 73 pass (including new PR-review format contract tests)
- Red check: renaming `**Plain simple English:**` in the skill failed the guard; restored and re-passed

---
Created with LLM: Cursor Grok 4.5 | high | Harness: Cursor