### PR TITLE
fix(fableplan): ask before building after posting plan to issue

### DIFF
--- a/skills/fable-validate-fableplan-loop/SKILL.md
+++ b/skills/fable-validate-fableplan-loop/SKILL.md
@@ -52,7 +52,7 @@ If **No**, skip straight to step 4.
 
 **No Capability gate:** fableplan runs for every issue that passed the step-2 scope gate, whatever the validated score — that's the difference from fable-validate-loop. Do not skip planning for low-capability-band issues.
 
-Invoke the `fableplan` skill for the same issue number (Skill tool, `skill: fableplan`), and **scope it to its planning phase — steps 1 through 5 only**: fetch the issue, dispatch the Fable 5 Plan subagent, sanity-check the plan against the code, post the vetted plan as an issue comment, and relay it. Instruct fableplan to use the harness suffix `fable-validate-fableplan-loop` (not `fableplan`) in the posted comment's attribution footer, so the comment records the actual entry point. **Do NOT execute fableplan's steps 6–7 (worktree + build)** — implementation belongs to work-on-issue-loop in step 5, which owns the implement → PR → review chain; building here would duplicate it outside that chain.
+Invoke the `fableplan` skill for the same issue number (Skill tool, `skill: fableplan`), and **scope it to its planning phase — steps 1 through 5 only**: fetch the issue, dispatch the Fable 5 Plan subagent, sanity-check the plan against the code, post the vetted plan as an issue comment, and relay it. Instruct fableplan to use the harness suffix `fable-validate-fableplan-loop` (not `fableplan`) in the posted comment's attribution footer, so the comment records the actual entry point. **Do NOT execute fableplan's steps 7–8 (worktree + build)** — implementation belongs to work-on-issue-loop in step 5, which owns the implement → PR → review chain; building here would duplicate it outside that chain.
 
 Give the planning subagent the validation verdict (the scratchpad copy from step 1) alongside the issue — the plan must respect what validation established (verified/refuted claims, the Optimal-direction note when architecture was ⚠️, 5b concerns).
 
@@ -79,5 +79,5 @@ Relay work-on-issue-loop's final summary (PR URL, review cycles, final verdict),
 | `Scope: too large`, Architecture ❌ Infeasible, or a PR already addressing the issue | Stop and report per step 2 — the cases the loop can't safely auto-resolve |
 | Tempted to wait for a literal user reply to fable-validate's or fableplan's prompt | Parse the output yourself and proceed per the step rules |
 | Verdict says Update issue description? Yes | Apply the edits **before** fableplan runs, so the plan targets the corrected issue |
-| fableplan about to enter its build steps (6–7) | Don't — stop it at step 5; work-on-issue-loop owns implementation |
+| fableplan about to enter its build steps (7–8) | Don't — stop it at step 5; work-on-issue-loop owns implementation |
 | fableplan's sanity-check finds the plan structurally wrong | Stop and report — don't hand a broken plan to work-on-issue-loop, and don't silently re-plan |

--- a/skills/fable-validate-loop/SKILL.md
+++ b/skills/fable-validate-loop/SKILL.md
@@ -50,7 +50,7 @@ If **No**, skip straight to step 4.
 
 **Capability gate:** if the verdict's validated complexity score is **below 50** (Capability < 2 under the `validate-issue` band encoding), skip fableplan and go straight to step 5 — work-on-issue-loop plans adequately for low-capability-band changes on its own. **Safety carve-out (overrides the gate):** if the validation flags money, data integrity, security, or an auto-protective mechanism anywhere in its findings, run fableplan regardless of score. (If the user wants a plan unconditionally, that's `fable-validate-fableplan-loop` — this same chain with the gate removed.)
 
