### PR TITLE
feat(fable-validate-fableplan): add plan-only counterpart to fable-validate-fableplan-loop [C6, Opus 5, high]

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Every issue's first line also carries an explicit **`fableplan: yes|no`** signal
 | `fable-validate` | Like `validate-issue`, but the fact-checking runs on a Fable 5 subagent; your main session presents the verdict and acts on it. |
 | `fable-validate-loop` | Runs `fable-validate`, applies issue fixes, gets a Fable plan (only when Capability ≥ 2 / score ≥ 50, or touching safety-critical code), then drives to a reviewed PR. |
 | `fable-validate-fableplan-loop` | Same as above, but the Fable plan is unconditional — every issue gets a posted plan before implementation, no matter how simple. |
+| `fable-validate-fableplan` | The same chain without the build: Fable validates the issue, issue fixes are applied, and a Fable plan is always posted. It stops there — no worktree, no PR, no review loop. |
 | `validate-fableplan-loop` | The hybrid: validates on your session's own model, but still brings in Fable for planning when Capability ≥ 2 / score ≥ 50 or safety-flagged, then drives to a reviewed PR. |
 | `fableplan-work-on-issue` | The trimmed chain: Fable 5 plans the issue and posts the plan, then `work-on-issue` builds it and opens a PR. No validation, no review loop — stops at the open PR. |
 | `fableplan-loop` | Same as above, plus the review loop: after the Fable plan is posted, `work-on-issue-loop` builds it, opens the PR, and keeps fixing review findings until approval. No validation. |

--- a/docs/contract-inventory.md
+++ b/docs/contract-inventory.md
@@ -21,6 +21,7 @@ This inventory records every shared pipeline rule those families restate in pros
 | `skills/fable-validate-loop/SKILL.md` | Capability-gated fableplan + validation stop conditions |
 | `skills/validate-fableplan-loop/SKILL.md` | Capability-gated fableplan + validation stop conditions (session-model validate) |
 | `skills/fable-validate-fableplan-loop/SKILL.md` | Always-plan exception + validation stop conditions |
+| `skills/fable-validate-fableplan/SKILL.md` | Same always-plan exception + validation stop conditions; ends at the posted plan (no implement stage) |
 | `skills/new-issue-loop/SKILL.md` | Duplicate / convergence stop before validate-issue-loop |
 | `skills/fable-new-issue-loop/SKILL.md` | Same duplicate / convergence stop (Fable front) |
 | `skills/validate-issue-loop/SKILL.md` | Validation stop conditions; hands off review loop |
@@ -36,15 +37,15 @@ Non-skill consumers (e.g. `templates/claude-workflow/prompts/fix-pr.md`) are not
 |---|---|---|---|---|---|
 | Review-cycle / LGTM stop | `fix-pr-review-loop` procedure (`review_count > 5`) | `fix-pr-review-loop`, `work-on-issue-loop` (full); `fableplan-loop` (must paraphrase the threshold); fixer classifiers (`fix-pr-review`, Action `fix-pr` prompt) must also treat `**Verification limitation:**` as not a finding | Bare `LGTM` with no remaining **finding** sections stops at any cycle count — a `**Verification limitation:**` line is not a finding and does not prevent a clean pass; after more than **5** review cycles, the first `LGTM` ends the loop even with non-blocking leftovers; `Needs Updates` alone never stops by cycle count | Full procedure vs short paraphrase ("past 5 cycles the first LGTM") is fine; who triggers the first `@claude` review differs by entry skill; fixer copies state the carve-out at classify time rather than restating the full stop table | `tests/loop-validate-pipeline-contract.test.js`; `tests/pr-review-contract.test.js` (limitation carve-out in loops + fixer consumers) |
 | Fableplan Capability gate | Shared semantic in gated validate→plan loops | `fable-validate-loop`, `validate-fableplan-loop` | Skip fableplan when Capability **< 2** / score **below 50** with no safety flags; safety carve-out (money, data integrity, security, auto-protective) overrides the skip | "Fable validates" vs "session model validates" wording; which skill name is the unconditional counterpart | same |
