### PR TITLE
docs(skills): dedupe restated rules in fix-pr-review and work-on-issue [C2, Fable 5, high]

### DIFF
--- a/skills/fix-pr-review/SKILL.md
+++ b/skills/fix-pr-review/SKILL.md
@@ -49,7 +49,7 @@ State what you picked (authors + timestamps) so the user can confirm it's the ri
 
 **Note whether the collected set contains any blocking finding** — a `Needs Fixing` or `Requires Human Review` item from any review, an inline thread asserting a real defect (classified in step 3), or any failing CI check from step 2. This drives the re-review routing in step 10.
 
-**If the only new feedback is `LGTM` with no blocking sections:** there's nothing blocking, but still address any non-blocking items the review raised — implement each `Recommended Optional` item with the absolute-best-solution standard (step 6), and file each `Create Follow-up Issue` item as a GitHub issue (complete body per its step 3 bar — never a stub). Don't invent work the review never raised; if the feedback is a bare `LGTM` with no finding items at all and no open inline threads — a `**Verification limitation:**` line is not a finding and does not count — report that the PR is approved and stop, naming every `**Verification limitation:**` line from that review in the step-11 report (omit the field when none) — unless step 0 flagged merge conflicts, in which case still run step 7 (resolve, verify, push, disposition comment) so the approved PR is actually mergeable.
+**If the only new feedback is `LGTM` with no blocking sections:** there's nothing blocking, but still address any non-blocking items the review raised — implement each `Recommended Optional` item with the absolute-best-solution standard (step 6), and file each `Create Follow-up Issue` item as a GitHub issue (complete body per its step 3 bar — never a stub). Don't invent work the review never raised; if the feedback is a bare `LGTM` with no finding items at all and no open inline threads — a `**Verification limitation:**` line does not count (step 3 owns that rule) — report that the PR is approved and stop, naming every `**Verification limitation:**` line from that review in the step-11 report (omit the field when none) — unless step 0 flagged merge conflicts, in which case still run step 7 (resolve, verify, push, disposition comment) so the approved PR is actually mergeable.
 
 ### 2. Fetch failing CI checks
 
@@ -71,7 +71,7 @@ Parse all collected feedback — structured reviews, inline diff threads, and fa
 
 A `**Verification limitation:**` line is **not a finding.** Skip every such line when classifying — do not bucket it, dispose it, rebut it, or treat it as remaining work. It does not block the approved-and-stop path and does not count toward "findings still listed."
 
-For free-form feedback with no sections — including inline diff comments — classify each point yourself into the same four buckets by its substance, still excluding `**Verification limitation:**` lines. Keep each finding atomic — split compound feedback ("fix X and also Y") into separate findings so each gets its own verdict. When the same defect is raised by more than one source — reviewer, thread, *or* a CI Failure finding from step 2 (e.g. a reviewer flags "this breaks the type check" while the type-check job is already `bucket: fail`) — merge into one finding and note all sources, including the check name alongside the reviewer(s).
+For free-form feedback with no sections — including inline diff comments — classify each point yourself into the same four buckets by its substance. Keep each finding atomic — split compound feedback ("fix X and also Y") into separate findings so each gets its own verdict. When the same defect is raised by more than one source — reviewer, thread, *or* a CI Failure finding from step 2 (e.g. a reviewer flags "this breaks the type check" while the type-check job is already `bucket: fail`) — merge into one finding and note all sources, including the check name alongside the reviewer(s).
 
 ### 4. Re-validate each finding against the code (the core step)
 
@@ -82,7 +82,7 @@ For **every** finding — including ones that read as obviously correct — trac
 | ✅ **Confirmed** | Code at `file:line` matches the finding; the defect/improvement is real | Fix it (step 6) |
 | ❌ **Refuted** | Code does not do what the finding claims, or the suggested change would itself be wrong/regressive | Do **not** change; record a one-line, code-grounded rebuttal for the reply |
 | ⚠️ **Partial** | Real but narrower/broader than stated, or true only on one path | Fix the true part; note the correction |
-| ❓ **Judgment** | A real tradeoff or a decision the reviewer couldn't make (most `Requires Human Review` items) | Derive the absolute-best solution and **implement it** (see below) — don't pause, don't guess blindly, don't punt empty-handed. When the finding includes **Recommended proposed solution:**, treat that as the reviewer's preferred option: verify it against the code and absolute-best standard, then implement it if it holds (or implement the better alternative and explain why in the disposition). |
+| ❓ **Judgment** | A real tradeoff or a decision the reviewer couldn't make (most `Requires Human Review` items) | Derive the absolute-best solution and **implement it** (the paragraph below owns the rule). When the finding includes **Recommended proposed solution:**, treat that as the reviewer's preferred option: verify it against the code and absolute-best standard, then implement it if it holds (or implement the better alternative and explain why in the disposition). |
 
 Validation discipline (this is where fixing a review goes wrong):
 - **Read the body, not just the cited line.** A name states intent; open the function and trace the conditional fully before agreeing.