-Otherwise, invoke the `fableplan` skill for the same issue number (Skill tool, `skill: fableplan`), and **scope it to its planning phase — steps 1 through 5 only**: fetch the issue, dispatch the Fable 5 Plan subagent, sanity-check the plan against the code, post the vetted plan as an issue comment, and relay it. **Do NOT execute fableplan's steps 6–7 (worktree + build)** — implementation belongs to work-on-issue-loop in step 5, which owns the implement → PR → review chain; building here would duplicate it outside that chain.
+Otherwise, invoke the `fableplan` skill for the same issue number (Skill tool, `skill: fableplan`), and **scope it to its planning phase — steps 1 through 5 only**: fetch the issue, dispatch the Fable 5 Plan subagent, sanity-check the plan against the code, post the vetted plan as an issue comment, and relay it. **Do NOT execute fableplan's steps 7–8 (worktree + build)** — implementation belongs to work-on-issue-loop in step 5, which owns the implement → PR → review chain; building here would duplicate it outside that chain.
 
 Give the planning subagent the validation verdict (the scratchpad copy from step 1) alongside the issue — the plan must respect what validation established (verified/refuted claims, the Optimal-direction note when architecture was ⚠️, 5b concerns).
 
@@ -76,5 +76,5 @@ Relay work-on-issue-loop's final summary (PR URL, review cycles, final verdict),
 | `Scope: too large`, Architecture ❌ Infeasible, or a PR already addressing the issue | Stop and report per step 2 — the cases the loop can't safely auto-resolve |
 | Tempted to wait for a literal user reply to fable-validate's or fableplan's prompt | Parse the output yourself and proceed per the step rules |
 | Verdict says Update issue description? Yes | Apply the edits **before** fableplan runs, so the plan targets the corrected issue |
-| fableplan about to enter its build steps (6–7) | Don't — stop it at step 5; work-on-issue-loop owns implementation |
+| fableplan about to enter its build steps (7–8) | Don't — stop it at step 5; work-on-issue-loop owns implementation |
 | fableplan's sanity-check finds the plan structurally wrong | Stop and report — don't hand a broken plan to work-on-issue-loop, and don't silently re-plan |

--- a/skills/fableplan-loop/SKILL.md
+++ b/skills/fableplan-loop/SKILL.md
@@ -28,7 +28,7 @@ If the issue is closed, or a merged/open PR already addresses it, **do not plan 
 
 ### 1. Run fableplan — planning phase only
 
-Invoke the `fableplan` skill for the target issue (Skill tool, `skill: fableplan`), and **scope it to its planning phase — steps 1 through 5 only**: fetch the issue, dispatch the Fable 5 Plan subagent, sanity-check the plan against the code, post the vetted plan as an issue comment, and relay it. Instruct fableplan to use the harness suffix `fableplan-loop` (not `fableplan`) in the posted comment's attribution footer, so the comment records the actual entry point. **Do NOT execute fableplan's steps 6–7 (worktree + build)** — implementation belongs to work-on-issue-loop in step 2, which owns the implement → PR → review chain; building here would duplicate it outside that chain and in the wrong worktree location.
+Invoke the `fableplan` skill for the target issue (Skill tool, `skill: fableplan`), and **scope it to its planning phase — steps 1 through 5 only**: fetch the issue, dispatch the Fable 5 Plan subagent, sanity-check the plan against the code, post the vetted plan as an issue comment, and relay it. Instruct fableplan to use the harness suffix `fableplan-loop` (not `fableplan`) in the posted comment's attribution footer, so the comment records the actual entry point. **Do NOT execute fableplan's steps 7–8 (worktree + build)** — implementation belongs to work-on-issue-loop in step 2, which owns the implement → PR → review chain; building here would duplicate it outside that chain and in the wrong worktree location.
 
 Keep the vetted plan's scratchpad file — step 2 passes it through. If fableplan's sanity-check finds the plan structurally wrong, or fableplan fails after its internal retry, **stop and report** — don't hand a broken plan to work-on-issue-loop, and don't fall back to planning yourself or implementing unplanned.
 
