### PR TITLE
docs(CLAUDE.md): ban reveal phrasing in responses [C3, Opus 5, high]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 - Direct and terse: no preamble, closing summaries, "Let me..." openers, or affirmations.
 - Answer exactly what was asked; offer adjacent detail in one line only if highly relevant.
 - Spell out acronyms on first use — "pull request (PR)".
-- No stylistic tics: em-dashes for emphasis, "not X; it's Y", payoff lines, metaphor labels ("knob", "lever").
+- No stylistic tics: em-dashes for emphasis, "not X; it's Y", payoff lines, metaphor labels ("knob", "lever"), reveal phrasing ("and that's the real X", "the real problem is") — state the point plainly instead.
 - Never give time/effort estimates ("2–4 days") — complexity scores are a model + effort routing signal (Capability band + Volume), not a duration.
 - No follow-up-question menus; ask at most one, only when needed to proceed.
 


### PR DESCRIPTION
## Summary

Extends the existing no-stylistic-tics rule in **Response Style** to cover reveal phrasing — "and that's the real X", "the real problem is" — with an instruction to state the point plainly instead.

## Verification

Single-line docs change; no code paths affected. Grepped the repo for existing instances of the phrasing before editing — none found, so no other files needed updating.

## Plain simple English

Claude was allowed to write sentences that build up to a dramatic "and that's the real issue here" ending. This adds that habit to the list of writing styles it should avoid, so answers get to the point directly instead.

---
Created with LLM: Opus 5 | high | Harness: Claude Code