@@ -109,7 +109,7 @@ Otherwise, delegate **only when the session is already long** — enough context
 Implement every finding that calls for a change: ✅ Confirmed, ⚠️ Partial (the true part), ❓ Judgment (the absolute-best solution you derived), and `Recommended Optional` (best-solution standard). Skip only ❌ Refuted and `Create Follow-up Issue` items.
 
 - Read the surrounding code and follow existing conventions before editing.
-- Keep each fix scoped to its finding; don't smuggle in unrelated refactors. (Scope ≠ minimalism: the step 4 best-solution standard still applies to Judgment and Optional items.)
+- Keep each fix scoped to its finding; don't smuggle in unrelated refactors.
 - After all fixes, **verify**: run the project's tests/build/lint (check the repo's `CLAUDE.md` / `package.json` / Makefile for the commands — e.g. `bun test`, `go test -race ./...`, `bun run build`). Evidence before assertions: do not claim a fix works without running verification, and report any failures honestly rather than papering over them.
 - If a fix turns out infeasible or reveals the finding was actually Refuted, move it to the Refuted bucket with the reason.
 
@@ -183,7 +183,7 @@ gh pr comment <N> --body "@codex luna review"
 
 ### 11. Report to the user
 
-Terse summary: which reviews/threads you acted on, counts per disposition (fixed / partial / refuted / judgment-resolved / optional / deferred), the commit SHA, verification result, and that a re-review was requested (note which model it was routed to). When the review carried any `**Verification limitation:**` lines, name each unverified source in the report even though they are not findings — omit that field when none. When the invocation carried an unrecognized argument (Input section), name it too — omit that field when none. Flag the resolved judgment calls so the user can override if they disagree — but the work is already done, not waiting on them.
+Terse summary: which reviews/threads you acted on, counts per disposition (fixed / partial / refuted / judgment-resolved / optional / deferred), the commit SHA, verification result, and that a re-review was requested (note which model it was routed to). When the review carried any `**Verification limitation:**` lines, name each unverified source in the report — omit that field when none. When the invocation carried an unrecognized argument (Input section), name it too — omit that field when none. Flag the resolved judgment calls so the user can override if they disagree — but the work is already done, not waiting on them.
 
 ## Red Flags — STOP
 