@@ -50,7 +50,7 @@ Relay work-on-issue-loop's final summary (PR URL, number of review cycles, final
 |---|---|
 | Tempted to skip planning and jump straight to implementation | Never reorder — plan-then-build is the point of this skill; there is no Capability gate, fableplan always runs |
 | Tempted to run validate-issue first | Not part of this skill — that's validate-fableplan-loop; this variant deliberately skips validation |
-| fableplan about to enter its build steps (6–7) | Don't — stop it at step 5; work-on-issue-loop owns implementation |
+| fableplan about to enter its build steps (7–8) | Don't — stop it at step 5; work-on-issue-loop owns implementation |
 | fableplan's sanity-check finds the plan structurally wrong | Stop and report — don't hand a broken plan to work-on-issue-loop, and don't silently re-plan |
 | Tempted to stop at the open PR without triggering review | The review loop is the point of this variant — that trimmed behavior is fableplan-work-on-issue; here work-on-issue-loop owns the trigger and the cycles |
 | No issue could be resolved | Stop and ask — work-on-issue-loop needs a concrete issue to target and close |

--- a/skills/fableplan-work-on-issue/SKILL.md
+++ b/skills/fableplan-work-on-issue/SKILL.md
@@ -28,7 +28,7 @@ If the issue is closed, or a merged/open PR already addresses it, **do not plan 
 
 ### 1. Run fableplan — planning phase only
 
-Invoke the `fableplan` skill for the target issue (Skill tool, `skill: fableplan`), and **scope it to its planning phase — steps 1 through 5 only**: fetch the issue, dispatch the Fable 5 Plan subagent, sanity-check the plan against the code, post the vetted plan as an issue comment, and relay it. Instruct fableplan to use the harness suffix `fableplan-work-on-issue` (not `fableplan`) in the posted comment's attribution footer, so the comment records the actual entry point. **Do NOT execute fableplan's steps 6–7 (worktree + build)** — implementation belongs to work-on-issue in step 2, which owns the implement → PR chain; building here would duplicate it outside that chain and in the wrong worktree location.
+Invoke the `fableplan` skill for the target issue (Skill tool, `skill: fableplan`), and **scope it to its planning phase — steps 1 through 5 only**: fetch the issue, dispatch the Fable 5 Plan subagent, sanity-check the plan against the code, post the vetted plan as an issue comment, and relay it. Instruct fableplan to use the harness suffix `fableplan-work-on-issue` (not `fableplan`) in the posted comment's attribution footer, so the comment records the actual entry point. **Do NOT execute fableplan's steps 7–8 (worktree + build)** — implementation belongs to work-on-issue in step 2, which owns the implement → PR chain; building here would duplicate it outside that chain and in the wrong worktree location.
 
 Keep the vetted plan's scratchpad file — step 2 passes it through. If fableplan's sanity-check finds the plan structurally wrong, or fableplan fails after its internal retry, **stop and report** — don't hand a broken plan to work-on-issue, and don't fall back to planning yourself or implementing unplanned.
 
@@ -50,7 +50,7 @@ Relay work-on-issue's final summary (the worktree/branch, what was implemented, 
 |---|---|
 | Tempted to skip planning and jump straight to implementation | Never reorder — plan-then-build is the point of this skill; there is no Capability gate, fableplan always runs |
 | Tempted to run validate-issue first | Not part of this skill — that's validate-fableplan-loop; this trimmed variant deliberately skips validation |
-| fableplan about to enter its build steps (6–7) | Don't — stop it at step 5; work-on-issue owns implementation |
+| fableplan about to enter its build steps (7–8) | Don't — stop it at step 5; work-on-issue owns implementation |
 | fableplan's sanity-check finds the plan structurally wrong | Stop and report — don't hand a broken plan to work-on-issue, and don't silently re-plan |
 | Tempted to trigger `@claude` review or loop on the PR after it opens | Out of scope — this skill ends at the open PR; point the user at fableplan-loop or fix-pr-review-loop if they want review driven to convergence |
 | No issue could be resolved | Stop and ask — work-on-issue needs a concrete issue to target and close |

