### PR TITLE
feat(tldr): add tldr skill to the repo [C5, Opus 5, high]

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ flowchart LR
 
 Every new issue records direct predecessors as `**Depends on:** #<n>[, #<n>…] | none` for required code/product results and `**Runs after:** #<n>[, #<n>…] | none` for serialization without code inheritance. The `workflows/milestone-pipeline.js` dynamic workflow validates the full dependency graph before starting. Typed tracks use `after` for hard prerequisites and `runsAfter` for ordering-only predecessors. Unrelated tracks run concurrently; both successor types wait for stable predecessor review results. Hard successors build from verified predecessor heads, including a checked integration base for multiple heads, while ordering-only successors inherit no code. Legacy array tracks remain compatible and treat serial edges as hard dependencies. Re-running a partially completed milestone is safe: closed issues are skipped and issues that already have an open PR resume through `fix-pr-review-loop` instead of opening a duplicate; when a token target is set, a best-effort budget floor (`budgetFloor`, default 80k tokens) defers the remaining issues and returns partial results instead of dying at the hard ceiling, and each run posts its `runId` to the milestone's first issue so state survives losing the conversation. Reviews run as in-session subagent reviewer/fixer cycles by default (`reviewMode: 'subagent'` — no GitHub Actions dependency), or through the repo's `@claude` Action with `reviewMode: 'github'`. Bun regression tests execute the workflow through its async harness.
 
+### Utility skills
+
+| Skill | What it does |
+|-------|--------------|
+| `tldr` | Recaps the previous answer in plain English under 55 words, written for a sharp 17-year-old, one sentence per line. |
+
 ### Review bot prerequisite
 
 The PR-review skills (`fix-pr-review`, all `-loop` variants) depend on an automated reviewer that responds to `@claude review` comments and answers in a specific format (an `LGTM` / `Needs Updates` verdict plus structured findings). This repo ships two options:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Every new issue records direct predecessors as `**Depends on:** #<n>[, #<n>…] 
 
 | Skill | What it does |
 |-------|--------------|
-| `tldr` | Recaps the previous answer in plain English under 55 words, written for a sharp 17-year-old, one sentence per line. |
+| `tldr` | Recaps the previous answer in plain English under 55 words, written for a slightly above-average 18-year-old, one sentence per line. |
 
 ### Review bot prerequisite
 

--- a/skills/tldr/SKILL.md
+++ b/skills/tldr/SKILL.md
@@ -10,11 +10,11 @@ Produce a dead-simple recap of your most recent substantive response.
 ## Rules
 
 1. **Use plain simple English under 55 words.** Going over is a failure. Count them.
-2. **Audience: a sharp 17-year-old.** No insider jargon, no acronyms without spelling out, no domain assumptions. Everyday language only.
+2. **Audience: a slightly above-average 18-year-old.** Not gifted, not an expert — just a bit above average. No insider jargon, no acronyms without spelling out, no domain assumptions. Everyday language only.
 3. **One sentence per line, separated by a blank line.** Put two line breaks after every sentence so each stands alone. No headers, no bullet lists, no preamble like "Here's the TLDR" — just the summary itself.
 4. **Summarize the prior answer**, not the original question. If there is no prior substantive response in the conversation, say so in one line and ask what to summarize.
 5. **Keep it accurate.** Simplify, never fabricate. If the real answer has a critical caveat, keep it.
 
 ## What this means
 
-Explain the core idea as you would to a smart teenager: concrete, conversational, analogy if it helps. Strip mechanism detail down to the point that matters.
+Explain the core idea as you would to a slightly above-average 18-year-old: concrete, conversational, analogy if it helps. Strip mechanism detail down to the point that matters.

--- a/skills/tldr/SKILL.md
+++ b/skills/tldr/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: tldr
+description: Use when the user types /tldr to get a plain-simple-English summary of the most recent response in under 55 words.
+---
+
+# TLDR
+
+Produce a dead-simple recap of your most recent substantive response.
+
+## Rules
+
+1. **Use plain simple English under 55 words.** Going over is a failure. Count them.
+2. **Audience: a sharp 17-year-old.** No insider jargon, no acronyms without spelling out, no domain assumptions. Everyday language only.
+3. **One sentence per line, separated by a blank line.** Put two line breaks after every sentence so each stands alone. No headers, no bullet lists, no preamble like "Here's the TLDR" — just the summary itself.
+4. **Summarize the prior answer**, not the original question. If there is no prior substantive response in the conversation, say so in one line and ask what to summarize.
+5. **Keep it accurate.** Simplify, never fabricate. If the real answer has a critical caveat, keep it.
+
+## What this means
+
+Explain the core idea as you would to a smart teenager: concrete, conversational, analogy if it helps. Strip mechanism detail down to the point that matters.


### PR DESCRIPTION
## Summary

- Adds `skills/tldr/` to the repo. The skill existed only as a real directory in `~/.claude/skills/tldr/`, untracked by any repo, so it was not installed by `install.sh`, `npx rk-skills`, or the plugin marketplace.
- Updates its output format rule: one sentence per line with a blank line between sentences, replacing the previous "one short paragraph" rule.
- Adds a **Utility skills** section to the README listing it.

## Verification

- `bun test` — 146 pass, 0 fail.
- `install.sh` globs `skills/*/`, so no registry file needed changing.

## Plain simple English

The `/tldr` command lived only on one machine and was never saved to this project, so nobody else could install it. This adds it here, and changes its style so each sentence sits on its own line with a blank line between, which is easier to read.

---
Created with LLM: Opus 5 | high | Harness: Claude Code
