### PR TITLE
feat(issueplan): add same-session issue planning [C10, GPT-5, high]

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Every issue's first line also carries an explicit **`fableplan: yes|no`** signal
 | `validate-issue-loop` | Runs `validate-issue`, applies any fixes the verdict calls for to the issue itself, then hands off to `work-on-issue-loop`. Stops instead if the issue is too large, infeasible, or already fixed elsewhere. |
 | `work-on-issue` | Implements an issue end-to-end: scans the issue thread for a posted implementation plan and builds to it (newest wins; deviations must be named in the PR), in an isolated git worktree (a separate working copy, so your main checkout stays untouched), verifies it, and opens a PR that closes the issue. |
 | `work-on-issue-loop` | Runs `work-on-issue`, requests a code review, then keeps fixing whatever the review finds until the PR gets an approval ("LGTM" — looks good to me). |
+| `issueplan` | Uses the current session's LLM to plan and build a task without a subagent. It posts the plan when an issue is referenced and asks whether to continue. |
 
 ### PR review skills
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Every issue's first line also carries an explicit **`fableplan: yes|no`** signal
 | `validate-issue-loop` | Runs `validate-issue`, applies any fixes the verdict calls for to the issue itself, then hands off to `work-on-issue-loop`. Stops instead if the issue is too large, infeasible, or already fixed elsewhere. |
 | `work-on-issue` | Implements an issue end-to-end: scans the issue thread for a posted implementation plan and builds to it (newest wins; deviations must be named in the PR), in an isolated git worktree (a separate working copy, so your main checkout stays untouched), verifies it, and opens a PR that closes the issue. |
 | `work-on-issue-loop` | Runs `work-on-issue`, requests a code review, then keeps fixing whatever the review finds until the PR gets an approval ("LGTM" — looks good to me). |
-| `issueplan` | Uses the current session's LLM to plan and build a task without a subagent. It posts the plan when an issue is referenced and asks whether to continue. |
+| `issueplan` | Uses the current session's LLM to plan and build a task without a subagent. For an issue, it posts the plan and asks whether to build. A prose task proceeds to implementation and a PR after the plan. |
 
 ### PR review skills
 

--- a/skills/issueplan/SKILL.md
+++ b/skills/issueplan/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: issueplan
-description: Use when the user wants the current large language model to plan a task in the same session before building it. Produces and checks an implementation plan without a subagent, posts it when a GitHub issue is referenced, then asks whether to continue building. Trigger on "/issueplan", "issueplan this", or "plan this issue in this session".
+description: >-
+  Use when the user wants the current large language model to plan and build a task in the same session without a subagent. When an issue is referenced, it posts the plan and asks whether to build. Without an issue, it builds and opens a pull request after presenting the plan. Trigger on "/issueplan", "issueplan this", or "plan this issue in this session".
 ---
 
 # issueplan
@@ -97,13 +98,15 @@ Show the checked plan to the user. Include the issue comment URL when step 4 pos
 
 State any attribution limitation or repository constraint that affects the plan.
 
-### 6. Ask whether to build when an issue was referenced
+### 6. Confirm issue builds or continue prose tasks
 
 Ask whether to continue building or stop after the posted plan. Use the harness question tool when one is available.
 
 End the workflow when the user stops. They can resume later with `work-on-issue`.
 
-Continue directly when the user gave no issue. Ask first only when the plan exposes a required product decision or unsafe ambiguity.
+For a task with no issue, continue directly into worktree creation, implementation, and pull request creation after presenting the checked plan.
+
+Ask first only when the plan exposes a required product decision or unsafe ambiguity.
 
 ### 7. Create an isolated git worktree
 

