### PR TITLE
docs: add conditional act-CI PR-comment instruction [C3, Sonnet 5, high]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@
 - Prefer editing existing files over creating new ones.
 - Press `#` in a session to incorporate learnings into AGENTS.md.
 - Never proactively invoke `superpowers:*` skills — only on explicit `/` trigger.
+- **If CI runs via `act` locally** (e.g. GitHub Actions minutes are exhausted or no runner is registered) instead of a GitHub-hosted/self-hosted runner: scrub the log for secrets (tokens, keys, unmasked env values) and truncate or split if it would exceed GitHub's ~65k-char comment limit; post that sanitized output as a PR comment ending with the LLM Attribution Footer (`gh pr comment <n> --body-file <prepared-body>` — raw footer-less dumps are not exempt, whether via `--body-file` or pasted inline) so the result is visible to reviewers; then read that comment before merging — fix or explain any failure first, never merge past a posted failure without a stated reason. If `act` wasn't run either, run the project's lint/typecheck/test commands locally before merging instead of merging blind.
 
 ## LLM Attribution Footer
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@
 - Prefer editing existing files over creating new ones.
 - Press `#` in a session to incorporate learnings into CLAUDE.md.
 - Never proactively invoke `superpowers:*` skills — only on explicit `/` trigger.
+- **If CI runs via `act` locally** (e.g. GitHub Actions minutes are exhausted or no runner is registered) instead of a GitHub-hosted/self-hosted runner: post its output as a PR comment (`gh pr comment <n> --body-file <output>`) so the result is visible to reviewers, then read that comment before merging — fix or explain any failure first, never merge past a posted failure without a stated reason. If `act` wasn't run either, run the project's lint/typecheck/test commands locally before merging instead of merging blind.
 
 ## LLM Attribution Footer
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@
 - Prefer editing existing files over creating new ones.
 - Press `#` in a session to incorporate learnings into CLAUDE.md.
 - Never proactively invoke `superpowers:*` skills — only on explicit `/` trigger.
-- **If CI runs via `act` locally** (e.g. GitHub Actions minutes are exhausted or no runner is registered) instead of a GitHub-hosted/self-hosted runner: post its output as a PR comment (`gh pr comment <n> --body-file <output>`) so the result is visible to reviewers, then read that comment before merging — fix or explain any failure first, never merge past a posted failure without a stated reason. If `act` wasn't run either, run the project's lint/typecheck/test commands locally before merging instead of merging blind.
+- **If CI runs via `act` locally** (e.g. GitHub Actions minutes are exhausted or no runner is registered) instead of a GitHub-hosted/self-hosted runner: scrub the log for secrets (tokens, keys, unmasked env values) and truncate or split if it would exceed GitHub's ~65k-char comment limit; post that sanitized output as a PR comment ending with the LLM Attribution Footer (`gh pr comment <n> --body-file <prepared-body>` — raw footer-less dumps are not exempt, whether via `--body-file` or pasted inline) so the result is visible to reviewers; then read that comment before merging — fix or explain any failure first, never merge past a posted failure without a stated reason. If `act` wasn't run either, run the project's lint/typecheck/test commands locally before merging instead of merging blind.
 
 ## LLM Attribution Footer
 


### PR DESCRIPTION
## Summary
- New Engineering bullet in CLAUDE.md: when CI runs via `act` locally (e.g. GitHub Actions billing minutes exhausted or no runner registered) instead of a hosted/self-hosted runner, post the `act` output as a PR comment and read it before merging.
- If `act` wasn't run either, fall back to running the project's lint/typecheck/test commands locally rather than merging with no local signal at all.
- Conditional on tooling actually used — doesn't mandate `act`, just states what to do when it is the substitute for blocked CI.

## Verification
- Doc-only change; read back the rendered CLAUDE.md section for wording/placement (Engineering section, alongside the other CI-adjacent conventions).

## Plain simple English
When a project can't run its usual automated tests on GitHub (for example, it ran out of paid minutes), and someone runs those tests on their own computer instead using a tool called `act`, this rule says: post the results as a comment on the pull request, and don't merge until someone has read that comment and fixed or explained any failure.

---
Created with LLM: Sonnet 5 | high | Harness: Claude Code