### PR TITLE
feat(claude-action): add Opus 5 and versioned model shorthands [C25, Opus 5, high]

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -251,7 +251,7 @@ jobs:
                 # optional model shorthand.
                 KEYWORD=$(printf '%s' "$STRIPPED" | tr -d '\r' \
                   | sed -n 's/^[[:space:]]*@claude[[:space:]]\{1,\}//p' | head -n 1 \
-                  | awk '{ if ($1 ~ /^(opus|opus5|sonnet|sonnet5|fable|fable5)$/) { print $2 } else { print $1 } }' \
+                  | awk '{ if (tolower($1) ~ /^(opus|opus5|sonnet|sonnet5|fable|fable5)$/) { print $2 } else { print $1 } }' \
                   | tr '[:upper:]' '[:lower:]')
 
                 PR_AUTHOR_TRUSTED=false

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -105,7 +105,7 @@ jobs:
             NONBLANK=$(printf '%s' "$STRIPPED" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d')
             NONBLANK_LINES=$(printf '%s' "$NONBLANK" | awk 'END{print NR}')
             if [ "$NONBLANK_LINES" -eq 1 ] && \
-               printf '%s' "$NONBLANK" | grep -qE '^@claude([[:space:]]+[a-z]+)?[[:space:]]+review([[:space:]]+effort:(low|medium|high|xhigh))?$'; then
+               printf '%s' "$NONBLANK" | grep -qE '^@claude([[:space:]]+[a-z]+[0-9]*)?[[:space:]]+review([[:space:]]+effort:(low|medium|high|xhigh))?$'; then
               echo "invoked=true" >> "$GITHUB_OUTPUT"
             else
               echo "invoked=false" >> "$GITHUB_OUTPUT"
@@ -133,15 +133,18 @@ jobs:
           # Empty when unset.
           DOCS_RELEASE_ENABLED: ${{ vars.DOCS_RELEASE_ENABLED }}
         run: |
-          # Extract optional model shorthand after @claude on a line boundary
-          # e.g. "@claude sonnet fix this" → "sonnet"
-          MODEL_SHORT=$(printf '%s' "$STRIPPED" | grep -oE '(^|(\r?\n))[[:space:]]*@claude[[:space:]]+[a-z]+' | head -1 | awk '{print $NF}' || true)
+          # Extract optional model shorthand after @claude on a line boundary,
+          # including an optional version digit.
+          # e.g. "@claude sonnet fix this" → "sonnet", "@claude opus5 …" → "opus5"
+          MODEL_SHORT=$(printf '%s' "$STRIPPED" | grep -oE '(^|(\r?\n))[[:space:]]*@claude[[:space:]]+[a-z]+[0-9]*' | head -1 | awk '{print $NF}' || true)
 
+          # Each family accepts a bare name and a "5" suffix — "opus"/"opus5" both
+          # select Opus 5. Only the no-shorthand default stays on Opus 4.8.
           case "$MODEL_SHORT" in
-            opus)    MODEL_ID="claude-opus-4-8[1m]" ;;
-            sonnet)  MODEL_ID="claude-sonnet-5" ;;
-            fable)   MODEL_ID="claude-fable-5" ;;
-            *)       MODEL_ID="claude-opus-4-8[1m]" ;;  # default (no model specified)
+            opus|opus5)     MODEL_ID="claude-opus-5" ;;
+            sonnet|sonnet5) MODEL_ID="claude-sonnet-5" ;;
+            fable|fable5)   MODEL_ID="claude-fable-5" ;;
+            *)              MODEL_ID="claude-opus-4-8[1m]" ;;  # default (no model specified)
           esac
 
           echo "model_id=$MODEL_ID" >> "$GITHUB_OUTPUT"
@@ -175,7 +178,7 @@ jobs:
           FLOW=""
           if [ "$EVENT_NAME" = "issue_comment" ] && [ "$DOCS_RELEASE_ENABLED" = "true" ]; then
             for cand in create-release sync-docs; do
-              if printf '%s' "$STRIPPED" | grep -qiE "(^|(\r?\n))[[:space:]]*@claude([[:space:]]+(opus|sonnet|fable))?[[:space:]]+${cand}([[:space:]]|\$)"; then
+              if printf '%s' "$STRIPPED" | grep -qiE "(^|(\r?\n))[[:space:]]*@claude([[:space:]]+(opus|opus5|sonnet|sonnet5|fable|fable5))?[[:space:]]+${cand}([[:space:]]|\$)"; then
                 FLOW="$cand"
                 break
               fi
