### PR TITLE
docs: note main-session execution for docs and release skills [C2, Composer 2.5, high]

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Every issue's first line also carries an explicit **`fableplan: yes|no`** signal
 
 | Skill | What it does |
 |-------|--------------|
-| `sync-docs` | Updates `CLAUDE.md`, `AGENTS.md`, `SKILL.md`, and `README.md` to match what recent commits actually changed. |
-| `create-release` | Cuts a version tag and publishes a GitHub release with generated notes, bumping the package version first so publish workflows fire correctly. |
-| `sync-docs-release` | The two above in sequence: sync docs, land the doc changes, then cut the release. The doc changes go onto a branch and a PR by default — it never commits them to your default branch — and it asks whether to merge that PR before releasing. |
+| `sync-docs` | Updates `CLAUDE.md`, `AGENTS.md`, `SKILL.md`, and `README.md` to match what recent commits actually changed — in your main session, so you see every edit. |
+| `create-release` | Cuts a version tag and publishes a GitHub release with generated notes in your main session, bumping the package version first so publish workflows fire correctly. |
+| `sync-docs-release` | Runs `sync-docs` and `create-release` in sequence in your main session: sync docs, land the doc changes, then cut the release. The doc changes go onto a branch and a PR by default — it never commits them to your default branch — and it asks whether to merge that PR before releasing. |
 
 ### Fable-driven skills
 


### PR DESCRIPTION
## Summary

- README skill-table rows for `sync-docs`, `create-release`, and `sync-docs-release` now state they run in the main session
- Closes the doc gap left after #121 inlined those workflows (install blurb was updated; skill descriptions were not)

## Verification

- `git diff` shows only the three README table cells changed
- Wording matches `skills/sync-docs-release/SKILL.md` ("all in the main session")

## Plain simple English

The README now says the docs-sync and release skills run in your main chat session. You see each edit and release step directly. This matches how those skills work after the inline refactor.

---
Created with LLM: Composer 2.5 | high | Harness: Cursor