### PR TITLE
docs(fix-pr-review): dedupe the best-solution and footer restatements [C8, Fable 5, medium]

### DIFF
--- a/skills/fix-pr-review/SKILL.md
+++ b/skills/fix-pr-review/SKILL.md
@@ -91,9 +91,9 @@ Validation discipline (this is where fixing a review goes wrong):
 - **Safety carve-out:** any finding touching money, data integrity, security, or an auto-protective mechanism gets fixed or escalated to the user even at low confidence — never silently dropped as Refuted unless you can prove from code it's a non-issue.
 - **CI Failures validate differently — there's no reviewer to be wrong, only the log to explain.** Read the failing step's actual error/assertion, not just the job name. ✅ Confirmed if the failure traces to this PR's diff — fix it (and reproduce the exact failing command locally where feasible, so step 6's verification actually exercises it). ❌ Refuted only with evidence it's *not* this PR's doing — pre-existing on `<baseRefName>` (check CI history / reproduce on base) or a one-off infra flake (timeout/network blip unrelated to any path this PR touches) — don't patch around it; note it in the disposition and flag it to the user, since a flaky or broken base branch is worth knowing about independent of this PR.
 
-**For every ❓ Judgment finding, do the analysis the reviewer couldn't and implement the result — don't hand the tradeoff back.** Trace the code, enumerate the viable approaches, and derive the **absolute-best solution**, evaluated as if cost, effort, time, resources, token spend, and code volume were unlimited — they are *not* factors and must never narrow the option space. The only things that can override "best" are correctness and safety. Choose the most correct, most robust design even when it's far more work, then implement it (step 6) in this same run. Do **not** pause to ask the user. Record the decision in the disposition comment — the chosen solution, the code-grounded reasoning (`file:line`), and the rejected alternatives in one line each — so the human can override after the fact if they disagree.
+**For every ❓ Judgment finding, do the analysis the reviewer couldn't and implement the result — don't hand the tradeoff back.** Trace the code, enumerate the viable approaches, and derive the **absolute-best solution** per the global "absolute best solution" rule in CLAUDE.md/AGENTS.md, then implement it (step 6) in this same run. Do **not** pause to ask the user. Record the decision in the disposition comment — the chosen solution, the code-grounded reasoning (`file:line`), and the rejected alternatives in one line each — so the human can override after the fact if they disagree.
 
-This same absolute-best-solution standard governs `Recommended Optional` improvements: implement them too, choosing the best design with cost/effort/time/resources treated as non-factors.
+The same standard governs `Recommended Optional` improvements: implement them too.
 
 ### 5. Decide whether to delegate implementation
 
@@ -109,7 +109,7 @@ Otherwise, delegate **only when the session is already long** — enough context
 Implement every finding that calls for a change: ✅ Confirmed, ⚠️ Partial (the true part), ❓ Judgment (the absolute-best solution you derived), and `Recommended Optional` (best-solution standard). Skip only ❌ Refuted and `Create Follow-up Issue` items.
 
 - Read the surrounding code and follow existing conventions before editing.
-- Keep each fix scoped to its finding; don't smuggle in unrelated refactors. (Scope ≠ minimalism: for Judgment and Optional items, pick the *best* design, not the smallest diff — correctness and robustness outrank brevity.)
+- Keep each fix scoped to its finding; don't smuggle in unrelated refactors. (Scope ≠ minimalism: the step 4 best-solution standard still applies to Judgment and Optional items.)
 - After all fixes, **verify**: run the project's tests/build/lint (check the repo's `CLAUDE.md` / `package.json` / Makefile for the commands — e.g. `bun test`, `go test -race ./...`, `bun run build`). Evidence before assertions: do not claim a fix works without running verification, and report any failures honestly rather than papering over them.
 - If a fix turns out infeasible or reveals the finding was actually Refuted, move it to the Refuted bucket with the reason.
 