@@ -206,7 +209,8 @@ jobs:
           PR_AUTHOR_LOGIN: ${{ github.event.issue.user.login }}
         run: |
           # Fail-closed routing keyed on the FIRST word after @claude (an
-          # optional model shorthand — opus/sonnet/fable — is skipped). Four
+          # optional model shorthand — opus/sonnet/fable, each also
+          # accepted with a "5" suffix — is skipped). Four
           # outcomes:
           #   - implement: a docs-sync/release FLOW, or a plain issue (an `issues`
           #     event, or an issue_comment whose issue is NOT a PR) — the
@@ -247,7 +251,7 @@ jobs:
                 # optional model shorthand.
                 KEYWORD=$(printf '%s' "$STRIPPED" | tr -d '\r' \
                   | sed -n 's/^[[:space:]]*@claude[[:space:]]\{1,\}//p' | head -n 1 \
-                  | awk '{ if ($1 == "opus" || $1 == "sonnet" || $1 == "fable") { print $2 } else { print $1 } }' \
+                  | awk '{ if ($1 ~ /^(opus|opus5|sonnet|sonnet5|fable|fable5)$/) { print $2 } else { print $1 } }' \
                   | tr '[:upper:]' '[:lower:]')
 
                 PR_AUTHOR_TRUSTED=false

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -134,9 +134,10 @@ jobs:
           DOCS_RELEASE_ENABLED: ${{ vars.DOCS_RELEASE_ENABLED }}
         run: |
           # Extract optional model shorthand after @claude on a line boundary,
-          # including an optional version digit.
-          # e.g. "@claude sonnet fix this" → "sonnet", "@claude opus5 …" → "opus5"
-          MODEL_SHORT=$(printf '%s' "$STRIPPED" | grep -oE '(^|(\r?\n))[[:space:]]*@claude[[:space:]]+[a-z]+[0-9]*' | head -1 | awk '{print $NF}' || true)
+          # including an optional version digit. Case-insensitive match (-i),
+          # then lowercased, so "Opus"/"OPUS5" resolve the same as "opus5".
+          # e.g. "@claude sonnet fix this" → "sonnet", "@claude Opus5 …" → "opus5"
+          MODEL_SHORT=$(printf '%s' "$STRIPPED" | grep -ioE '(^|(\r?\n))[[:space:]]*@claude[[:space:]]+[a-z]+[0-9]*' | head -1 | awk '{print $NF}' | tr '[:upper:]' '[:lower:]' || true)
 
           # Each family accepts a bare name and a "5" suffix — "opus"/"opus5" both
           # select Opus 5. Only the no-shorthand default stays on Opus 4.8.

--- a/templates/claude-workflow/README.md
+++ b/templates/claude-workflow/README.md
@@ -94,9 +94,11 @@ parses the `docs-release/*` branch name.
 | `@claude <anything>` on an issue | implement: validate → implement → PR via the issue-workflow prompt | Yes |
 | `@claude sync docs` / `create release` / `sync release` | docs/release flows (needs `DOCS_RELEASE_ENABLED=true`) | Scoped |
 
-Model shorthand (`@claude opus …`, `sonnet`, `fable`) and `effort:low|medium|high|xhigh`
-are parsed from the comment; review events (formal reviews, inline comments)
-always stay read-only regardless of keyword.
+Model shorthand (`@claude opus …`, `sonnet`, `fable` — each also accepted with a
+`5` suffix, e.g. `opus5`) and `effort:low|medium|high|xhigh` are parsed from the
+comment. `opus`/`opus5` selects Opus 5; a comment with no shorthand keeps the
+Opus 4.8 default. Review events (formal reviews, inline comments) always stay
+read-only regardless of keyword.
 
 ## Security model
 

--- a/templates/claude-workflow/scripts/compose_claude_comment.py
+++ b/templates/claude-workflow/scripts/compose_claude_comment.py
@@ -22,6 +22,7 @@ from strip_llm_footer import strip_llm_footer
 
 MODEL_DISPLAY_NAMES = {
     "claude-opus-4-8[1m]": "Claude Opus 4.8 (1M)",
+    "claude-opus-5": "Claude Opus 5",
     "claude-sonnet-5": "Claude Sonnet 5",
     "claude-fable-5": "Claude Fable 5",
 }

