### PR TITLE
docs: sync Fable xhigh ceiling to README and agent guidelines [C2, Composer 2.5, high]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@
 
 - **Verb:** `Created` (new work), `Updated` (edits/revisions), `Validated` (review/verification).
 - `<current model>`: the model actually in use (e.g. `Opus 5`).
-- `<effort>`: `medium` / `high` / `xhigh`, or `low` when a Fable build actually ran at that discretionary tier; default `high`.
+- `<effort>`: `medium` / `high` / `xhigh`, or `low` when a Fable build actually ran at that discretionary tier; default `high`. Fable 5 never uses `xhigh` — `high` is its ceiling on every stage.
 - `<harness>`: what produced the change — `Codex` for an interactive session, or the specific skill/agent that ran (e.g. `commit-push-pr`, `agent`, `Cursor`). Named values identify the skill/harness. They do **not** identify the git operations. A hand-done commit/push/PR in a session is `Codex`. Never write `commit-push-pr` for it.
 - **Project precedence:** a repo AGENTS.md footer format overrides this default.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@
 
 - **Verb:** `Created` (new work), `Updated` (edits/revisions), `Validated` (review/verification).
 - `<current model>`: the model actually in use (e.g. `Opus 5`).
-- `<effort>`: `medium` / `high` / `xhigh`, or `low` when a Fable build actually ran at that discretionary tier; default `high`.
+- `<effort>`: `medium` / `high` / `xhigh`, or `low` when a Fable build actually ran at that discretionary tier; default `high`. Fable 5 never uses `xhigh` — `high` is its ceiling on every stage.
 - `<harness>`: what produced the change — `Claude Code` for an interactive session, or the specific skill/agent that ran (e.g. `commit-push-pr`, `agent`, `Cursor`). Named values identify the skill/harness. They do **not** identify the git operations. A hand-done commit/push/PR in a session is `Claude Code`. Never write `commit-push-pr` for it.
 - **Project precedence:** a repo CLAUDE.md footer format overrides this default.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ flowchart LR
 
 Several skills mention a **complexity score** (`C0`–`C100`): a model + effort routing signal in the issue title. **Capability** (which LLM / whether a Fable plan runs first) lives in the score band; **Volume** (how hard to push) lives in the depth inside the band — see `validate-issue` step 6. "Fable" skills hand part of the work to a subagent running on the Fable 5 model — a second Claude instance that plans, validates, or drafts while your main session does the building.
 
-Every issue's first line also carries an explicit **`fableplan: yes|no`** signal, so later steps read the planning decision instead of re-deriving it from the score. It's `yes` only in the Capability 2 band (scores 50–74), where an Opus-class build is worth planning by Fable first. Effort runs `high`/`xhigh` for Opus and Sonnet builds; Fable builds may also run at `medium` or, at the planner's discretion, `low` for issues lighter than the formula's own floor.
+Every issue's first line also carries an explicit **`fableplan: yes|no`** signal, so later steps read the planning decision instead of re-deriving it from the score. It's `yes` only in the Capability 2 band (scores 50–74), where an Opus-class build is worth planning by Fable first. Effort runs `high`/`xhigh` for Opus and Sonnet builds; Fable builds may also run at `medium` or, at the planner's discretion, `low` for issues lighter than the formula's own floor. Fable 5 never runs at `xhigh` — `high` is its ceiling on every stage (build, plan, validate, review, fix).
 
 ### Issue skills
 


### PR DESCRIPTION
## Summary

- Synced docs from baseline `d3b9f10` through `51a16d0` (writing-style rules, `fable-validate-fableplan`, milestone merge/release, github review batches, opus5 selector were already landed in prior commits).
- Filled one remaining gap: README and global agent guidelines now state Fable 5 caps at `high` on every stage, matching `validate-issue` and the milestone-pipeline runtime.

## Verification

- `git diff` — three files, one sentence each (`CLAUDE.md`, `AGENTS.md`, `README.md`).

## Plain simple English

The docs now say Fable 5 never runs at the highest effort tier. High is its limit on every step. This matches how the skills and pipeline already behave.

---
Created with LLM: Composer 2.5 | high | Harness: Cursor