### PR TITLE
refactor(tldr): drop the 18-year-old audience rule in favor of plain ASD-STE100 [C8, Opus 5, high]

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Every new issue records direct predecessors as `**Depends on:** #<n>[, #<n>…] 
 
 | Skill | What it does |
 |-------|--------------|
-| `tldr` | Recaps the previous answer in plain English under 55 words, written for a slightly above-average 18-year-old, one sentence per line. |
+| `tldr` | Recaps the previous answer in ASD-STE100 (Simplified Technical English) under 55 words, one sentence per line. |
 
 ### Review bot prerequisite
 

--- a/skills/tldr/SKILL.md
+++ b/skills/tldr/SKILL.md
@@ -10,11 +10,11 @@ Produce a dead-simple recap of your most recent substantive response.
 ## Rules
 
 1. **Use ASD-STE100 (Simplified Technical English) under 55 words.** Going over is a failure. Count them. Apply the Response Style rules in CLAUDE.md/AGENTS.md.
-2. **Audience: a slightly above-average 18-year-old.** Not gifted, not an expert — just a bit above average. No insider jargon, no acronyms without spelling out, no domain assumptions. Everyday STE wording only.
+2. **No jargon and no unspelled acronyms.** Use approved STE wording only. Do not assume domain knowledge.
 3. **One sentence per line, separated by a blank line.** Put two line breaks after every sentence so each stands alone. No headers, no bullet lists, no preamble like "Here's the TLDR" — just the summary itself.
 4. **Summarize the prior answer**, not the original question. If there is no prior substantive response in the conversation, say so in one line and ask what to summarize.
 5. **Keep it accurate.** Simplify, never fabricate. If the real answer has a critical caveat, keep it.
 
 ## What this means
 
-Explain the core idea as you would to a slightly above-average 18-year-old: concrete, conversational, analogy if it helps. Strip mechanism detail down to the point that matters.
+Explain the core idea in plain STE: concrete, direct, one idea per sentence. Strip mechanism detail down to the point that matters.


### PR DESCRIPTION
## Summary

The `tldr` skill carried two audience rules at once: write in ASD-STE100, and write for "a slightly above-average 18-year-old". The age target was fuzzy and added nothing that STE does not already cover.

Rule 2 now states the constraint directly — no jargon, no unspelled acronyms, no assumed domain knowledge, approved STE wording only. The "What this means" section drops the same framing.

The 55-word cap, the one-sentence-per-line layout, the summarize-the-prior-answer rule, and the accuracy rule are unchanged.

## Verification

- Read the full `skills/tldr/SKILL.md` before and after the edit.
- `grep -rn "18-year-old" --include="*.md" .` returns no hits after the change.
- Docs-only change. No code, no tests to run.

## Plain simple English

The /tldr summary rule no longer names a reader age. It now says only to write in Simplified Technical English, with no jargon and no short forms that are not spelled out. The 55-word limit and the one-sentence-per-line layout do not change.

---
Created with LLM: Opus 5 | high | Harness: Claude Code