--- a/templates/claude-workflow/scripts/test_compose_claude_comment.py
+++ b/templates/claude-workflow/scripts/test_compose_claude_comment.py
@@ -17,6 +17,7 @@ HARNESS = "anthropics/claude-code-action@v1"
 class ModelDisplayNameTest(unittest.TestCase):
     def test_known_ids_mapped(self):
         self.assertEqual(model_display_name("claude-opus-4-8[1m]"), "Claude Opus 4.8 (1M)")
+        self.assertEqual(model_display_name("claude-opus-5"), "Claude Opus 5")
         self.assertEqual(model_display_name("claude-sonnet-5"), "Claude Sonnet 5")
         self.assertEqual(model_display_name("claude-fable-5"), "Claude Fable 5")
 

--- a/templates/claude-workflow/scripts/test_workflow_logic.py
+++ b/templates/claude-workflow/scripts/test_workflow_logic.py
@@ -401,9 +401,24 @@ class ResolveModelTest(unittest.TestCase):
             "claude-opus-5",
         )
 
+    def test_capitalized_opus5_shorthand_selects_opus_5(self):
+        # Must survive: a shorthand token that routing recognizes and skips
+        # for every case variant must resolve to the same model for every
+        # case variant — never silently drop to the Opus 4.8 default.
+        self.assertEqual(
+            run_resolve_model("issue_comment", "@claude Opus5 review")["model_id"],
+            "claude-opus-5",
+        )
+
     def test_sonnet5_shorthand_selects_sonnet_5(self):
         self.assertEqual(
             run_resolve_model("issue_comment", "@claude sonnet5 fix this")["model_id"],
+            "claude-sonnet-5",
+        )
+
+    def test_uppercase_sonnet5_shorthand_selects_sonnet_5(self):
+        self.assertEqual(
+            run_resolve_model("issue_comment", "@claude SONNET5 fix this")["model_id"],
             "claude-sonnet-5",
         )
 

--- a/templates/claude-workflow/scripts/test_workflow_logic.py
+++ b/templates/claude-workflow/scripts/test_workflow_logic.py
@@ -30,6 +30,7 @@ CLAUDE_YML = os.path.abspath(os.path.join(HERE, "..", "workflows", "claude.yml")
 
 VERIFY_STEP = "Verify @claude is an actual invocation (not in a code block or example)"
 CLASSIFY_MODE_STEP = "Classify invocation route (review, implement, or fix-pr)"
+RESOLVE_MODEL_STEP = "Resolve model from @claude invocation"
 
 
 def _read(path):
@@ -131,6 +132,41 @@ def run_classify_mode(
     )
 
 
+def _run_block_all_outputs(script, env_overrides):
+    """Execute an extracted run block with injected env; return every key it
+    wrote to GITHUB_OUTPUT as a dict (last-wins per key, same rule as
+    _run_block)."""
+    with tempfile.TemporaryDirectory() as d:
+        out_path = os.path.join(d, "github_output")
+        open(out_path, "w").close()
+        env = dict(os.environ)
+        env.update(env_overrides)
+        env["GITHUB_OUTPUT"] = out_path
+        r = subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True)
+        values = {}
+        with open(out_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.rstrip("\n")
+                if "=" in line:
+                    key, _, val = line.partition("=")
+                    values[key] = val
+        if not values:
+            raise AssertionError(f"run block wrote no GITHUB_OUTPUT; stderr:\n{r.stderr}")
+        return values
+
+
+def run_resolve_model(event_name, stripped, docs_release_enabled=""):
+    script = extract_step_run_block(_read(CLAUDE_YML), RESOLVE_MODEL_STEP)
+    return _run_block_all_outputs(
+        script,
+        {
+            "EVENT_NAME": event_name,
+            "STRIPPED": stripped,
+            "DOCS_RELEASE_ENABLED": docs_release_enabled,
+        },
+    )
+
+
 def run_verify_invocation(event_name, body, trigger_actor="someuser"):
     script = extract_step_run_block(_read(CLAUDE_YML), VERIFY_STEP)
     return _run_block(
@@ -207,6 +243,24 @@ class ClassifyModeRoutingTest(unittest.TestCase):
             run_classify_mode("issue_comment", "@claude sonnet review",
                               pr_url=PR_URL, pr_author_assoc="MEMBER"),
             "review",
+        )
+
+    def test_review_keyword_after_uppercase_model_shorthand_is_review(self):
+        # Must survive: a capitalized shorthand ("Opus") must be skipped
+        # identically to its lowercase form, or the real "review" keyword
+        # gets discarded and a trusted-author PR misroutes to push-capable
+        # fix-pr instead of staying read-only.
+        self.assertEqual(
+            run_classify_mode("issue_comment", "@claude Opus review",
+                              pr_url=PR_URL, pr_author_assoc="MEMBER"),
+            "review",
+        )
+
+    def test_fix_pr_keyword_after_uppercase_model_shorthand_routes_to_fix_pr(self):
+        self.assertEqual(
+            run_classify_mode("issue_comment", "@claude SONNET5 fix this",
+                              pr_url=PR_URL, pr_author_assoc="OWNER"),
+            "fix-pr",
         )
 
     def test_review_and_fix_loses_push_on_purpose(self):
@@ -320,6 +374,65 @@ class ClassifyModeRoutingTest(unittest.TestCase):
                               pr_url=PR_URL, flow="create-release",
                               pr_author_assoc="MEMBER"),
             "implement",
