### PR TITLE
test(contracts): guard verdict template and report cap in loop skills [C4, Fable 5, medium]

### DIFF
--- a/docs/contract-inventory.md
+++ b/docs/contract-inventory.md
@@ -40,6 +40,8 @@ Non-skill consumers (e.g. `templates/claude-workflow/prompts/fix-pr.md`) are not
 | Always-plan (no Capability gate) | Intentional exception set | `fable-validate-fableplan-loop`, `fable-validate-fableplan`, `fableplan-loop` | Must document that there is **no** Capability gate / fableplan **always** runs; must not install the skip-below-50 gate as this skill's own rule | Why the gate is absent (no validation score vs unconditional plan product) | same — exception path |
 | Duplicate / convergence stop | Shared semantic in new-issue chains | `new-issue-loop`, `fable-new-issue-loop` | Stop when a duplicate open issue/PR already covers the work, or when the discussion has not converged on one issue to file | Front skill is `new-issue` vs `fable-new-issue` | same |
 | Validation scope / feasibility / existing-PR stop | Shared semantic in validate→plan/implement chains | `validate-issue-loop`, `fable-validate-loop`, `validate-fableplan-loop`, `fable-validate-fableplan-loop`, `fable-validate-fableplan` | Stop instead of continuing the chain when validation flags the issue as too large, architecturally infeasible, or already addressed by an existing open PR | Whether a Fable plan step sits between update and implement; whether the chain ends at the posted plan (`fable-validate-fableplan`) or at a reviewed PR | same |
+| Verdict-block template | `validate-issue` step 7 output format | `validate-issue-loop`, `fable-validate-loop`, `validate-fableplan-loop`, `fable-validate-fableplan-loop`, `fable-validate-fableplan` (each quotes the template it parses) | One template line co-locates every parsed field: `Update issue description?`, `Complexity: <…>/100`, `Capability <k>`, `Volume <v>`, `fableplan: <yes\|no>`, `Scope: <OK \| too large — split/umbrella/narrow>` | Placeholder spelling (`<score>` vs `<0-100>`, `<Yes\|No>` vs `<Yes \| No>`) | same |
+| Final-report 55-word ELI18 cap | Shared presentation rule of the autonomous chains | `validate-issue-loop`, `fable-validate-loop`, `validate-fableplan-loop`, `fable-validate-fableplan-loop`, `fable-validate-fableplan`, `fableplan-loop`, `fableplan-work-on-issue`, `new-issue-loop`, `fable-new-issue-loop` | Bold "Cap the whole report … 55 words, ELI18" instruction in the report step | Parenthetical scope notes ("prefix + relayed summary") and trailing phrasing | same |
 
 ## Intentional exceptions
 
@@ -67,3 +69,4 @@ If the skill review-cycle threshold and the workflow default must stay locked to
 
 ---
 Updated with LLM: Opus 5 | high | Harness: Claude Code
+Updated with LLM: Fable 5 | medium | Harness: Claude Code

--- a/tests/loop-validate-pipeline-contract.test.js
+++ b/tests/loop-validate-pipeline-contract.test.js
@@ -38,6 +38,31 @@ const VALIDATION_STOP = [
   'skills/fable-validate-fableplan/SKILL.md',
 ]
 
+// Loop skills that quote validate-issue's verdict block so they can parse it
+// without waiting on the interactive reply. validate-issue owns the canonical
+// format (placeholder spelling may differ: `<0-100>` vs `<score>`).
+const VERDICT_TEMPLATE_OWNER = 'skills/validate-issue/SKILL.md'
+const VERDICT_TEMPLATE_CONSUMERS = [
+  'skills/validate-issue-loop/SKILL.md',
+  'skills/fable-validate-loop/SKILL.md',
+  'skills/validate-fableplan-loop/SKILL.md',
+  'skills/fable-validate-fableplan-loop/SKILL.md',
+  'skills/fable-validate-fableplan/SKILL.md',
+]
+
+// Final-report presentation rule every autonomous chain ends with.
+const REPORT_CAP = [
+  'skills/validate-issue-loop/SKILL.md',
+  'skills/fable-validate-loop/SKILL.md',
+  'skills/validate-fableplan-loop/SKILL.md',
+  'skills/fable-validate-fableplan-loop/SKILL.md',
+  'skills/fable-validate-fableplan/SKILL.md',
+  'skills/fableplan-loop/SKILL.md',
+  'skills/fableplan-work-on-issue/SKILL.md',
+  'skills/new-issue-loop/SKILL.md',
+  'skills/fable-new-issue-loop/SKILL.md',
+]
+
 const INVENTORY = 'docs/contract-inventory.md'
 
 /** Strip YAML frontmatter so description: keywords cannot satisfy procedure rules. */
