### PR TITLE
docs(AGENTS.md): mirror reveal-phrasing ban from CLAUDE.md [C3, Opus 5, high]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - Direct and terse: no preamble, closing summaries, "Let me..." openers, or affirmations.
 - Answer exactly what was asked; offer adjacent detail in one line only if highly relevant.
 - Spell out acronyms on first use — "pull request (PR)".
-- No stylistic tics: em-dashes for emphasis, "not X; it's Y", payoff lines, metaphor labels ("knob", "lever").
+- No stylistic tics: em-dashes for emphasis, "not X; it's Y", payoff lines, metaphor labels ("knob", "lever"), reveal phrasing ("and that's the real X", "the real problem is") — state the point plainly instead.
 - Never give time/effort estimates ("2–4 days") — complexity scores are a model + effort routing signal (Capability band + Volume), not a duration.
 - No follow-up-question menus; ask at most one, only when needed to proceed.
 


### PR DESCRIPTION
## Summary
- Synced docs against commits since the last doc-sync (`35e8bb7..HEAD`): milestoneplan skill addition (#77/#76), the `secrets: inherit` workflow fix (#75), and the reveal-phrasing ban (#78).
- Every one of those PRs already updated CLAUDE.md/README.md/SKILL.md itself, except AGENTS.md — #78 added "reveal phrasing" to CLAUDE.md's no-stylistic-tics rule but never mirrored it into AGENTS.md, so the two agent docs drifted out of lockstep.
- This PR brings AGENTS.md back in sync with CLAUDE.md. No other doc changes were needed.

## Test plan
- [x] Diffed CLAUDE.md vs AGENTS.md body content to confirm no other drift remains
- [x] Confirmed README.md/SKILL.md files already reflect the milestoneplan skill and Plan-effort stamping from the source PRs

## Plain simple English
One of our two Claude/Codex instruction files (AGENTS.md) was missing a small rule the other file (CLAUDE.md) already had — a ban on "and that's the real problem" style phrasing. This PR just copies that rule over so both files agree again.

---
Created with LLM: Opus 5 | high | Harness: sync-docs-release