+        )
+
+
+class ResolveModelTest(unittest.TestCase):
+    """Pin the model-shorthand → MODEL_ID resolution and the docs/release FLOW
+    matcher, extracted straight from the live YAML so a change to the
+    shorthand regex or the model-id case statement is what the test runs
+    against."""
+
+    def test_no_shorthand_defaults_to_opus_4_8(self):
+        self.assertEqual(
+            run_resolve_model("issue_comment", "@claude fix this")["model_id"],
+            "claude-opus-4-8[1m]",
+        )
+
+    def test_opus_shorthand_selects_opus_5(self):
+        self.assertEqual(
+            run_resolve_model("issue_comment", "@claude opus review")["model_id"],
+            "claude-opus-5",
+        )
+
+    def test_opus5_shorthand_selects_opus_5(self):
+        self.assertEqual(
+            run_resolve_model("issue_comment", "@claude opus5 review")["model_id"],
+            "claude-opus-5",
+        )
+
+    def test_sonnet5_shorthand_selects_sonnet_5(self):
+        self.assertEqual(
+            run_resolve_model("issue_comment", "@claude sonnet5 fix this")["model_id"],
+            "claude-sonnet-5",
+        )
+
+    def test_fable5_shorthand_selects_fable_5(self):
+        self.assertEqual(
+            run_resolve_model("issue_comment", "@claude fable5 review")["model_id"],
+            "claude-fable-5",
+        )
+
+    def test_flow_matches_create_release_with_model_shorthand(self):
+        self.assertEqual(
+            run_resolve_model(
+                "issue_comment", "@claude opus5 create-release", docs_release_enabled="true"
+            )["flow"],
+            "create-release",
+        )
+
+    def test_flow_matches_sync_docs_without_shorthand(self):
+        self.assertEqual(
+            run_resolve_model(
+                "issue_comment", "@claude sync-docs", docs_release_enabled="true"
+            )["flow"],
+            "sync-docs",
+        )
+
+    def test_flow_empty_when_docs_release_disabled(self):
+        self.assertEqual(
+            run_resolve_model("issue_comment", "@claude create-release")["flow"],
+            "",
         )
 
 

--- a/templates/claude-workflow/workflows/claude.yml
+++ b/templates/claude-workflow/workflows/claude.yml
@@ -251,7 +251,7 @@ jobs:
                 # optional model shorthand.
                 KEYWORD=$(printf '%s' "$STRIPPED" | tr -d '\r' \
                   | sed -n 's/^[[:space:]]*@claude[[:space:]]\{1,\}//p' | head -n 1 \
-                  | awk '{ if ($1 ~ /^(opus|opus5|sonnet|sonnet5|fable|fable5)$/) { print $2 } else { print $1 } }' \
+                  | awk '{ if (tolower($1) ~ /^(opus|opus5|sonnet|sonnet5|fable|fable5)$/) { print $2 } else { print $1 } }' \
                   | tr '[:upper:]' '[:lower:]')
 
                 PR_AUTHOR_TRUSTED=false