-| Always-plan (no Capability gate) | Intentional exception set | `fable-validate-fableplan-loop`, `fableplan-loop` | Must document that there is **no** Capability gate / fableplan **always** runs; must not install the skip-below-50 gate as this skill's own rule | Why the gate is absent (no validation score vs unconditional plan product) | same — exception path |
+| Always-plan (no Capability gate) | Intentional exception set | `fable-validate-fableplan-loop`, `fable-validate-fableplan`, `fableplan-loop` | Must document that there is **no** Capability gate / fableplan **always** runs; must not install the skip-below-50 gate as this skill's own rule | Why the gate is absent (no validation score vs unconditional plan product) | same — exception path |
 | Duplicate / convergence stop | Shared semantic in new-issue chains | `new-issue-loop`, `fable-new-issue-loop` | Stop when a duplicate open issue/PR already covers the work, or when the discussion has not converged on one issue to file | Front skill is `new-issue` vs `fable-new-issue` | same |
-| Validation scope / feasibility / existing-PR stop | Shared semantic in validate→implement loops | `validate-issue-loop`, `fable-validate-loop`, `validate-fableplan-loop`, `fable-validate-fableplan-loop` | Stop instead of implementing when validation flags the issue as too large, architecturally infeasible, or already addressed by an existing open PR | Whether a Fable plan step sits between update and implement | same |
+| Validation scope / feasibility / existing-PR stop | Shared semantic in validate→plan/implement chains | `validate-issue-loop`, `fable-validate-loop`, `validate-fableplan-loop`, `fable-validate-fableplan-loop`, `fable-validate-fableplan` | Stop instead of continuing the chain when validation flags the issue as too large, architecturally infeasible, or already addressed by an existing open PR | Whether a Fable plan step sits between update and implement; whether the chain ends at the posted plan (`fable-validate-fableplan`) or at a reviewed PR | same |
 
 ## Intentional exceptions
 
 ### Always-plan skills omit the Capability gate
 
-`fable-validate-fableplan-loop` and `fableplan-loop` intentionally have **no** "skip fableplan when Capability < 2 / score < 50" gate. That is the product difference from `fable-validate-loop` / `validate-fableplan-loop`, not drift. The guard requires those two files to state the missing gate explicitly and does **not** require the skip-below-50 instruction as their own rule.
+`fable-validate-fableplan-loop`, `fable-validate-fableplan`, and `fableplan-loop` intentionally have **no** "skip fableplan when Capability < 2 / score < 50" gate. That is the product difference from `fable-validate-loop` / `validate-fableplan-loop`, not drift. For `fable-validate-fableplan` the plan is the run's only output, so a gate would leave it with nothing to deliver. The guard requires those three files to state the missing gate explicitly and does **not** require the skip-below-50 instruction as their own rule.
 
 ### Base validators are not pipeline consumers
 
@@ -65,4 +66,4 @@ If the skill review-cycle threshold and the workflow default must stay locked to
 `tests/complexity-score.test.js` already asserts Capability-gate phrasing in `fable-validate-loop` and `validate-fableplan-loop`. This inventory's guard is the pipeline-family source of truth for the full consumer sets and exceptions above.
 
 ---
-Updated with LLM: Cursor Grok 4.5 | high | Harness: Cursor
+Updated with LLM: Opus 5 | high | Harness: Claude Code