--- a/skills/fableplan/SKILL.md
+++ b/skills/fableplan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fableplan
-description: Use when the user wants a task planned by a Fable 5 planning subagent before building it. Spins up a Plan subagent running on Fable 5 to produce an implementation plan, relays the plan back to the main agent to build, and — if a GitHub issue is referenced — posts the plan as a comment on that issue. Trigger on "/fableplan", "fableplan this", or "plan this with fable".
+description: Use when the user wants a task planned by a Fable 5 planning subagent before building it. Spins up a Plan subagent running on Fable 5 to produce an implementation plan, relays the plan back to the main agent, and — if a GitHub issue is referenced — posts the plan as a comment on that issue and asks the user whether to continue building now before proceeding. Trigger on "/fableplan", "fableplan this", or "plan this with fable".
 ---
 
 # fableplan
@@ -75,9 +75,13 @@ After posting, give the user the comment URL `gh` returns. Follow the repo's CLA
 
 ### 5. Relay the plan to the user
 
-Present the vetted plan to the user (the main agent). This is the plan you will build from.
+Present the vetted plan to the user (the main agent).
 
-### 6. Set up an isolated git worktree
+### 6. Ask whether to continue building (only if an issue was referenced)
+
+The plan is now safely posted to the issue regardless of what happens next — don't assume the user wants an immediate build. Ask (e.g. via `AskUserQuestion`) whether to continue building this now or stop here. If they stop, end the skill; they can resume later with `work-on-issue` on the same issue. If no issue was referenced in step 1, there's nothing posted to fall back to, so skip the question and proceed straight to building.
+
+### 7. Set up an isolated git worktree
 
 Before making any code changes, move the build into its own git worktree so it never touches the user's current workspace. If the directory isn't a git repository, tell the user and ask how to proceed rather than building in place. Otherwise create a fresh branch and worktree for the task, prefixed with the coding-agent identifier — `cc/` for Claude Code, `cursor/` for Cursor, `codex/` for Codex — ahead of the `fableplan/` segment.
 
@@ -100,9 +104,9 @@ git worktree add ../<repo>-fableplan-cursor-<short-task-name> -b cursor/fablepla
 
 (swap `cursor` for `codex` on Codex), then `cd` into it and re-verify `pwd` before later steps — shell state doesn't persist between Bash calls.
 
-Do all of step 7's building inside that worktree. When the build is done, follow the repo's usual conventions for merging or opening a PR from the branch, and remove the worktree once it's no longer needed (`git worktree remove <path>`).
+Do all of step 8's building inside that worktree. When the build is done, follow the repo's usual conventions for merging or opening a PR from the branch, and remove the worktree once it's no longer needed (`git worktree remove <path>`).
 
-### 7. Build
+### 8. Build
 
 In the worktree from step 6, the main agent builds the task per the plan. Confirm with the user first only if the plan reveals ambiguity or a decision the user must make; otherwise proceed.
 

--- a/skills/fableplan/SKILL.md
+++ b/skills/fableplan/SKILL.md
@@ -108,7 +108,7 @@ Do all of step 8's building inside that worktree. When the build is done, follow
 
 ### 8. Build
 
-In the worktree from step 6, the main agent builds the task per the plan. Confirm with the user first only if the plan reveals ambiguity or a decision the user must make; otherwise proceed.
+In the worktree from step 7, the main agent builds the task per the plan. Confirm with the user first only if the plan reveals ambiguity or a decision the user must make; otherwise proceed.
 
 ## Notes
 