--- a/templates/claude-workflow/workflows/claude.yml
+++ b/templates/claude-workflow/workflows/claude.yml
@@ -105,7 +105,7 @@ jobs:
             NONBLANK=$(printf '%s' "$STRIPPED" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d')
             NONBLANK_LINES=$(printf '%s' "$NONBLANK" | awk 'END{print NR}')
             if [ "$NONBLANK_LINES" -eq 1 ] && \
-               printf '%s' "$NONBLANK" | grep -qE '^@claude([[:space:]]+[a-z]+)?[[:space:]]+review([[:space:]]+effort:(low|medium|high|xhigh))?$'; then
+               printf '%s' "$NONBLANK" | grep -qE '^@claude([[:space:]]+[a-z]+[0-9]*)?[[:space:]]+review([[:space:]]+effort:(low|medium|high|xhigh))?$'; then
               echo "invoked=true" >> "$GITHUB_OUTPUT"
             else
               echo "invoked=false" >> "$GITHUB_OUTPUT"
@@ -133,15 +133,18 @@ jobs:
           # Empty when unset.
           DOCS_RELEASE_ENABLED: ${{ vars.DOCS_RELEASE_ENABLED }}
         run: |
-          # Extract optional model shorthand after @claude on a line boundary
-          # e.g. "@claude sonnet fix this" → "sonnet"
-          MODEL_SHORT=$(printf '%s' "$STRIPPED" | grep -oE '(^|(\r?\n))[[:space:]]*@claude[[:space:]]+[a-z]+' | head -1 | awk '{print $NF}' || true)
+          # Extract optional model shorthand after @claude on a line boundary,
+          # including an optional version digit.
+          # e.g. "@claude sonnet fix this" → "sonnet", "@claude opus5 …" → "opus5"
+          MODEL_SHORT=$(printf '%s' "$STRIPPED" | grep -oE '(^|(\r?\n))[[:space:]]*@claude[[:space:]]+[a-z]+[0-9]*' | head -1 | awk '{print $NF}' || true)
 
+          # Each family accepts a bare name and a "5" suffix — "opus"/"opus5" both
+          # select Opus 5. Only the no-shorthand default stays on Opus 4.8.
           case "$MODEL_SHORT" in
-            opus)    MODEL_ID="claude-opus-4-8[1m]" ;;
-            sonnet)  MODEL_ID="claude-sonnet-5" ;;
-            fable)   MODEL_ID="claude-fable-5" ;;
-            *)       MODEL_ID="claude-opus-4-8[1m]" ;;  # default (no model specified)
+            opus|opus5)     MODEL_ID="claude-opus-5" ;;
+            sonnet|sonnet5) MODEL_ID="claude-sonnet-5" ;;
+            fable|fable5)   MODEL_ID="claude-fable-5" ;;
+            *)              MODEL_ID="claude-opus-4-8[1m]" ;;  # default (no model specified)
           esac
 
           echo "model_id=$MODEL_ID" >> "$GITHUB_OUTPUT"
@@ -175,7 +178,7 @@ jobs:
           FLOW=""
           if [ "$EVENT_NAME" = "issue_comment" ] && [ "$DOCS_RELEASE_ENABLED" = "true" ]; then
             for cand in create-release sync-docs; do
-              if printf '%s' "$STRIPPED" | grep -qiE "(^|(\r?\n))[[:space:]]*@claude([[:space:]]+(opus|sonnet|fable))?[[:space:]]+${cand}([[:space:]]|\$)"; then
+              if printf '%s' "$STRIPPED" | grep -qiE "(^|(\r?\n))[[:space:]]*@claude([[:space:]]+(opus|opus5|sonnet|sonnet5|fable|fable5))?[[:space:]]+${cand}([[:space:]]|\$)"; then
                 FLOW="$cand"
                 break
               fi
@@ -206,7 +209,8 @@ jobs:
           PR_AUTHOR_LOGIN: ${{ github.event.issue.user.login }}
         run: |
           # Fail-closed routing keyed on the FIRST word after @claude (an
-          # optional model shorthand — opus/sonnet/fable — is skipped). Four
+          # optional model shorthand — opus/sonnet/fable, each also
+          # accepted with a "5" suffix — is skipped). Four
           # outcomes:
           #   - implement: a docs-sync/release FLOW, or a plain issue (an `issues`
           #     event, or an issue_comment whose issue is NOT a PR) — the