--- a/skills/fable-validate-fableplan/SKILL.md
+++ b/skills/fable-validate-fableplan/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: fable-validate-fableplan
+description: Use when the user asks to validate a GitHub issue with Fable 5 and always plan it with Fable 5, stopping once the plan is posted — "fable-validate-fableplan", "fable validate and fable plan #N", "validate and plan #N with fable, don't build it". Runs fable-validate, auto-applies its update-issue edits when the verdict calls for it, then has fableplan produce and post a Fable 5 implementation plan for EVERY issue (no Capability gate), and stops at the posted plan — no worktree, no build, no PR, no review loop. Stops earlier when validation flags the issue as too large, architecturally infeasible, or already addressed by an existing PR. The no-implementation counterpart to fable-validate-fableplan-loop.
+---
+
+# fable-validate-fableplan
+
+Chain fable-validate → (conditional) update issue → fableplan into one autonomous run, and stop there: Fable 5 validates the issue, the main agent fixes the issue description if needed, and Fable 5 plans the implementation. The vetted plan is posted to the issue as a comment. **Nothing is built.**
+
+This is **fable-validate-fableplan-loop with the implementation stage removed** — the head of that chain is identical (same validation, same scope gate, same issue edits, same unconditional Fable plan), but the handoff to `work-on-issue-loop` is dropped. Reach for this when you want the issue fact-checked, corrected, and planned so a human (or a later run) can decide what to do with the plan. When the plan should be built and driven through review in the same run, use `fable-validate-fableplan-loop` instead.
+
+**Do not skip or reorder the chain.** Validation gates planning — a plan built on refuted claims is wrong. There is **no sanctioned skip**: every step runs; only the "wait for the user's reply" moments are replaced by the decision rules below.
+
+**No Capability gate.** fableplan **always runs** for every issue that passes the scope gate, whatever the validated complexity score. There is no "skip when Capability < 2 / score < 50" rule in this skill — producing the plan is the product, so gating it away would leave the run with no output. This matches `fable-validate-fableplan-loop`; it is the deliberate difference from `fable-validate-loop` / `validate-fableplan-loop`.
+
+## Input
+
+Same defaults as fable-validate: issue URL, `#<N>` / `<N>` / `owner/repo#N`, or nothing (defaults to the latest open issue in the current repo).
+
+## Steps
+
+### 1. Run fable-validate
+
+Invoke the `fable-validate` skill for the target issue (Skill tool, `skill: fable-validate`). Let it run fully — Fable 5 subagent validation, spot-check, verdict — producing the standard verdict block:
+
+```
+**#<N>: Update issue description? <Yes|No>**  ·  Complexity: <score>/100 — Capability <k> (<driver>); Volume <v> · fableplan: <yes|no>  ·  Scope: <OK | too large — split/umbrella/narrow>
+```
+
+Treat the verdict as structured output to parse yourself, not a prompt to wait on. Record the resolved issue number — every later step targets exactly this issue. Keep the verdict block and the validation report in the scratchpad; step 4 passes them to the planner.
+
+### 2. Scope gate — stop if the issue is not worth planning
+
+Check the verdict's **Scope** field, **Architecture** section, and **Concerns** (for an already-addressing PR) before doing anything else:
+
+| Condition | Action |
+|---|---|
+| `Scope: too large` (split / umbrella / narrow flagged) | **STOP.** Report the disposition and proposed parts. One plan for a multi-part issue reproduces the scope problem in the plan — splitting is a human call. |
+| Architecture marked ❌ **Infeasible** | **STOP.** Report the infeasibility and the "Optimal direction" note; planning a design the validation rejected would post the wrong plan. |
+| A **merged** PR already implements the fix | **STOP.** Report the PR and the close/repurpose recommendation — nothing left to plan. |
+| An **open** PR is already addressing the issue | **STOP.** Report the overlapping PR; supersede/join/wait is a human call. |
+
+Otherwise (Scope: OK; architecture ✅/⚠️ or not applicable; no PR already addressing it), continue.
+
+### 3. Apply the update-issue edits, if called for
+
+If the verdict says **Update issue description? Yes**, apply the suggested title/body edits now per fable-validate step 5 / validate-issue step 8 — claim-verification gate, final consistency pass, and the stacked attribution line (`Validated with LLM: Fable 5 | high | Harness: Claude Code | fable-validate-fableplan`) — from the current checkout (no worktree for issue edits).
+
+If **No**, skip straight to step 4.
+
+**Order matters:** the edits land before fableplan runs, so the Fable 5 planner fetches and plans against the corrected issue, not the flawed original.
+
+### 4. Run fableplan — planning phase only, always
+
+Invoke the `fableplan` skill for the same issue number (Skill tool, `skill: fableplan`), and **scope it to its planning phase — steps 1 through 5 only**: fetch the issue, dispatch the Fable 5 Plan subagent, sanity-check the plan against the code, post the vetted plan as an issue comment, and relay it. Instruct fableplan to use the harness suffix `fable-validate-fableplan` (not `fableplan`) in the posted comment's attribution footer, so the comment records the actual entry point.
+
+**Do NOT execute fableplan's steps 7–8 (worktree + build), and do not answer its "build now?" prompt with anything but stop.** This skill ends at the posted plan. Building here would take the run past its scope without the user asking.
+
+Give the planning subagent the validation verdict and report (the scratchpad copies from step 1) alongside the issue — the plan must respect what validation established (verified/refuted claims, the Optimal-direction note when architecture was ⚠️, 5b concerns).
+
+If fableplan's sanity-check finds the plan structurally wrong, or fableplan fails after its internal retry, **stop and report** — don't post a broken plan, and don't fall back to planning yourself.
+
+### 5. Report
+
+Report, in order: scope gate passed, issue updated or not, plan posted (comment URL), and one line on what the plan proposes. Then name the follow-on options in one line — `work-on-issue` to build the plan and stop at the PR, `work-on-issue-loop` to build it and drive review to convergence, or `fable-validate-fableplan-loop` for the same chain end-to-end next time. **Do not start any of them.**
+
+**Cap the whole report at 55 words, ELI18** — plain language, no jargon, as if explaining the outcome to a smart 18-year-old with no context on this codebase.
+
+## Red Flags — STOP
+
+| Situation | Action |
+|---|---|
+| Tempted to implement the plan, open a worktree, or open a PR | Out of scope — this skill ends at the posted plan; name `work-on-issue` / `work-on-issue-loop` / `fable-validate-fableplan-loop` as the follow-on instead of starting one |
+| Tempted to skip validation and go straight to planning | Never reorder — validate-then-plan is the point of this skill, and there is no sanctioned skip |
+| Tempted to skip fableplan because the issue scored below 50 (Capability < 2) | Don't — there is no Capability gate here; fableplan always runs, and the plan is this skill's only output |
+| `Scope: too large`, Architecture ❌ Infeasible, or a PR already addressing the issue | Stop and report per step 2 — planning is wasted or wrong in those cases |
+| Tempted to wait for a literal user reply to fable-validate's or fableplan's prompt | Parse the output yourself and proceed per the step rules |
+| Verdict says Update issue description? Yes | Apply the edits **before** fableplan runs, so the plan targets the corrected issue |
+| fableplan about to enter its build steps (7–8) | Don't — stop it at step 5; nothing in this skill builds |
+| fableplan's sanity-check finds the plan structurally wrong | Stop and report — don't post a broken plan, and don't silently re-plan |