@@ -70,6 +95,9 @@ const texts = Object.fromEntries(
         ...ALWAYS_PLAN,
         ...DUPLICATE_CONVERGENCE,
         ...VALIDATION_STOP,
+        VERDICT_TEMPLATE_OWNER,
+        ...VERDICT_TEMPLATE_CONSUMERS,
+        ...REPORT_CAP,
         INVENTORY,
       ]),
     ].map(async (path) => [path, await read(path)]),
@@ -139,6 +167,37 @@ describe('loop/validate pipeline contract', () => {
         hasStopTableRow(body, /existing PR|already addressing|already implements/i),
         `${path}: STOP+existing-PR row`,
       ).toBe(true)
+    }
+  })
+
+  test('verdict-block template stays parseable in every loop that quotes it', () => {
+    // One template line must co-locate every field the loops parse. Placeholder
+    // spelling may vary (`<score>` vs `<0-100>`, `<Yes|No>` vs `<Yes | No>`);
+    // a missing or renamed field breaks the loops' verdict parsing.
+    const fieldPatterns = [
+      /Update issue description\? <Yes ?\| ?No>/,
+      /Complexity: <[^>]+>\/100/,
+      /Capability <k>/,
+      /Volume <v>/,
+      /fableplan: <yes\|no>/,
+      /Scope: <OK \| too large — split\/umbrella\/narrow>/,
+    ]
+    for (const path of [VERDICT_TEMPLATE_OWNER, ...VERDICT_TEMPLATE_CONSUMERS]) {
+      const body = procedureBody(texts[path])
+      const templateLine = body
+        .split('\n')
+        .find((line) => /Update issue description\?/.test(line) && /Complexity:/.test(line))
+      expect(templateLine, `${path}: verdict template line`).toBeDefined()
+      for (const pattern of fieldPatterns) {
+        expect(templateLine, `${path}: ${pattern}`).toMatch(pattern)
+      }
+    }
+  })
+
+  test('every autonomous chain caps its final report at 55 words ELI18', () => {
+    for (const path of REPORT_CAP) {
+      const body = procedureBody(texts[path])
+      expect(body, path).toMatch(/\*\*Cap the whole report[^\n]*55 words, ELI18\*\*/)
     }
   })
 


### PR DESCRIPTION
## Summary
- Add two semantic guards to `tests/loop-validate-pipeline-contract.test.js`: (1) the verdict-block template that 5 loop skills quote and parse must keep every parsed field co-located on one line, matched against the canonical format in `validate-issue`; (2) the "Cap the whole report at 55 words, ELI18" rule must stay present in all 9 autonomous chain skills.
- Record both rules as new rows in `docs/contract-inventory.md` with owner, consumers, required semantics, and allowed divergence.

## Design note
The original proposal was to extract these blocks into shared reference files. That conflicts with the repo's contract design: the existing tests require stop semantics in each skill's procedure body, so an autonomous loop carries its own stop conditions instead of depending on an optional file read. The inventory also states there is no generator for SKILL.md prose. This PR therefore guards the copies rather than moving them.

## Verification
- `bun test` — 132 pass, 0 fail.
- Mutation check: changing "55 words" to "80 words" in `fableplan-loop` and deleting the `fableplan:` field from `validate-issue-loop`'s template both fail the new tests; restoring the files returns the suite to green.

## Plain simple English
Nine automation skills repeat two important text blocks. If one copy changes and the others do not, the automation can break. This change adds tests that compare all copies. When a copy drifts, the tests fail and show the file.

---
Created with LLM: Fable 5 | medium | Harness: Claude Code

https://claude.ai/code/session_01KM6HNnzLmDhbvsBt6ZUhZv