--- a/skills/issueplan/SKILL.md
+++ b/skills/issueplan/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: issueplan
+description: Use when the user wants the current large language model to plan a task in the same session before building it. Produces and checks an implementation plan without a subagent, posts it when a GitHub issue is referenced, then asks whether to continue building. Trigger on "/issueplan", "issueplan this", or "plan this issue in this session".
+---
+
+# issueplan
+
+Plan with the current large language model (LLM) in the current session. Keep planning and building in this session.
+
+Do not create or use a subagent during this workflow. The current agent owns every step.
+
+## Input
+
+Accept a task description and an optional GitHub issue:
+
+- Accept prose, such as "issueplan adding X to Y."
+- Accept a full issue URL, `#<N>`, bare `<N>`, or `owner/repo#N`.
+- Ask what to plan only when the task is unclear.
+
+## Steps
+
+### 1. Resolve the GitHub issue when one is referenced
+
+Fetch the issue before planning:
+
+```
+gh issue view <N> --json number,title,body,url
+```
+
+Add `-R owner/repo` for another repository. A bare command resolves against the current repository.
+
+Stop if the command fails. Do not plan from a paraphrase when the referenced issue is unavailable.
+
+Record the issue number, URL, title, and full body. Skip issue posting in step 4 when the user gave no issue.
+
+Read any `## Execution` block as a task constraint. Keep the current session model and effort for planning.
+
+### 2. Produce the plan in the current session
+
+Do not call the Agent tool, Task tool, workflow delegation, or any subagent mechanism.
+
+Inspect the repository with read-only commands. Read its instruction files and the code that controls the requested behavior.
+
+Produce a concrete, ordered implementation plan. Include:
+
+- Files to create or modify.
+- The implementation approach and build sequence.
+- Correctness risks, safety risks, and edge cases.
+- Tests and other verification.
+
+Select the best solution for correctness and safety. Ignore cost, time, token use, and code volume during solution selection.
+
+Keep the plan in clean Markdown. Make it suitable for direct use and for a GitHub issue comment.
+
+Save the plan to a temporary scratchpad immediately. Preserve its exact text for step 4 and the later build.
+
+Use the current session model and effort in attribution. Use a repository-defined fallback only when its instructions require one.
+
+Never infer unavailable attribution values. State the limitation before posting when repository instructions provide no fallback.
+
+### 3. Check the plan against the code
+
+Verify each load-bearing claim against the repository. Confirm that named files, symbols, commands, and conventions exist.
+
+Correct small errors and update the scratchpad. Tell the user what changed.
+
+Stop when the plan depends on a missing mechanism or a major false assumption. Ask the user whether to revise the task or plan.
+
+### 4. Post the plan when an issue was resolved
+
+Add this heading before the checked plan:
+
+```
+## Implementation plan (current session)
+```
+
+End the comment with the repository's required attribution footer. Use this form when the repository has no stronger rule:
+
+```
+---
+Created with LLM: <current session model> | <current session effort> | Harness: issueplan
+```
+
+Post the prepared file:
+
+```
+gh issue comment <N> --body-file <tmpfile>
+```
+
+Add `-R owner/repo` for another repository. Give the returned comment URL to the user.
+
+Skip this step when the user gave no issue. Do not create or select an issue on the user's behalf.
+
+### 5. Present the plan
+
+Show the checked plan to the user. Include the issue comment URL when step 4 posted it.
+
+State any attribution limitation or repository constraint that affects the plan.
+
+### 6. Ask whether to build when an issue was referenced
+
+Ask whether to continue building or stop after the posted plan. Use the harness question tool when one is available.
+
+End the workflow when the user stops. They can resume later with `work-on-issue`.
+
+Continue directly when the user gave no issue. Ask first only when the plan exposes a required product decision or unsafe ambiguity.
+
+### 7. Create an isolated git worktree
+
+Keep all changes out of the user's current checkout. Stop and ask how to proceed when the directory is not a git repository.
+
+Fetch the remote default branch. Create a worktree and branch from the fetched commit.
+
+Prefix both names with the current coding agent identifier. Use `cc/`, `cursor/`, or `codex/` before `issueplan/<short-task-name>`.
+
+Use the harness worktree tool when available. On Codex or Cursor, use:
+
+```
+git fetch origin <default-branch>
+git worktree add ../<repo>-issueplan-<agent>-<short-task-name> -b <agent>/issueplan/<short-task-name> origin/<default-branch>
+```
+
+Verify that the new worktree starts at `origin/<default-branch>`. Verify the working directory before every later write.
+
+### 8. Build from the plan
+
+Implement the checked plan in the worktree with the current session LLM. Do not delegate implementation to a subagent.
+
+Follow repository test, commit, push, and pull request rules. Record any plan deviation in the pull request.
+
+Remove the worktree only after repository rules permit removal.
+
+## Rules
+
+- Keep the same session and current LLM for planning and building.
+- Use no subagent at any point.
+- Post only to an issue the user referenced.
+- Preserve the checked plan for the build.
+- Follow repository instructions for attribution and git workflow.

--- a/skills/issueplan/agents/openai.yaml
+++ b/skills/issueplan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Issue Plan"
+  short_description: "Plan and build issues in the current session"
+  default_prompt: "Use $issueplan to plan and build this issue in the current session."

--- a/skills/issueplan/agents/openai.yaml
+++ b/skills/issueplan/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Issue Plan"
-  short_description: "Plan and build issues in the current session"
-  default_prompt: "Use $issueplan to plan and build this issue in the current session."
+  short_description: "Plan and build tasks in the current session"
+  default_prompt: "Use $issueplan to plan and build this task in the current session."

