### PR TITLE
feat(#64): guard loop/validate shared pipeline rules against drift [C39, Cursor Grok 4.5, high]

### DIFF
--- a/docs/contract-inventory.md
+++ b/docs/contract-inventory.md
@@ -2,11 +2,11 @@
 
 Scoped to the loop/validate skill families ([#64](https://github.com/richkuo/rk-skills/issues/64)). Broader duplicated-contract tracking from superseded [#57](https://github.com/richkuo/rk-skills/issues/57) is out of scope here.
 
-This inventory records every shared pipeline rule those families restate in prose: who owns it, who restates it, what must stay aligned, what may diverge, and how CI guards it. Guards check **required shared semantics** (key thresholds and stop conditions), not exact string equality — wording may differ by harness ("Fable subagent" vs "session model") when the numbers and decisions match.
+This inventory records every shared pipeline rule those families restate in prose: who owns it, who restates it, what must stay aligned, what may diverge, and how CI guards it. Guards check **required shared semantics** (key thresholds and stop conditions), not exact string equality — wording may differ by harness ("Fable subagent" vs "session model") when the numbers and decisions match. Markers must appear in the **procedure body** (after YAML frontmatter); a `description:` line that only mentions the words is not enough. Stop rules are anchored to decision-table rows that co-locate `STOP` with the rule terms.
 
 ## How to update a guarded rule
 
-1. Edit every **consumer** listed for that row in the same change (there is no generator for `SKILL.md` prose).
+1. Edit every **consumer** listed for that row in the same change (there is no generator for `SKILL.md` prose). Keep the procedural wording in the body/decision table — do not rely on frontmatter alone.
 2. If the change is an intentional divergence, record it under **Allowed divergence** / the exception section below and update the guard's exception list.
 3. Run `bun test` — `tests/loop-validate-pipeline-contract.test.js` fails when a required marker is missing or contradicted.
 4. Keep this inventory row in sync with the guard's consumer lists.

--- a/docs/contract-inventory.md
+++ b/docs/contract-inventory.md
@@ -1,0 +1,65 @@
+# Contract inventory — loop / validate pipeline rules
+
+Scoped to the loop/validate skill families ([#64](https://github.com/richkuo/rk-skills/issues/64)). Broader duplicated-contract tracking from superseded [#57](https://github.com/richkuo/rk-skills/issues/57) is out of scope here.
+
+This inventory records every shared pipeline rule those families restate in prose: who owns it, who restates it, what must stay aligned, what may diverge, and how CI guards it. Guards check **required shared semantics** (key thresholds and stop conditions), not exact string equality — wording may differ by harness ("Fable subagent" vs "session model") when the numbers and decisions match.
+
+## How to update a guarded rule
+
+1. Edit every **consumer** listed for that row in the same change (there is no generator for `SKILL.md` prose).
+2. If the change is an intentional divergence, record it under **Allowed divergence** / the exception section below and update the guard's exception list.
+3. Run `bun test` — `tests/loop-validate-pipeline-contract.test.js` fails when a required marker is missing or contradicted.
+4. Keep this inventory row in sync with the guard's consumer lists.
+
+## Inventoried skill files
+
+| Skill | Role in this inventory |
+|---|---|
+| `skills/fix-pr-review-loop/SKILL.md` | Full owner of the review-cycle stop procedure |
+| `skills/work-on-issue-loop/SKILL.md` | Same review-cycle stop procedure (opens PR, then same loop) |
+| `skills/fableplan-loop/SKILL.md` | Paraphrases the review-cycle threshold; always-plan (no Capability gate) |
+| `skills/fable-validate-loop/SKILL.md` | Capability-gated fableplan + validation stop conditions |
+| `skills/validate-fableplan-loop/SKILL.md` | Capability-gated fableplan + validation stop conditions (session-model validate) |
+| `skills/fable-validate-fableplan-loop/SKILL.md` | Always-plan exception + validation stop conditions |
+| `skills/new-issue-loop/SKILL.md` | Duplicate / convergence stop before validate-issue-loop |
+| `skills/fable-new-issue-loop/SKILL.md` | Same duplicate / convergence stop (Fable front) |
+| `skills/validate-issue-loop/SKILL.md` | Validation stop conditions; hands off review loop |
+| `skills/validate-issue/SKILL.md` | Base validator — inventored; does **not** restate loop pipeline stop rules |
+| `skills/fable-validate/SKILL.md` | Fable wrapper for validate-issue — inventored; does **not** restate loop pipeline stop rules |
+
+## Shared pipeline rules
+
+| Rule | Canonical owner | Consumers that must state it | Required shared semantics | Allowed divergence | Guard |
+|---|---|---|---|---|---|
+| Review-cycle / LGTM stop | `fix-pr-review-loop` procedure (`review_count > 5`) | `fix-pr-review-loop`, `work-on-issue-loop` (full); `fableplan-loop` (must paraphrase the threshold) | Bare `LGTM` with no remaining sections stops at any cycle count; after more than **5** review cycles, the first `LGTM` ends the loop even with non-blocking leftovers; `Needs Updates` alone never stops by cycle count | Full procedure vs short paraphrase ("past 5 cycles the first LGTM") is fine; who triggers the first `@claude` review differs by entry skill | `tests/loop-validate-pipeline-contract.test.js` |
+| Fableplan Capability gate | Shared semantic in gated validate→plan loops | `fable-validate-loop`, `validate-fableplan-loop` | Skip fableplan when Capability **< 2** / score **below 50** with no safety flags; safety carve-out (money, data integrity, security, auto-protective) overrides the skip | "Fable validates" vs "session model validates" wording; which skill name is the unconditional counterpart | same |
+| Always-plan (no Capability gate) | Intentional exception set | `fable-validate-fableplan-loop`, `fableplan-loop` | Must document that there is **no** Capability gate / fableplan **always** runs; must not install the skip-below-50 gate as this skill's own rule | Why the gate is absent (no validation score vs unconditional plan product) | same — exception path |
+| Duplicate / convergence stop | Shared semantic in new-issue chains | `new-issue-loop`, `fable-new-issue-loop` | Stop when a duplicate open issue/PR already covers the work, or when the discussion has not converged on one issue to file | Front skill is `new-issue` vs `fable-new-issue` | same |
+| Validation scope / feasibility / existing-PR stop | Shared semantic in validate→implement loops | `validate-issue-loop`, `fable-validate-loop`, `validate-fableplan-loop`, `fable-validate-fableplan-loop` | Stop instead of implementing when validation flags the issue as too large, architecturally infeasible, or already addressed by an existing open PR | Whether a Fable plan step sits between update and implement | same |
+
+## Intentional exceptions
+
+### Always-plan skills omit the Capability gate
+
+`fable-validate-fableplan-loop` and `fableplan-loop` intentionally have **no** "skip fableplan when Capability < 2 / score < 50" gate. That is the product difference from `fable-validate-loop` / `validate-fableplan-loop`, not drift. The guard requires those two files to state the missing gate explicitly and does **not** require the skip-below-50 instruction as their own rule.
+
+### Base validators are not pipeline consumers
+
+`validate-issue` and `fable-validate` own claim-tracing and scoring. They do not restate the review-cycle threshold, Capability gate, or new-issue duplicate stop. The guard does not require those markers in those two files.
+
+## Out of scope for this inventory's guard
+
+| Surface | Why |
+|---|---|
+| `workflows/milestone-pipeline.js` `maxReviewCycles` (default **5**) | Configurable workflow arg, not skill prose. Same number today as the skill threshold, but changing one does not automatically change the other. |
+| `skills/milestone-workflow/SKILL.md` mentions of `maxReviewCycles` | Documents the workflow arg and planning bounds; not a restatement of the fix-pr-review-loop stop procedure. |
+| `tests/milestone-pipeline.test.js` | Exercises the workflow harness, not skill `SKILL.md` contracts. |
+
+If the skill review-cycle threshold and the workflow default must stay locked together later, that is a separate contract — not covered by `tests/loop-validate-pipeline-contract.test.js`.
+
+## Related partial coverage
+
+`tests/complexity-score.test.js` already asserts Capability-gate phrasing in `fable-validate-loop` and `validate-fableplan-loop`. This inventory's guard is the pipeline-family source of truth for the full consumer sets and exceptions above.
+
+---
+Created with LLM: Cursor Grok 4.5 | high | Harness: Cursor

--- a/tests/loop-validate-pipeline-contract.test.js
+++ b/tests/loop-validate-pipeline-contract.test.js
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test'
+
+/**
+ * Semantic guard for loop/validate skill-family pipeline rules.
+ * Checks key parameters (thresholds, stop conditions), not exact prose.
+ * See docs/contract-inventory.md.
+ */
+const root = new URL('../', import.meta.url)
+const read = (path) => Bun.file(new URL(path, root)).text()
+
+const REVIEW_CYCLE_FULL = [
+  'skills/fix-pr-review-loop/SKILL.md',
+  'skills/work-on-issue-loop/SKILL.md',
+]
+const REVIEW_CYCLE_PARAPHRASE = ['skills/fableplan-loop/SKILL.md']
+
+const CAPABILITY_GATE = [
+  'skills/fable-validate-loop/SKILL.md',
+  'skills/validate-fableplan-loop/SKILL.md',
+]
+const ALWAYS_PLAN = [
+  'skills/fable-validate-fableplan-loop/SKILL.md',
+  'skills/fableplan-loop/SKILL.md',
+]
+
+const DUPLICATE_CONVERGENCE = [
+  'skills/new-issue-loop/SKILL.md',
+  'skills/fable-new-issue-loop/SKILL.md',
+]
+
+const VALIDATION_STOP = [
+  'skills/validate-issue-loop/SKILL.md',
+  'skills/fable-validate-loop/SKILL.md',
+  'skills/validate-fableplan-loop/SKILL.md',
+  'skills/fable-validate-fableplan-loop/SKILL.md',
+]
+
+const INVENTORY = 'docs/contract-inventory.md'
+
+const texts = Object.fromEntries(
+  await Promise.all(
+    [
+      ...new Set([
+        ...REVIEW_CYCLE_FULL,
+        ...REVIEW_CYCLE_PARAPHRASE,
+        ...CAPABILITY_GATE,
+        ...ALWAYS_PLAN,
+        ...DUPLICATE_CONVERGENCE,
+        ...VALIDATION_STOP,
+        INVENTORY,
+      ]),
+    ].map(async (path) => [path, await read(path)]),
+  ),
+)
+
+describe('loop/validate pipeline contract', () => {
+  test('review-cycle owners encode threshold 5 and LGTM-first-wins past the cap', () => {
+    for (const path of REVIEW_CYCLE_FULL) {
+      const body = texts[path]
+      expect(body, path).toMatch(/review_count\s*>\s*5/)
+      expect(body, path).toMatch(/LGTM/)
+      expect(body, path).toMatch(/bare LGTM|no sections at all|nothing left to fix/i)
+      expect(body, path).toMatch(
+        /Needs Updates.*never stops|never force-stops a `Needs Updates`|never stops the loop by cycle count/is,
+      )
+    }
+  })
+
+  test('fableplan-loop paraphrases the past-5 first-LGTM stop', () => {
+    for (const path of REVIEW_CYCLE_PARAPHRASE) {
+      const body = texts[path]
+      expect(body, path).toMatch(/past 5/)
+      expect(body, path).toMatch(/first LGTM|LGTM it sees/i)
+    }
+  })
+
+  test('gated validate→plan loops state Capability < 2 / below 50 plus safety carve-out', () => {
+    for (const path of CAPABILITY_GATE) {
+      const body = texts[path]
+      expect(body, path).toMatch(/Capability\s*<\s*2/)
+      expect(body, path).toMatch(/below 50|score\s*<\s*50/)
+      expect(body, path).toMatch(/safety carve-out|safety flags/i)
+      expect(body, path).toMatch(/money/i)
+      expect(body, path).toMatch(/data integrity/i)
+      expect(body, path).toMatch(/security/i)
+      expect(body, path).toMatch(/auto-protective/i)
+    }
+  })
+
+  test('always-plan skills document the missing Capability gate as intentional', () => {
+    for (const path of ALWAYS_PLAN) {
+      const body = texts[path]
+      expect(body, path).toMatch(/no Capability gate|Capability gate removed/i)
+      expect(body, path).toMatch(/always runs|for EVERY issue/i)
+      // Must not install the skip gate as this skill's own procedure heading.
+      expect(body, path).not.toMatch(
+        /\*\*Capability gate:\*\*[^\n]*below 50[^\n]*skip fableplan/i,
+      )
+    }
+  })
+
+  test('new-issue loops stop on duplicate or non-convergence', () => {
+    for (const path of DUPLICATE_CONVERGENCE) {
+      const body = texts[path]
+      expect(body, path).toMatch(/duplicate/i)
+      expect(body, path).toMatch(/converg/i)
+      expect(body, path).toMatch(/STOP/)
+    }
+  })
+
+  test('validate→implement loops stop on too-large, infeasible, or existing PR', () => {
+    for (const path of VALIDATION_STOP) {
+      const body = texts[path]
+      expect(body, path).toMatch(/too large/i)
+      expect(body, path).toMatch(/infeasible/i)
+      expect(body, path).toMatch(/existing PR|already addressed|already addressing/i)
+    }
+  })
+
+  test('inventory documents always-plan exceptions and maxReviewCycles out of scope', () => {
+    const inventory = texts[INVENTORY]
+    expect(inventory).toContain('fable-validate-fableplan-loop')
+    expect(inventory).toContain('fableplan-loop')
+    expect(inventory).toMatch(/no.*Capability gate|Always-plan/i)
+    expect(inventory).toContain('maxReviewCycles')
+    expect(inventory).toMatch(/Out of scope/i)
+    expect(inventory).toContain('tests/loop-validate-pipeline-contract.test.js')
+  })
+})

--- a/tests/loop-validate-pipeline-contract.test.js
+++ b/tests/loop-validate-pipeline-contract.test.js
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test'
 /**
  * Semantic guard for loop/validate skill-family pipeline rules.
  * Checks key parameters (thresholds, stop conditions), not exact prose.
+ * Markers must appear in the procedure body — frontmatter `description:` alone is not enough.
  * See docs/contract-inventory.md.
  */
 const root = new URL('../', import.meta.url)
@@ -37,6 +38,26 @@ const VALIDATION_STOP = [
 
 const INVENTORY = 'docs/contract-inventory.md'
 
+/** Strip YAML frontmatter so description: keywords cannot satisfy procedure rules. */
+function procedureBody(markdown) {
+  const match = markdown.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n([\s\S]*)$/)
+  return match ? match[1] : markdown
+}
+
+/**
+ * True when a markdown table row co-locates the decision-table **STOP** /
+ * **STOP.** marker with every term pattern. Case-insensitive "Stop and report"
+ * in Red Flags is not enough — that would keep passing after the real stop
+ * rows are deleted.
+ */
+function hasStopTableRow(body, ...termPatterns) {
+  return body.split('\n').some((line) => {
+    if (!line.startsWith('|')) return false
+    if (!/\*\*STOP\.?\*\*/.test(line)) return false
+    return termPatterns.every((pattern) => pattern.test(line))
+  })
+}
+
 const texts = Object.fromEntries(
   await Promise.all(
     [
@@ -56,40 +77,39 @@ const texts = Object.fromEntries(
 describe('loop/validate pipeline contract', () => {
   test('review-cycle owners encode threshold 5 and LGTM-first-wins past the cap', () => {
     for (const path of REVIEW_CYCLE_FULL) {
-      const body = texts[path]
+      const body = procedureBody(texts[path])
       expect(body, path).toMatch(/review_count\s*>\s*5/)
-      expect(body, path).toMatch(/LGTM/)
       expect(body, path).toMatch(/bare LGTM|no sections at all|nothing left to fix/i)
       expect(body, path).toMatch(
         /Needs Updates.*never stops|never force-stops a `Needs Updates`|never stops the loop by cycle count/is,
       )
+      // Cap rule: past threshold, first LGTM ends the loop (not a bare keyword hit).
+      expect(body, path).toMatch(/review_count\s*>\s*5[\s\S]{0,120}LGTM/i)
     }
   })
 
   test('fableplan-loop paraphrases the past-5 first-LGTM stop', () => {
     for (const path of REVIEW_CYCLE_PARAPHRASE) {
-      const body = texts[path]
-      expect(body, path).toMatch(/past 5/)
-      expect(body, path).toMatch(/first LGTM|LGTM it sees/i)
+      const body = procedureBody(texts[path])
+      expect(body, path).toMatch(/past 5[\s\S]{0,80}(?:first )?LGTM|LGTM it sees/i)
     }
   })
 
   test('gated validate→plan loops state Capability < 2 / below 50 plus safety carve-out', () => {
     for (const path of CAPABILITY_GATE) {
-      const body = texts[path]
+      const body = procedureBody(texts[path])
       expect(body, path).toMatch(/Capability\s*<\s*2/)
       expect(body, path).toMatch(/below 50|score\s*<\s*50/)
-      expect(body, path).toMatch(/safety carve-out|safety flags/i)
-      expect(body, path).toMatch(/money/i)
-      expect(body, path).toMatch(/data integrity/i)
-      expect(body, path).toMatch(/security/i)
-      expect(body, path).toMatch(/auto-protective/i)
+      // Four carve-out terms must sit with the safety carve-out, not as stray keywords.
+      expect(body, path).toMatch(
+        /safety carve-out[\s\S]{0,300}money[\s\S]{0,120}data integrity[\s\S]{0,120}security[\s\S]{0,120}auto-protective/i,
+      )
     }
   })
 
   test('always-plan skills document the missing Capability gate as intentional', () => {
     for (const path of ALWAYS_PLAN) {
-      const body = texts[path]
+      const body = procedureBody(texts[path])
       expect(body, path).toMatch(/no Capability gate|Capability gate removed/i)
       expect(body, path).toMatch(/always runs|for EVERY issue/i)
       // Must not install the skip gate as this skill's own procedure heading.
@@ -101,19 +121,22 @@ describe('loop/validate pipeline contract', () => {
 
   test('new-issue loops stop on duplicate or non-convergence', () => {
     for (const path of DUPLICATE_CONVERGENCE) {
-      const body = texts[path]
-      expect(body, path).toMatch(/duplicate/i)
-      expect(body, path).toMatch(/converg/i)
-      expect(body, path).toMatch(/STOP/)
+      const body = procedureBody(texts[path])
+      // Decision-table rows must co-locate STOP with the rule — frontmatter alone fails.
+      expect(hasStopTableRow(body, /duplicate/i), `${path}: STOP+duplicate row`).toBe(true)
+      expect(hasStopTableRow(body, /converg/i), `${path}: STOP+converg row`).toBe(true)
     }
   })
 
   test('validate→implement loops stop on too-large, infeasible, or existing PR', () => {
     for (const path of VALIDATION_STOP) {
-      const body = texts[path]
-      expect(body, path).toMatch(/too large/i)
-      expect(body, path).toMatch(/infeasible/i)
-      expect(body, path).toMatch(/existing PR|already addressed|already addressing/i)
+      const body = procedureBody(texts[path])
+      expect(hasStopTableRow(body, /too large/i), `${path}: STOP+too large row`).toBe(true)
+      expect(hasStopTableRow(body, /infeasible/i), `${path}: STOP+infeasible row`).toBe(true)
+      expect(
+        hasStopTableRow(body, /existing PR|already addressing|already implements/i),
+        `${path}: STOP+existing-PR row`,
+      ).toBe(true)
     }
   })
 
@@ -125,5 +148,6 @@ describe('loop/validate pipeline contract', () => {
     expect(inventory).toContain('maxReviewCycles')
     expect(inventory).toMatch(/Out of scope/i)
     expect(inventory).toContain('tests/loop-validate-pipeline-contract.test.js')
+    expect(inventory).toMatch(/procedure body|frontmatter/i)
   })
 })


### PR DESCRIPTION
## Summary

- Added `docs/contract-inventory.md` for the loop/validate skill families: review-cycle/LGTM stop (threshold 5), Capability gate (`< 2` / below 50 + safety carve-out), duplicate/convergence stop, and validation scope/feasibility/existing-PR stop — with owner/consumers/shared semantics/allowed divergence.
- Documented always-plan skills (`fable-validate-fableplan-loop`, `fableplan-loop`) as an intentional no-Capability-gate exception; documented `maxReviewCycles` workflow consumers as out of scope for this guard.
- Added `tests/loop-validate-pipeline-contract.test.js` semantic guard (key parameters, not exact strings); runs via existing `bun test` / CI.

Closes #64

## Verification

- `bun test tests/loop-validate-pipeline-contract.test.js` — 7 pass
- Red→green: temporarily changing `review_count > 5` → `> 99` in `work-on-issue-loop` failed the guard; restore passed
- `bun test` — 71 pass across 6 files

## Plain simple English

Shared “when to stop” rules for the loop skills now live in one checklist, and a test fails if any covered skill quietly drops those rules. Two skills that always plan on purpose stay allowed; the milestone workflow’s separate cycle setting is called out as not covered here.

---
Created with LLM: Cursor Grok 4.5 | high | Harness: Cursor