@@ -247,7 +251,7 @@ jobs:
                 # optional model shorthand.
                 KEYWORD=$(printf '%s' "$STRIPPED" | tr -d '\r' \
                   | sed -n 's/^[[:space:]]*@claude[[:space:]]\{1,\}//p' | head -n 1 \
-                  | awk '{ if ($1 == "opus" || $1 == "sonnet" || $1 == "fable") { print $2 } else { print $1 } }' \
+                  | awk '{ if ($1 ~ /^(opus|opus5|sonnet|sonnet5|fable|fable5)$/) { print $2 } else { print $1 } }' \
                   | tr '[:upper:]' '[:lower:]')
 
                 PR_AUTHOR_TRUSTED=false

--- a/templates/claude-workflow/workflows/claude.yml
+++ b/templates/claude-workflow/workflows/claude.yml
@@ -134,9 +134,10 @@ jobs:
           DOCS_RELEASE_ENABLED: ${{ vars.DOCS_RELEASE_ENABLED }}
         run: |
           # Extract optional model shorthand after @claude on a line boundary,
-          # including an optional version digit.
-          # e.g. "@claude sonnet fix this" → "sonnet", "@claude opus5 …" → "opus5"
-          MODEL_SHORT=$(printf '%s' "$STRIPPED" | grep -oE '(^|(\r?\n))[[:space:]]*@claude[[:space:]]+[a-z]+[0-9]*' | head -1 | awk '{print $NF}' || true)
+          # including an optional version digit. Case-insensitive match (-i),
+          # then lowercased, so "Opus"/"OPUS5" resolve the same as "opus5".
+          # e.g. "@claude sonnet fix this" → "sonnet", "@claude Opus5 …" → "opus5"
+          MODEL_SHORT=$(printf '%s' "$STRIPPED" | grep -ioE '(^|(\r?\n))[[:space:]]*@claude[[:space:]]+[a-z]+[0-9]*' | head -1 | awk '{print $NF}' | tr '[:upper:]' '[:lower:]' || true)
 
           # Each family accepts a bare name and a "5" suffix — "opus"/"opus5" both
           # select Opus 5. Only the no-shorthand default stays on Opus 4.8.


### PR DESCRIPTION
## Summary

Adds Opus 5 to the model shorthands the `@claude` GitHub Action accepts, and makes every family accept a `5`-suffixed alias.

| Comment | Model |
|---|---|
| `@claude …` (no shorthand) | `claude-opus-4-8[1m]` (unchanged default) |
| `@claude opus …` / `@claude opus5 …` | `claude-opus-5` |
| `@claude sonnet …` / `@claude sonnet5 …` | `claude-sonnet-5` |
| `@claude fable …` / `@claude fable5 …` | `claude-fable-5` |

The shorthand token pattern goes from `[a-z]+` to `[a-z]+[0-9]*`, so all four places that parse it stay consistent:

1. the model resolver (`resolve_model`),
2. the `claude[bot]` self-trigger gate that only allows an exact one-line review trigger,
3. the docs-sync / create-release flow matcher,
4. the fix-pr route-keyword parser, which must skip the shorthand to find the real keyword.

Applied to both the live workflow and the `templates/claude-workflow` copy, plus the template README.

## Verification

- `bun test` — 130 pass, 0 fail.
- Both workflow files parse as YAML (`bunx js-yaml`).
- Simulated the extracted shell logic against sample comments: `@claude review` → 4.8 default; `opus`/`opus5` → Opus 5; `sonnet5 fix this` → Sonnet 5 with keyword `fix`; `fable5 review` → Fable 5 with keyword `review`; `@claude opus5 create-release` and `@claude fable5 sync-docs` match the flow regex; the bot self-trigger gate accepts `@claude opus5 review` and `@claude sonnet5 review effort:high`.

## Plain simple English

You can now tell the review bot to use Opus 5. Write `@claude opus` or `@claude opus5` in a comment. You can also add a `5` to the other names, like `sonnet5` or `fable5`. If you write only `@claude`, nothing changes — it still uses Opus 4.8.

---
Created with LLM: Opus 5 | high | Harness: Claude Code