--- a/skills/validate-fableplan-loop/SKILL.md
+++ b/skills/validate-fableplan-loop/SKILL.md
@@ -52,7 +52,7 @@ If **No**, skip straight to step 4.
 
 **Capability gate:** if the verdict's validated complexity score is **below 50** (Capability < 2 under the `validate-issue` band encoding), skip fableplan and go straight to step 5 — work-on-issue-loop plans adequately for low-capability-band changes on its own. **Safety carve-out (overrides the gate):** if the validation flags money, data integrity, security, or an auto-protective mechanism anywhere in its findings, run fableplan regardless of score.
 
-Otherwise, invoke the `fableplan` skill for the same issue number (Skill tool, `skill: fableplan`), and **scope it to its planning phase — steps 1 through 5 only**: fetch the issue, dispatch the Fable 5 Plan subagent, sanity-check the plan against the code, post the vetted plan as an issue comment, and relay it. **Do NOT execute fableplan's steps 6–7 (worktree + build)** — implementation belongs to work-on-issue-loop in step 5, which owns the implement → PR → review chain; building here would duplicate it outside that chain.
+Otherwise, invoke the `fableplan` skill for the same issue number (Skill tool, `skill: fableplan`), and **scope it to its planning phase — steps 1 through 5 only**: fetch the issue, dispatch the Fable 5 Plan subagent, sanity-check the plan against the code, post the vetted plan as an issue comment, and relay it. **Do NOT execute fableplan's steps 7–8 (worktree + build)** — implementation belongs to work-on-issue-loop in step 5, which owns the implement → PR → review chain; building here would duplicate it outside that chain.
 
 Give the planning subagent the validation findings (the verdict block and validate-issue's report) alongside the issue — the plan must respect what validation established (verified/refuted claims, the Optimal-direction note when architecture was ⚠️, and any concerns it raised).
 
@@ -78,6 +78,6 @@ Relay work-on-issue-loop's final summary (PR URL, review cycles, final verdict),
 | `Scope: too large`, Architecture ❌ Infeasible, or a PR already addressing the issue | Stop and report per step 2 — the cases the loop can't safely auto-resolve |
 | Tempted to wait for a literal user reply to validate-issue's or fableplan's prompt | Parse the output yourself and proceed per the step rules |
 | Verdict says Update issue description? Yes | Apply the edits **before** fableplan runs, so the plan targets the corrected issue |
-| fableplan about to enter its build steps (6–7) | Don't — stop it at step 5; work-on-issue-loop owns implementation |
+| fableplan about to enter its build steps (7–8) | Don't — stop it at step 5; work-on-issue-loop owns implementation |
 | fableplan's sanity-check finds the plan structurally wrong | Stop and report — don't hand a broken plan to work-on-issue-loop, and don't silently re-plan |
 | Issue scored below 50 (Capability < 2) with no safety flags | Skip fableplan and hand the issue straight to work-on-issue-loop — note the skip in the report |


### PR DESCRIPTION
## Summary
- After posting the Fable 5 plan as a comment on the referenced GitHub issue (step 4), the skill previously proceeded straight into worktree setup and build (steps 6–7) with no pause.
- Adds a new step 6: ask the user (e.g. via `AskUserQuestion`) whether to continue building now or stop, when an issue was referenced. If they stop, the vetted plan is already safely posted to the issue for a later `work-on-issue` run.
- If no issue was referenced, there's nothing posted to fall back to, so the skill still proceeds straight to building — the gate only applies to the issue-linked flow.
- Renumbered the subsequent worktree/build steps (6→7, 7→8) and updated the frontmatter `description` to reflect the new confirmation gate.

## Verification
- Read through the full updated `SKILL.md` to confirm step numbering and cross-references (step 4's "you'll need them in step 4" references, "step 7's building" → "step 8's building") are consistent.

## Plain simple English
The fableplan skill now pauses and asks before starting to build, once it has already saved the plan as a comment on the linked GitHub issue. It no longer barges ahead into writing code right after planning — you get a chance to say "not yet."

---
Created with LLM: Sonnet 5 | high | Harness: Claude Code