@@ -150,7 +150,7 @@ Commit message: a concise summary of what review findings were addressed (refere
 Updated with LLM: <current model> | <effort> | Harness: Claude Code
 ```
 
-Fill `<current model>` (e.g. `Opus 5`) and `<effort>` (`high` by default). Per the user's workflow, never include time/effort estimates in the message body.
+The global LLM Attribution Footer rule in CLAUDE.md/AGENTS.md owns the field values; this skill only fixes the verb to **Updated**.
 
 ### 9. Post the disposition comment back to the PR
 

--- a/skills/fix-pr-review/red-flags-and-mistakes.md
+++ b/skills/fix-pr-review/red-flags-and-mistakes.md
@@ -18,7 +18,7 @@ Reference for SKILL.md: the stop conditions and the failure patterns this skill 
 | Branch can't fast-forward to its upstream head | Stop — the branch diverged; surface to the user, don't force anything |
 | PR is from a fork | Check out with `gh pr checkout` and push to the tracked upstream — `origin` is the wrong remote for the head branch |
 | All findings refuted | Still post the disposition comment with the rebuttals and request re-review — don't silently no-op |
-| `Requires Human Review` item | Prefer the item's **Recommended proposed solution:** when present; still verify against absolute-best (cost/effort/time/resources ignored; only correctness and safety override). Implement the chosen solution; document the decision + rejected alternatives in the comment so the user can override. Never pause for confirmation, punt the bare tradeoff, or guess blindly |
+| `Requires Human Review` item | Prefer the item's **Recommended proposed solution:** when present; still verify against the step 4 best-solution standard. Implement the chosen solution; document the decision + rejected alternatives in the comment so the user can override. Never pause for confirmation, punt the bare tradeoff, or guess blindly |
 | Tests/build fail after fixes | Report the failure; don't push or claim success |
 | PR is `CONFLICTING` with the base branch | Resolve via step 7 (merge base into head, reconcile intent of both sides, re-verify) — never rebase a pushed PR branch, never resolve by blanket `ours`/`theirs`, never leave an approved PR unmergeable |
 | Conflict sides are irreconcilable in intent (esp. money/data/security/auto-protective code) | Stop and surface to the user instead of guessing a resolution |
@@ -36,7 +36,7 @@ Reference for SKILL.md: the stop conditions and the failure patterns this skill 
 - **Dropping a refuted finding silently.** Push back on the record in the comment with a code-grounded reason — that's how the reviewer learns it was wrong.
 - **Committing to the base branch.** Fixes land on the PR head branch only.
 - **Skipping verification before push.** Run the tests/build; report real results.
-- **Pausing or punting on a judgment call.** Do the analysis the reviewer couldn't and *implement* the absolute-best solution (cost/effort/time/resources are not factors; only correctness and safety override it); document it for override. Don't stop to ask, don't relay the bare tradeoff, don't guess blindly.
-- **Skipping the optional improvements.** `Recommended Optional` items get implemented to the same best-solution standard, not deferred.
+- **Pausing or punting on a judgment call.** Do the analysis the reviewer couldn't and *implement* the absolute-best solution (step 4 standard); document it for override. Don't stop to ask, don't relay the bare tradeoff, don't guess blindly.
+- **Skipping the optional improvements.** `Recommended Optional` items get implemented to the same standard, not deferred.
 - **Ignoring merge conflicts because "the review is addressed".** An unmergeable PR isn't done — check `mergeable` in step 0 and resolve conflicts in step 7, with the same verification and safety discipline as findings.
 - **Bundling the re-review trigger into the disposition comment.** Keep `@claude review` as its own comment so the bot fires reliably.


### PR DESCRIPTION
## Summary

- The absolute-best-solution rule was restated roughly nine times across `skills/fix-pr-review/SKILL.md` and `red-flags-and-mistakes.md`; it now appears in full only in step 4, which points at the global CLAUDE.md/AGENTS.md rule, and the other sites carry one-line pointers to that standard.
- The commit-footer instructions no longer restate the global LLM Attribution Footer field values or the no-time-estimates rule; the skill keeps only its unique constraint (the **Updated** verb).

## Verification

- `bun test`: 234 pass, 0 fail.
- Read both edited files; every step, red flag, and common mistake keeps its behavior — only the repeated rule text collapsed into pointers.
- Score: 8/100 — Capability 0; Volume 8 (Scope 2: two documentation files in one skill; Verification 2: repo contract tests).

## Plain simple English

The fix-pr-review instruction files said the same "always pick the best solution" rule many times, and repeated the standard commit-footer rules. We keep one full statement and replace the copies with short pointers. The behavior stays the same. The files are shorter and easier to maintain.

---
Updated with LLM: Fable 5 | medium | Harness: Claude Code

https://claude.ai/code/session_01Cp2a5o8a5yYtGehSk7gnHh