--- a/tests/issueplan-contract.test.js
+++ b/tests/issueplan-contract.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test'
+
+const root = new URL('../', import.meta.url)
+const read = (path) => Bun.file(new URL(path, root)).text()
+
+const [issueplan, readme] = await Promise.all([
+  read('skills/issueplan/SKILL.md'),
+  read('README.md'),
+])
+
+describe('issueplan contract', () => {
+  test('plans and builds with the current LLM in one session', () => {
+    expect(issueplan).toMatch(/current large language model.*same session/is)
+    expect(issueplan).toContain('Keep the same session and current LLM for planning and building.')
+    expect(issueplan).toContain('Use no subagent at any point.')
+    expect(issueplan).toMatch(/Do not call the Agent tool, Task tool, workflow delegation/is)
+    expect(issueplan).not.toContain('subagent_type')
+    expect(issueplan).not.toContain('model: fable')
+  })
+
+  test('keeps the issue plan and build flow', () => {
+    expect(issueplan).toContain('gh issue view <N> --json number,title,body,url')
+    expect(issueplan).toContain('Save the plan to a temporary scratchpad immediately.')
+    expect(issueplan).toContain('Check the plan against the code')
+    expect(issueplan).toContain('gh issue comment <N> --body-file <tmpfile>')
+    expect(issueplan).toContain('Ask whether to continue building or stop after the posted plan.')
+    expect(issueplan).toContain('Create an isolated git worktree')
+    expect(issueplan).toContain('Build from the plan')
+  })
+
+  test('attributes the plan to the active session', () => {
+    expect(issueplan).toContain('Created with LLM: <current session model> | <current session effort> | Harness: issueplan')
+    expect(issueplan).toContain('Never infer unavailable attribution values.')
+  })
+
+  test('is documented in the skill catalog', () => {
+    expect(readme).toContain('| `issueplan` |')
+    expect(readme).toMatch(/issueplan.*current session/is)
+  })
+})

--- a/tests/issueplan-contract.test.js
+++ b/tests/issueplan-contract.test.js
@@ -3,9 +3,10 @@ import { describe, expect, test } from 'bun:test'
 const root = new URL('../', import.meta.url)
 const read = (path) => Bun.file(new URL(path, root)).text()
 
-const [issueplan, readme] = await Promise.all([
+const [issueplan, readme, openaiYaml] = await Promise.all([
   read('skills/issueplan/SKILL.md'),
   read('README.md'),
+  read('skills/issueplan/agents/openai.yaml'),
 ])
 
 describe('issueplan contract', () => {
@@ -28,6 +29,12 @@ describe('issueplan contract', () => {
     expect(issueplan).toContain('Build from the plan')
   })
 
+  test('discloses the no-issue build path', () => {
+    expect(issueplan).toContain('Without an issue, it builds and opens a pull request after presenting the plan.')
+    expect(issueplan).toContain('For a task with no issue, continue directly into worktree creation, implementation, and pull request creation')
+    expect(readme).toContain('A prose task proceeds to implementation and a PR after the plan.')
+  })
+
   test('attributes the plan to the active session', () => {
     expect(issueplan).toContain('Created with LLM: <current session model> | <current session effort> | Harness: issueplan')
     expect(issueplan).toContain('Never infer unavailable attribution values.')
@@ -36,5 +43,17 @@ describe('issueplan contract', () => {
   test('is documented in the skill catalog', () => {
     expect(readme).toContain('| `issueplan` |')
     expect(readme).toMatch(/issueplan.*current session/is)
+  })
+
+  test('ships valid Codex agent metadata', () => {
+    const metadata = Bun.YAML.parse(openaiYaml)
+
+    expect(metadata).toEqual({
+      interface: {
+        display_name: 'Issue Plan',
+        short_description: 'Plan and build tasks in the current session',
+        default_prompt: 'Use $issueplan to plan and build this task in the current session.',
+      },
+    })
   })
 })


### PR DESCRIPTION
## Summary

- Add the `issueplan` skill for same-session planning and building.
- Preserve issue lookup, plan checks, issue posting, worktree isolation, and build continuation.
- Add Codex skill metadata, catalog documentation, and contract tests.
- Prohibit subagents throughout the workflow.

## Verification

- Skill validator: passed.
- `bun test`: 167 tests passed.
- Staged diff check: passed.

## Plain simple English

The current session can now plan and build a task. It can post the plan to a referenced issue. It uses no subagent.

---
Created with LLM: GPT-5 | high | Harness: Codex