### PR TITLE
docs(tldr): remove repeated rules from the skill [C0, Fable 5, medium]

### DIFF
--- a/skills/tldr/SKILL.md
+++ b/skills/tldr/SKILL.md
@@ -10,7 +10,7 @@ Produce a dead-simple recap of your most recent substantive response.
 ## Rules
 
 1. **Write it as a Plain simple English block** per the Response Style rules in CLAUDE.md/AGENTS.md: ASD-STE100, under 55 words. Going over is a failure. Count them.
-2. **No jargon and no unspelled acronyms.** Do not assume domain knowledge.
+2. **Beyond STE: spell out every acronym and assume no domain knowledge.** STE permits technical names; use one only when the summary cannot work without it.
 3. **One sentence per line, separated by a blank line.** No headers, no bullet lists, no preamble like "Here's the TLDR" — just the summary itself.
 4. **Summarize the prior answer**, not the original question. If there is no prior substantive response in the conversation, say so in one line and ask what to summarize.
 5. **Keep it accurate.** Simplify, never fabricate. If the real answer has a critical caveat, keep it.

--- a/skills/tldr/SKILL.md
+++ b/skills/tldr/SKILL.md
@@ -9,12 +9,8 @@ Produce a dead-simple recap of your most recent substantive response.
 
 ## Rules
 
-1. **Use ASD-STE100 (Simplified Technical English) under 55 words.** Going over is a failure. Count them. Apply the Response Style rules in CLAUDE.md/AGENTS.md.
-2. **No jargon and no unspelled acronyms.** Use approved STE wording only. Do not assume domain knowledge.
-3. **One sentence per line, separated by a blank line.** Put two line breaks after every sentence so each stands alone. No headers, no bullet lists, no preamble like "Here's the TLDR" — just the summary itself.
+1. **Write it as a Plain simple English block** per the Response Style rules in CLAUDE.md/AGENTS.md: ASD-STE100, under 55 words. Going over is a failure. Count them.
+2. **No jargon and no unspelled acronyms.** Do not assume domain knowledge.
+3. **One sentence per line, separated by a blank line.** No headers, no bullet lists, no preamble like "Here's the TLDR" — just the summary itself.
 4. **Summarize the prior answer**, not the original question. If there is no prior substantive response in the conversation, say so in one line and ask what to summarize.
 5. **Keep it accurate.** Simplify, never fabricate. If the real answer has a critical caveat, keep it.
-
-## What this means
-
-Explain the core idea in plain STE: concrete, direct, one idea per sentence. Strip mechanism detail down to the point that matters.

--- a/skills/tldr/SKILL.md
+++ b/skills/tldr/SKILL.md
@@ -9,8 +9,6 @@ Produce a dead-simple recap of your most recent substantive response.
 
 ## Rules
 
-1. **Write it as a Plain simple English block** per the Response Style rules in CLAUDE.md/AGENTS.md: ASD-STE100, under 55 words. Going over is a failure. Count them.
-2. **No jargon and no unspelled acronyms.** Do not assume domain knowledge.
-3. **One sentence per line, separated by a blank line.** No headers, no bullet lists, no preamble like "Here's the TLDR" — just the summary itself.
-4. **Summarize the prior answer**, not the original question. If there is no prior substantive response in the conversation, say so in one line and ask what to summarize.
-5. **Keep it accurate.** Simplify, never fabricate. If the real answer has a critical caveat, keep it.
+1. **Write it as a Plain simple English block** per the Response Style rules in CLAUDE.md/AGENTS.md, one sentence per line separated by a blank line. No jargon, no unspelled acronyms, no assumed domain knowledge. No headers, no bullet lists, no preamble like "Here's the TLDR" — just the summary itself.
+2. **Summarize the prior answer**, not the original question. If there is no prior substantive response in the conversation, say so in one line and ask what to summarize.
+3. **Keep critical caveats.** Simplify the answer without dropping a caveat that changes what the reader should do.

--- a/skills/tldr/SKILL.md
+++ b/skills/tldr/SKILL.md
@@ -10,7 +10,7 @@ Produce a dead-simple recap of your most recent substantive response.
 ## Rules
 
 1. **Write it as a Plain simple English block** per the Response Style rules in CLAUDE.md/AGENTS.md: ASD-STE100, under 55 words. Going over is a failure. Count them.
-2. **Beyond STE: spell out every acronym and assume no domain knowledge.** STE permits technical names; use one only when the summary cannot work without it.
+2. **No jargon and no unspelled acronyms.** Do not assume domain knowledge.
 3. **One sentence per line, separated by a blank line.** No headers, no bullet lists, no preamble like "Here's the TLDR" — just the summary itself.
 4. **Summarize the prior answer**, not the original question. If there is no prior substantive response in the conversation, say so in one line and ask what to summarize.
 5. **Keep it accurate.** Simplify, never fabricate. If the real answer has a critical caveat, keep it.


### PR DESCRIPTION
## Summary

- The five rules merge into three: one format rule (Plain simple English block, line format, no jargon or preamble), one target rule (summarize the prior answer), one caveat rule.
- The 55-word cap now appears only in the description line and via the Plain simple English definition; the "never fabricate" clause is removed because the global Integrity section owns it.
- The "What this means" section repeated the rules and is removed.

## Verification

- Read the edited file; every remaining constraint is skill-specific, and each dropped clause is owned by the description line, the Plain simple English definition, or the global Integrity rule.
- Score: 0/100 — Capability 0; Volume 0 (one localized documentation file, no risk).

## Plain simple English

The tldr instruction file said some rules more than once, and some rules repeated global rules that always apply. We removed the repeated text and merged five rules into three. The behavior stays the same. The file is now shorter and easier to follow.

---
Updated with LLM: Fable 5 | medium | Harness: Claude Code

https://claude.ai/code/session_01Cp2a5o8a5yYtGehSk7gnHh