### PR TITLE
test(contracts): guard docs-sync and release procedure copies [C2, Fable 5, medium]

### DIFF
--- a/tests/sync-docs-release-contract.test.js
+++ b/tests/sync-docs-release-contract.test.js
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test'
+
+/**
+ * Semantic guard for the docs-sync / release procedure, which exists in three
+ * independently-consumed copies: two local runner agents (agents/*.md, installed
+ * by bin/install.mjs) and the CI prompt (templates/claude-workflow/prompts/
+ * sync-docs-release.md, fetched standalone by consumer repos' Actions runs).
+ * The copies cannot reference each other at run time, so drift is guarded here.
+ * Checks shared semantics, not exact prose.
+ *
+ * Known, unguarded divergence: the CLAUDE.md size-cap numbers differ today
+ * (CI prompt: condense over 40000 bytes back under 38000; local runner:
+ * condense over 35000 back under 30000). Unify or document before guarding.
+ */
+const root = new URL('../', import.meta.url)
+const read = (path) => Bun.file(new URL(path, root)).text()
+
+const CI_PROMPT = 'templates/claude-workflow/prompts/sync-docs-release.md'
+const SYNC_RUNNER = 'agents/sync-docs-runner.md'
+const RELEASE_RUNNER = 'agents/create-release-runner.md'
+
+const SYNC_COPIES = [CI_PROMPT, SYNC_RUNNER]
+const RELEASE_COPIES = [CI_PROMPT, RELEASE_RUNNER]
+
+const texts = Object.fromEntries(
+  await Promise.all(
+    [CI_PROMPT, SYNC_RUNNER, RELEASE_RUNNER].map(async (path) => [path, await read(path)]),
+  ),
+)
+
+describe('sync-docs / release contract', () => {
+  test('docs-sync copies find a docs-sync baseline and range from it', () => {
+    for (const path of SYNC_COPIES) {
+      const text = texts[path]
+      expect(text, path).toMatch(/baseline/i)
+      expect(text, path).toMatch(/baseline.?\.\.\.?HEAD|<last-sync-sha>\.\.HEAD/i)
+    }
+  })
+
+  test('docs-sync copies state the bidirectional rule and its verification gate', () => {
+    for (const path of SYNC_COPIES) {
+      const text = texts[path]
+      expect(text, path).toMatch(/bidirectional/i)
+      expect(text, path).toMatch(/delete or correct|remove or correct/i)
+      expect(text, path).toMatch(/never remove a claim you.{0,20}(have not|haven't) (confirmed|verified)/i)
+    }
+  })
+
+  test('docs-sync copies forbid creating new top-level docs during a sync', () => {
+    for (const path of SYNC_COPIES) {
+      expect(texts[path], path).toMatch(
+        /(must not create|never create) (either|one|a new top-level doc)/i,
+      )
+    }
+  })
+
+  test('release copies never force-overwrite an existing tag', () => {
+    for (const path of RELEASE_COPIES) {
+      expect(texts[path], path).toMatch(/(never|do not) force-overwrite/i)
+    }
+  })
+
+  test('release copies use generated release notes and real tag inspection', () => {
+    for (const path of RELEASE_COPIES) {
+      const text = texts[path]
+      expect(text, path).toMatch(/--generate-notes/)
+      expect(text, path).toMatch(/git tag.{0,30}-v:refname/)
+      expect(text, path).toMatch(/never rely on memory/i)
+    }
+  })
+
+  test('CI prompt completes history and tags before any range analysis', () => {
+    // CI checkouts are shallow; the local runners never need this.
+    const text = texts[CI_PROMPT]
+    expect(text).toMatch(/--unshallow/)
+    expect(text).toMatch(/--tags/)
+  })
+})

--- a/tests/sync-docs-release-contract.test.js
+++ b/tests/sync-docs-release-contract.test.js
@@ -27,11 +27,14 @@ const texts = Object.fromEntries(
     [CI_PROMPT, SYNC_RUNNER, RELEASE_RUNNER].map(async (path) => [path, await read(path)]),
   ),
 )
+const normalized = Object.fromEntries(
+  Object.entries(texts).map(([path, source]) => [path, source.replace(/\s+/g, ' ')]),
+)
 
 describe('sync-docs / release contract', () => {
   test('docs-sync copies find a docs-sync baseline and range from it', () => {
     for (const path of SYNC_COPIES) {
-      const text = texts[path]
+      const text = normalized[path]
       expect(text, path).toMatch(/baseline/i)
       expect(text, path).toMatch(/baseline.?\.\.\.?HEAD|<last-sync-sha>\.\.HEAD/i)
     }
@@ -39,7 +42,7 @@ describe('sync-docs / release contract', () => {
 
   test('docs-sync copies state the bidirectional rule and its verification gate', () => {
     for (const path of SYNC_COPIES) {
-      const text = texts[path]
+      const text = normalized[path]
       expect(text, path).toMatch(/bidirectional/i)
       expect(text, path).toMatch(/delete or correct|remove or correct/i)
       expect(text, path).toMatch(/never remove a claim you.{0,20}(have not|haven't) (confirmed|verified)/i)
@@ -48,7 +51,7 @@ describe('sync-docs / release contract', () => {
 
   test('docs-sync copies forbid creating new top-level docs during a sync', () => {
     for (const path of SYNC_COPIES) {
-      expect(texts[path], path).toMatch(
+      expect(normalized[path], path).toMatch(
         /(must not create|never create) (either|one|a new top-level doc)/i,
       )
     }
@@ -56,13 +59,13 @@ describe('sync-docs / release contract', () => {
 
   test('release copies never force-overwrite an existing tag', () => {
     for (const path of RELEASE_COPIES) {
-      expect(texts[path], path).toMatch(/(never|do not) force-overwrite/i)
+      expect(normalized[path], path).toMatch(/(never|do not) force-overwrite/i)
     }
   })
 
   test('release copies use generated release notes and real tag inspection', () => {
     for (const path of RELEASE_COPIES) {
-      const text = texts[path]
+      const text = normalized[path]
       expect(text, path).toMatch(/--generate-notes/)
       expect(text, path).toMatch(/git tag.{0,30}-v:refname/)
       expect(text, path).toMatch(/never rely on memory/i)
@@ -71,7 +74,7 @@ describe('sync-docs / release contract', () => {
 
   test('CI prompt completes history and tags before any range analysis', () => {
     // CI checkouts are shallow; the local runners never need this.
-    const text = texts[CI_PROMPT]
+    const text = normalized[CI_PROMPT]
     expect(text).toMatch(/--unshallow/)
     expect(text).toMatch(/--tags/)
   })


### PR DESCRIPTION
## Summary
- Add `tests/sync-docs-release-contract.test.js`: a semantic guard over the three copies of the docs-sync / release procedure — `agents/sync-docs-runner.md`, `agents/create-release-runner.md`, and `templates/claude-workflow/prompts/sync-docs-release.md`.
- Guarded shared rules: docs-sync baseline and `baseline..HEAD` range, bidirectional sync with the never-remove-unverified-claims gate, no new top-level docs during a sync, never force-overwrite an existing tag, `--generate-notes`, real tag inspection, and the CI-only `--unshallow`/`--tags` step.

## Design note
The original proposal was to make the CI prompt reference the runner agents. That is infeasible: the prompt is fetched standalone by consumer repos' GitHub Actions runs, where the agent files do not exist. The duplication is load-bearing, so this PR guards it instead — the same approach the repo already uses for the pr-review-format copies.

Known divergence left unguarded and documented in the test header: the CLAUDE.md size-cap numbers differ (CI prompt condenses over 40000 bytes back under 38000; the local runner condenses over 35000 back under 30000). Unifying them needs a product call.

## Verification
- `bun test` — 136 pass, 0 fail.
- Mutation check: weakening the force-overwrite rule in `create-release-runner.md` and dropping "bidirectionally" from the CI prompt both fail the new tests; restoring returns the suite to green.

## Plain simple English
One procedure for doc updates and releases lives in three files. The files cannot point to each other, because one runs alone in CI. This change adds a test that makes sure the important rules stay the same in all three files.

---
Created with LLM: Fable 5 | medium | Harness: Claude Code

https://claude.ai/code/session_01KM6HNnzLmDhbvsBt6ZUhZv