--- a/tests/loop-validate-pipeline-contract.test.js
+++ b/tests/loop-validate-pipeline-contract.test.js
@@ -21,6 +21,7 @@ const CAPABILITY_GATE = [
 ]
 const ALWAYS_PLAN = [
   'skills/fable-validate-fableplan-loop/SKILL.md',
+  'skills/fable-validate-fableplan/SKILL.md',
   'skills/fableplan-loop/SKILL.md',
 ]
 
@@ -34,6 +35,7 @@ const VALIDATION_STOP = [
   'skills/fable-validate-loop/SKILL.md',
   'skills/validate-fableplan-loop/SKILL.md',
   'skills/fable-validate-fableplan-loop/SKILL.md',
+  'skills/fable-validate-fableplan/SKILL.md',
 ]
 
 const INVENTORY = 'docs/contract-inventory.md'
@@ -128,7 +130,7 @@ describe('loop/validate pipeline contract', () => {
     }
   })
 
-  test('validate→implement loops stop on too-large, infeasible, or existing PR', () => {
+  test('validate→plan/implement chains stop on too-large, infeasible, or existing PR', () => {
     for (const path of VALIDATION_STOP) {
       const body = procedureBody(texts[path])
       expect(hasStopTableRow(body, /too large/i), `${path}: STOP+too large row`).toBe(true)


### PR DESCRIPTION
## Summary

Adds `fable-validate-fableplan` — `fable-validate-fableplan-loop` with the implementation stage removed.

The chain head is identical: `fable-validate` runs, the same scope gate stops the run on a too-large / architecturally-infeasible / already-addressed issue, the update-issue edits land when the verdict calls for them, and `fableplan` always posts a Fable 5 plan (no Capability gate). The run then stops at the posted plan and names the follow-on options instead of starting one. No worktree, no build, no PR, no review loop.

The always-plan rule is deliberate here for a second reason beyond the loop variant's: the plan is this skill's only output, so gating it away would leave the run with nothing to deliver.

## Verification

- `bun test` — 130 pass, 0 fail.
- The new skill is registered in `tests/loop-validate-pipeline-contract.test.js` under both `ALWAYS_PLAN` (must state the missing Capability gate) and `VALIDATION_STOP` (must carry the three STOP rows), so the shared guard covers it.

## Changes

- `skills/fable-validate-fableplan/SKILL.md` — new skill.
- `tests/loop-validate-pipeline-contract.test.js` — added to the two guard consumer lists; one test title widened from "loops" to "chains".
- `docs/contract-inventory.md` — inventoried file row, always-plan and validation-stop consumer lists, and the intentional-exception note.
- `README.md` — Fable-driven skills table row.

## Plain simple English

There is already a skill that checks a GitHub issue with Fable, corrects it, plans it, then builds it. This adds the same thing without the build. It checks the issue, fixes the description, posts a plan, and stops. Use it when a person must decide what to do with the plan.

---
Created with LLM: Opus 5 | high | Harness: Claude Code