--- a/skills/fix-pr-review/SKILL.md
+++ b/skills/fix-pr-review/SKILL.md
@@ -69,7 +69,7 @@ Parse all collected feedback — structured reviews, inline diff threads, and fa
 - **Recommended Optional** — non-blocking improvement.
 - **Create Follow-up Issue** — out-of-scope, track separately. Wherever this run files one (the LGTM-only path in step 1, or the disposition's deferred section), the issue gets a complete body per the repo's issue conventions — complexity-prefixed title, problem, goal, approach, acceptance criteria, a `## Plain simple English` section under 55 words, attribution footer; `github-issue-format` owns the full rule. Never file a stub.
 
-A `**Verification limitation:**` line is **not a finding.** Skip every such line when classifying — do not bucket it, dispose it, rebut it, or treat it as remaining work. It does not block the approved-and-stop path and does not count toward "findings still listed."
+A `**Verification limitation:**` line is not a finding. Skip every such line when classifying — do not bucket it, dispose it, rebut it, or treat it as remaining work. It does not block the approved-and-stop path and does not count toward "findings still listed."
 
 For free-form feedback with no sections — including inline diff comments — classify each point yourself into the same four buckets by its substance. Keep each finding atomic — split compound feedback ("fix X and also Y") into separate findings so each gets its own verdict. When the same defect is raised by more than one source — reviewer, thread, *or* a CI Failure finding from step 2 (e.g. a reviewer flags "this breaks the type check" while the type-check job is already `bucket: fail`) — merge into one finding and note all sources, including the check name alongside the reviewer(s).
 

--- a/skills/work-on-issue/SKILL.md
+++ b/skills/work-on-issue/SKILL.md
@@ -112,12 +112,10 @@ Only after verification passes:
 
 ```bash
 git status                    # review BEFORE staging — any stray artifacts, logs, local config?
-git add -A                    # only if status showed nothing unrelated; otherwise stage files explicitly
+git add -A                    # only if status showed nothing unrelated; otherwise stage the intended files by name and leave the strays out
 git commit -F <msg-file>
 git push -u origin <branch>   # the worktree's <prefix>/issue-<N>-<slug> branch
 ```
-
-If `git status` shows anything unrelated to the change, don't `add -A` — stage the intended files by name and leave the strays out.
 
 Commit message: a concise summary of the change, referencing the issue (match the repo's commit-title convention — e.g. `feat(#<N>): …` / `fix(#<N>): …` if the repo uses it). This is new work, so the footer uses the **Created** verb. **Honor the repo's footer convention (its `CLAUDE.md` takes precedence over this default)**:
 
@@ -160,17 +158,17 @@ Terse summary: the worktree/branch, what you implemented (one or two lines), the
 |-----------|--------|
 | About to implement on the default branch or a divergent checked-out branch | Stop — enter the isolated worktree first (step 1) |
 | Caller supplies invalid, duplicate, missing, ambiguous, cross-repository, or changed `baseRefs`; multiple bases conflict; or a verified predecessor is not an ancestor of the integration base | Stop blocked, aborting any pending merge first — never fall back to the default branch or guess a replacement |
-| Fresh worktree's HEAD doesn't match the resolved base | Reset only the just-created, commit-free worktree to the verified base; never reset a re-entered worktree |
+| Fresh worktree's HEAD doesn't match the resolved base | Reset per step 1 — only the just-created, commit-free worktree, never a re-entered one |
 | Worktree for this issue already exists | Enter it by `path`; don't create a duplicate |
 | Issue lives in a different repo than the current checkout | Stop — work in a clone of that repo, or tell the user which repo to check out |
 | Issue is already closed, or an open PR already addresses it | Stop at step 0, before a worktree exists — report the closed issue or surface the PR; continue only when that PR is this session's own branch |
-| Issue thread already carries an implementation plan | Adopt the newest one (step 0) and build to it — never re-derive an approach the plan already settled; name every deviation in the PR body, and add `, fableplan` to the title bracket only when that plan is Fable-authored |
-| Adopted plan conflicts with the traced code, a newer maintainer comment, or an invariant | Follow the code / the newer instruction / the safe design — only step 2's three overrides justify deviating — and state the deviation in the PR body |
+| Issue thread already carries an implementation plan | Adopt the newest one (step 0) and build to it (step 2) — never re-derive an approach the plan already settled |
+| Adopted plan conflicts with the traced code, a newer maintainer comment, or an invariant | Deviate per step 2's three overrides — nothing else justifies it — and state the deviation in the PR body |
 | Issue description conflicts with what the code actually does, or its sketch was ⚠️/❌ in validation | Trust the traced code and implement the optimal direction for this repo, not the original sketch; note the discrepancy in the PR body |
 | Fix touches money / data integrity / security / auto-protective logic | Implement the safest correct design from first principles; verify the invariant isn't violated |
 | Anywhere the default branch is needed (fetch or PR `--base`) | Detect it (`gh repo view --json defaultBranchRef`), re-detecting inline where used — shell variables don't persist between commands |
 | Tempted to skip or soften tests because "it's a small change" | Small changes break too; write the regression test and watch it fail on the unfixed code (red → green) |
 | Tests/build/lint fail locally | Fix or surface it — never commit, push, or claim success on a failing tree |
 | `git status` shows files unrelated to the change | Don't `git add -A` — stage the intended files by name |
-| Writing the PR body | Follow step 6 — `## Summary` / verification first, `Closes #<N>` (without it the merge doesn't resolve the issue), `## Plain simple English`, footer |
-| Tempted to trigger an `@claude` review, wait on CI, or pause to ask the user mid-flow | Don't — implement, verify, commit, push, open the PR, then report; the skill ends with the open PR, and review requests belong to the caller |
+| Writing the PR body | Follow step 6 — `Closes #<N>` is what makes the merge resolve the issue |
+| Tempted to trigger an `@claude` review, wait on CI, or pause to ask the user mid-flow | Don't — the skill ends with the open PR, and review requests belong to the caller (step 7) |


### PR DESCRIPTION
## Summary
- `skills/fix-pr-review/SKILL.md`: the `**Verification limitation:**` exclusion was stated in four places and the absolute-best-solution mandate in three. Step 3 and step 4's judgment paragraph now own each rule in full; the other mentions are short pointers. 3,666 → 3,635 words.
- `skills/work-on-issue/SKILL.md`: four guardrail rows and step 5 restated in full the plan-deviation, PR-body, review-handoff, worktree-reset, and staging rules their owner steps (1, 2, 5, 6, 7) already state. The rows now point at the owner instead. 3,368 → 3,307 words.
- No rule changed meaning; only restatements were cut.

## Verification
- Re-read each trimmed mention against its owner section to confirm every criterion still appears once in full: the limitation-line non-blocking clauses, the fableplan title-marker condition, the three plan overrides, and the commit-free reset guard all remain stated by their owners.

## Plain simple English
Two skill files said some rules three or four times each. Copies of a rule can go out of sync when the rule changes. Now each rule is written once, and the other places point to it. The skills behave the same.

---
Created with LLM: Fable 5 | high | Harness: Claude Code
https://claude.ai/code/session_01QebX1aDH4KC9gqp3264BL1