### PR TITLE
docs(sync-docs-runner): tighten CLAUDE.md condensation thresholds [C5, Sonnet 5, medium]

### DIFF
--- a/agents/sync-docs-runner.md
+++ b/agents/sync-docs-runner.md
@@ -111,7 +111,7 @@ Claude Code warns when CLAUDE.md exceeds 40k chars ("Large CLAUDE.md will impact
 wc -c CLAUDE.md
 ```
 
-If the byte count exceeds **40000**, condense in-place before finishing the sync. Target: bring the file back under 38000 chars (leaves headroom for the next sync). Do NOT split into multiple files — agents only auto-load the root CLAUDE.md.
+If the byte count exceeds **35000**, condense in-place before finishing the sync. Target: bring the file back under 30000 chars (leaves headroom for the next sync). Do NOT split into multiple files — agents only auto-load the root CLAUDE.md.
 
 **If a CHANGELOG.md exists, relocate rather than delete.** Before dropping completed-migration prose, resolved-incident narrative, or per-issue "why" detail (passes 2 and 5 below), move it into CHANGELOG.md keyed by issue/PR instead of discarding it — the history stays available without loading into agent context every turn. Only outright-delete history when the repo has no CHANGELOG.md to receive it. Never create a CHANGELOG.md solely to offload bytes during a sync; if CLAUDE.md is oversized and no CHANGELOG.md exists, surface that to the user as an option rather than introducing the file unilaterally.
 


### PR DESCRIPTION
## Summary
- Lower the CLAUDE.md condensation trigger from 40000 to 35000 chars, and the post-condense target from 38000 to 30000 chars, in the sync-docs-runner agent.

## Verification
- Confirmed no other stale references to the old 40000/38000 thresholds remain in the file.

## Plain simple English
This changes when the doc-syncing helper trims down an overgrown CLAUDE.md file: it now starts cleaning up sooner (at 35,000 characters instead of 40,000) and leaves more room to grow afterward (target 30,000 instead of 38,000).

---
Created with LLM: Sonnet 5 | medium | Harness: Claude Code