### PR TITLE
docs(tldr): state ASD-STE100 explicitly in the skill [C0, Fable 5, high]

### DIFF
--- a/skills/tldr/SKILL.md
+++ b/skills/tldr/SKILL.md
@@ -9,6 +9,6 @@ Produce a dead-simple recap of your most recent substantive response.
 
 ## Rules
 
-1. **Write it as a Plain simple English block in ASD-STE100 (Simplified Technical English)** per the Response Style rules in CLAUDE.md/AGENTS.md, one sentence per line separated by a blank line. No jargon, no unspelled acronyms, no assumed domain knowledge. No headers, no bullet lists, no preamble like "Here's the TLDR" — just the summary itself.
+1. **Write it as a Plain simple English block in ASD-STE100 (Simplified Technical English)** per the Response Style rules in CLAUDE.md/AGENTS.md, one sentence per line separated by a blank line. No headers, no bullet lists, no preamble like "Here's the TLDR" — just the summary itself.
 2. **Summarize the prior answer**, not the original question. If there is no prior substantive response in the conversation, say so in one line and ask what to summarize.
 3. **Keep critical caveats.** Simplify the answer without dropping a caveat that changes what the reader should do.

--- a/skills/tldr/SKILL.md
+++ b/skills/tldr/SKILL.md
@@ -9,6 +9,6 @@ Produce a dead-simple recap of your most recent substantive response.
 
 ## Rules
 
-1. **Write it as a Plain simple English block in ASD-STE100 (Simplified Technical English)** per the Response Style rules in CLAUDE.md/AGENTS.md, one sentence per line separated by a blank line. No headers, no bullet lists, no preamble like "Here's the TLDR" — just the summary itself.
+1. **Write it as a Plain simple English block in ASD-STE100 (Simplified Technical English)** per the Response Style rules in CLAUDE.md/AGENTS.md, one sentence per line separated by a blank line. Bullet lists are allowed. No headers, no preamble like "Here's the TLDR" — just the summary itself.
 2. **Summarize the prior answer**, not the original question. If there is no prior substantive response in the conversation, say so in one line and ask what to summarize.
 3. **Keep critical caveats.** Simplify the answer without dropping a caveat that changes what the reader should do.

--- a/skills/tldr/SKILL.md
+++ b/skills/tldr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tldr
-description: Use when the user types /tldr to get a plain-simple-English summary of the most recent response in under 55 words.
+description: Use when the user types /tldr to get a plain-simple-English summary, written in ASD-STE100, of the most recent response in under 55 words.
 ---
 
 # TLDR
@@ -9,6 +9,6 @@ Produce a dead-simple recap of your most recent substantive response.
 
 ## Rules
 
-1. **Write it as a Plain simple English block** per the Response Style rules in CLAUDE.md/AGENTS.md, one sentence per line separated by a blank line. No jargon, no unspelled acronyms, no assumed domain knowledge. No headers, no bullet lists, no preamble like "Here's the TLDR" — just the summary itself.
+1. **Write it as a Plain simple English block in ASD-STE100 (Simplified Technical English)** per the Response Style rules in CLAUDE.md/AGENTS.md, one sentence per line separated by a blank line. No jargon, no unspelled acronyms, no assumed domain knowledge. No headers, no bullet lists, no preamble like "Here's the TLDR" — just the summary itself.
 2. **Summarize the prior answer**, not the original question. If there is no prior substantive response in the conversation, say so in one line and ask what to summarize.
 3. **Keep critical caveats.** Simplify the answer without dropping a caveat that changes what the reader should do.


### PR DESCRIPTION
## Summary
- Name ASD-STE100 (Simplified Technical English) directly in the tldr skill's description and rule 1.
- Remove the jargon, acronym, and domain-knowledge bans from rule 1. The STE standard and the Response Style rules the skill points to already own them.
- Allow bullet lists. Keep the tldr-specific format rules: one sentence per line, no headers, no preamble.

## Verification
- Read the current skill on main and the edited file. The change is prose only. No code paths are affected.

## Plain simple English

The tldr command must write its summary in Simplified Technical English. The skill file did not name this standard. It also repeated rules that the standard already contains. Now the skill names the standard, removes the repeated rules, and permits bullet lists.

---
Updated with LLM: Fable 5 | high | Harness: Claude Code

https://claude.ai/code/session_0165aPkQWpoao1cb5vGSVaek