### PR TITLE
docs: document Response Style pointer pattern after #118 [C2, Composer 2.5, high]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - **No verbal irony.** Never say the opposite of what you mean for sarcasm, mock praise, or dry inversion. Write the intended meaning in plain words. Write "This design is fragile." Do not write "Oh great, another rock-solid design."
 - **No metacommentary.** Never narrate your own response or process ("Good question", "To answer this", "Let me explain", "In short", "As mentioned above", "It's worth noting"). Never describe what the response will do or just did. State the content itself.
 - **Scope of the four rules above** (stacked contrast, litotes, verbal irony, metacommentary): chat replies and every written artifact — PR bodies, commit messages, issue bodies, review comments, and docs.
+- **Skills and templates:** point at this Response Style section for shared rules; do not restate them in skill prose. Skill-specific caps (e.g. 55-word Plain simple English) stay local.
 - Never give time/effort estimates ("2–4 days"). A complexity score is a model + effort routing signal (Capability band + Volume). It gives no duration.
 - No follow-up-question menus; ask at most one, only when needed to proceed.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@
 - **No verbal irony.** Never say the opposite of what you mean for sarcasm, mock praise, or dry inversion. Write the intended meaning in plain words. Write "This design is fragile." Do not write "Oh great, another rock-solid design."
 - **No metacommentary.** Never narrate your own response or process ("Good question", "To answer this", "Let me explain", "In short", "As mentioned above", "It's worth noting"). Never describe what the response will do or just did. State the content itself.
 - **Scope of the four rules above** (stacked contrast, litotes, verbal irony, metacommentary): chat replies and every written artifact — PR bodies, commit messages, issue bodies, review comments, and docs.
+- **Skills and templates:** point at this Response Style section for shared rules; do not restate them in skill prose. Skill-specific caps (e.g. 55-word Plain simple English) stay local.
 - Never give time/effort estimates ("2–4 days"). A complexity score is a model + effort routing signal (Capability band + Volume). It gives no duration.
 - No follow-up-question menus; ask at most one, only when needed to proceed.
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Also included:
 
 - `CLAUDE.md` — an example set of global instructions these skills are tuned for (attribution footers, complexity scores, the worktree+PR workflow). Use it as a reference for your own `~/.claude/CLAUDE.md`.
 - `commands/commit.md` — a `/commit` slash command for creating well-formed git commits.
-- `docs/contract-inventory.md` — the inventory of shared rules the loop/validate skills restate (review-cycle stop, score gate, duplicate/convergence and validation stops); `bun test` fails when a covered skill drops a required rule, so the family can't drift apart silently.
+- `docs/contract-inventory.md` — inventory of shared pipeline rules loop/validate skills must carry (review-cycle stop, score gate, duplicate/convergence and validation stops); Response Style limits point at `CLAUDE.md`/`AGENTS.md` instead of restating. `bun test` fails when a covered skill drops a required rule, so the family can't drift apart silently.
 
 ## Install (with npx)
 


### PR DESCRIPTION
## Summary

- Sync docs to commit since last sync (`895806d`): #118 pointed loop/validate skills at `CLAUDE.md`/`AGENTS.md` Response Style instead of restating shared rules.
- Add the pointer invariant to `CLAUDE.md` and `AGENTS.md`.
- Update `README.md` contract-inventory bullet to match.

## Verification

- `git diff` — three doc files only, surgical edits.

## Plain simple English

After a recent change, skills now link to the global writing rules instead of copying them. This update writes that rule into the main agent docs and the README so future edits stay consistent.

---
Created with LLM: Composer 2.5 | high | Harness: Cursor