### PR TITLE
chore(claude.yml): revert @claude Action model to Opus 4.8 [C5, Opus 5, high]

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -138,10 +138,10 @@ jobs:
           MODEL_SHORT=$(printf '%s' "$STRIPPED" | grep -oE '(^|(\r?\n))[[:space:]]*@claude[[:space:]]+[a-z]+' | head -1 | awk '{print $NF}' || true)
 
           case "$MODEL_SHORT" in
-            opus)    MODEL_ID="claude-opus-5" ;;
+            opus)    MODEL_ID="claude-opus-4-8[1m]" ;;
             sonnet)  MODEL_ID="claude-sonnet-5" ;;
             fable)   MODEL_ID="claude-fable-5" ;;
-            *)       MODEL_ID="claude-opus-5" ;;  # default (no model specified)
+            *)       MODEL_ID="claude-opus-4-8[1m]" ;;  # default (no model specified)
           esac
 
           echo "model_id=$MODEL_ID" >> "$GITHUB_OUTPUT"

--- a/templates/claude-workflow/scripts/compose_claude_comment.py
+++ b/templates/claude-workflow/scripts/compose_claude_comment.py
@@ -21,7 +21,7 @@ from rewrite_create_pr_link import rewrite_create_pr_link
 from strip_llm_footer import strip_llm_footer
 
 MODEL_DISPLAY_NAMES = {
-    "claude-opus-5": "Claude Opus 5",
+    "claude-opus-4-8[1m]": "Claude Opus 4.8 (1M)",
     "claude-sonnet-5": "Claude Sonnet 5",
     "claude-fable-5": "Claude Fable 5",
 }

--- a/templates/claude-workflow/scripts/test_compose_claude_comment.py
+++ b/templates/claude-workflow/scripts/test_compose_claude_comment.py
@@ -16,7 +16,7 @@ HARNESS = "anthropics/claude-code-action@v1"
 
 class ModelDisplayNameTest(unittest.TestCase):
     def test_known_ids_mapped(self):
-        self.assertEqual(model_display_name("claude-opus-5"), "Claude Opus 5")
+        self.assertEqual(model_display_name("claude-opus-4-8[1m]"), "Claude Opus 4.8 (1M)")
         self.assertEqual(model_display_name("claude-sonnet-5"), "Claude Sonnet 5")
         self.assertEqual(model_display_name("claude-fable-5"), "Claude Fable 5")
 
@@ -107,7 +107,7 @@ class ComposeCLITest(unittest.TestCase):
         env = {
             **os.environ,
             "BODY_IN": "body",
-            "MODEL_ID": "claude-opus-5",
+            "MODEL_ID": "claude-opus-4-8[1m]",
             "EFFORT": "xhigh",
             "CLAUDE_HARNESS": HARNESS,
             "STATUS_NOTE": "",
@@ -116,7 +116,7 @@ class ComposeCLITest(unittest.TestCase):
             [sys.executable, script], env=env, capture_output=True, text=True, check=True
         )
         self.assertEqual(
-            result.stdout, compose("body", "claude-opus-5", "xhigh", HARNESS)
+            result.stdout, compose("body", "claude-opus-4-8[1m]", "xhigh", HARNESS)
         )
 
 

--- a/templates/claude-workflow/workflows/claude.yml
+++ b/templates/claude-workflow/workflows/claude.yml
@@ -138,10 +138,10 @@ jobs:
           MODEL_SHORT=$(printf '%s' "$STRIPPED" | grep -oE '(^|(\r?\n))[[:space:]]*@claude[[:space:]]+[a-z]+' | head -1 | awk '{print $NF}' || true)
 
           case "$MODEL_SHORT" in
-            opus)    MODEL_ID="claude-opus-5" ;;
+            opus)    MODEL_ID="claude-opus-4-8[1m]" ;;
             sonnet)  MODEL_ID="claude-sonnet-5" ;;
             fable)   MODEL_ID="claude-fable-5" ;;
-            *)       MODEL_ID="claude-opus-5" ;;  # default (no model specified)
+            *)       MODEL_ID="claude-opus-4-8[1m]" ;;  # default (no model specified)
           esac
 
           echo "model_id=$MODEL_ID" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Reverts the `@claude` GitHub Action model selection from `claude-opus-5` back to `claude-opus-4-8[1m]` in `.github/workflows/claude.yml`:

- `opus` shorthand → `claude-opus-4-8[1m]`
- default (no model specified) → `claude-opus-4-8[1m]`

`sonnet` and `fable` shorthands are unchanged. `claude-run.yml` takes `model_id` as an input and hardcodes no model, so no change was needed there.

## Verification

`grep -rn "opus" .github/` confirms no remaining `claude-opus-5` references.

## Plain simple English

The automated reviewer bot in this repo was set to run on the newest Opus model. This change points it back at the previous Opus 4.8 version instead, both when someone explicitly asks for Opus and when no model is named.

---
Created with LLM: Opus 5 | high | Harness: Claude Code