### PR TITLE
feat(skills): offer fableplan to the user when an issue's signal says yes [C4, Fable 5, high]

### DIFF
--- a/skills/new-issue/SKILL.md
+++ b/skills/new-issue/SKILL.md
@@ -96,6 +96,8 @@ Add `--label`/`--assignee` only when the repo visibly uses them (`gh label list`
 
 Terse: issue URL, number, one-line summary of what it covers, complexity score, and any candidate follow-ups you did **not** file (with why). Offer "validate issue" / "work on issue" as next steps in one line.
 
+**When the issue's signal is `fableplan: yes`, also ask the user explicitly** — one line, e.g. "This issue is Capability 2 — want a Fable 5 plan posted before building? (fableplan)" — and let the user decide; don't launch fableplan unprompted, and don't silently drop the recommendation.
+
 ## Guardrails
 
 | Situation | Action |

--- a/skills/new-issue/SKILL.md
+++ b/skills/new-issue/SKILL.md
@@ -96,7 +96,7 @@ Add `--label`/`--assignee` only when the repo visibly uses them (`gh label list`
 
 Terse: issue URL, number, one-line summary of what it covers, complexity score, and any candidate follow-ups you did **not** file (with why). Offer "validate issue" / "work on issue" as next steps in one line.
 
-**When the issue's signal is `fableplan: yes`, also ask the user explicitly** — one line, e.g. "This issue is Capability 2 — want a Fable 5 plan posted before building? (fableplan)" — and let the user decide; don't launch fableplan unprompted, and don't silently drop the recommendation.
+**When the issue's signal is `fableplan: yes`, also ask the user explicitly** — one line, e.g. "This issue is Capability 2 — want a Fable 5 plan posted before building? (fableplan)" — and let the user decide; don't launch fableplan unprompted, and don't silently drop the recommendation. (Autonomous loop skills that wrap this one parse the signal and apply their own documented gates instead of asking.)
 
 ## Guardrails
 

--- a/skills/validate-issue/SKILL.md
+++ b/skills/validate-issue/SKILL.md
@@ -317,6 +317,12 @@ Pass the issue number through; the skill is idempotent about the worktree (reuse
 
 **If step 6.5 flagged the issue as too large, surface the disposition before handing off** — implementing an oversized, multi-part issue as one PR reproduces the scope problem in the diff. Recommend splitting/decomposing first; proceed to work-on-issue only on the user's say-so, or scope the implementation to the single core part if they want to start there.
 
+### 7.6. When the user replies "fableplan" — hand off to the fableplan skill
+
+**Invoke the `fableplan` skill**, passing the issue number through — not the bare word "fableplan" as a task description; the skill's own trigger phrases (`/fableplan`, "fableplan this", "plan this with fable") expect a task or issue reference, and the issue number is what makes it post the plan as an issue comment. `fableplan` owns everything from there: it dispatches the Fable 5 Plan subagent, posts the plan as a comment on the issue, and itself asks the user whether to continue building now — don't duplicate that ask here.
+
+Honor this reply whenever the user gives it, even on an issue where step 7's signal was `fableplan: no` — the signal governs whether *this* skill recommends and offers the option, not whether the user's own explicit request is honored. Don't second-guess an explicit "fableplan" reply by re-litigating the signal.
+
 ### 8. When the user replies "update issue"
 
 This can mean editing the issue title and/or editing the issue body (apply the suggested edits) — both from the current checkout, per step 0. Do both as appropriate.

--- a/skills/validate-issue/SKILL.md
+++ b/skills/validate-issue/SKILL.md
@@ -304,8 +304,10 @@ Scope: (omit unless the issue is too large per step 6.5)
 
 <If Yes: a short bulleted list of specific edits the author should make to the title and/or description — wrong file:line, incorrect behavior, missing repro, ambiguous scope, a title that misstates the bug or scope, etc. One line each, phrased as edits ("Change X to Y", "Add Z", "Remove claim about W", "Retitle to …").>
 
-→ Reply "work on issue" to proceed, "update issue" to apply the edits first<, or "split issue" / "decompose" to file the proposed parts — only when step 6.5 flagged it>.
+→ Reply "work on issue" to proceed, "update issue" to apply the edits first<, "fableplan" to have Fable 5 post an implementation plan first — offer this only when the signal is fableplan: yes><, or "split issue" / "decompose" to file the proposed parts — only when step 6.5 flagged it>.
 ```
+
+**When the signal is `fableplan: yes`, the offer is mandatory, and it's the user's call:** always include the "fableplan" option in the reply line, and if the user instead replies "work on issue" directly, ask once — "Signal says fableplan: yes — post a Fable 5 plan first, or build without one?" — before handing off. Never launch fableplan unprompted, and never silently skip the recommendation. (Autonomous loop skills that wrap this one parse the signal and apply their own documented gates instead of asking.)
 
 ### 7.5. When the user replies "work on issue" — hand off to the work-on-issue skill
 


### PR DESCRIPTION
## Summary
- `validate-issue`: when the verdict's signal is `fableplan: yes`, the reply line must offer "fableplan", and a direct "work on issue" reply gets one ask — plan first or build without — before handoff. Never launches fableplan unprompted; autonomous loops keep their own documented gates.
- `new-issue`: after filing a `fableplan: yes` issue, the report asks the user whether to post a Fable 5 plan before building.

## Verification
- `bun test` — 71 pass, 0 fail.

## Plain simple English
When a task is complex enough that a smart-model plan is recommended, the assistant now always asks you first — "want a plan made before building?" — instead of deciding on its own. You stay in control of whether the planning step runs.

https://claude.ai/code/session_01JTV4RfiJM1EVSz76KosbeC

---
Created with LLM: Fable 5 | high | Harness: Claude Code