### PR TITLE
chore(release): bump version to 1.18.0 [C2, GPT-5, high]

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rk-skills",
   "displayName": "rk-skills",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "description": "Claude Code workflow skills: GitHub issue/PR/release automation and Fable-driven planning.",
   "author": {
     "name": "Richard Kuo"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rk-skills",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "description": "Installer for Claude Code workflow skills — GitHub issue/PR/release automation and Fable-driven planning.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump the package and plugin versions to `1.18.0`.

## Verification

- `bun test`

## Plain simple English

This change sets the package version for the new release. It keeps the package and plugin versions the same.

---
Created with LLM: GPT-5 | high | Harness: Codex
