### PR TITLE
docs(skills): dedupe the new-issue family against its owner skills [C2, Fable 5, high]

### DIFF
--- a/skills/fable-new-issue-loop/SKILL.md
+++ b/skills/fable-new-issue-loop/SKILL.md
@@ -5,48 +5,14 @@ description: Use when the user asks to have a Fable 5 subagent draft and file a 
 
 # fable-new-issue-loop
 
-Chain fable-new-issue → validate-issue-loop into one autonomous run: a Fable 5 subagent drafts the issue, the main agent files it, and the loop drives it to a reviewed PR without a human in between. Identical to new-issue-loop except the front of the chain is fable-new-issue.
+Chain fable-new-issue → validate-issue-loop into one autonomous run: a Fable 5 subagent drafts the issue, the main agent files it, and the loop drives it to a reviewed PR without a human in between.
 
-**Do not skip filing a complete issue.** The downstream loop validates and implements *the issue text* — a thin or unverified draft propagates straight into the PR. Every step of fable-new-issue still runs (subagent drafting, duplicate gate, spot-check, filing); only the "offer next steps and wait" step is replaced by the handoff.
+**This skill is `new-issue-loop` with a different front of the chain.** Follow the `new-issue-loop` skill for the full procedure: the complete-issue rule, the input contract, the stop gate, the handoff to validate-issue-loop (explicit issue reference, `owner/repo#N` when filed cross-repo), the report format, and the Red Flags. Apply only the deltas below.
 
-## Input
+## Deltas from new-issue-loop
 
-Same as fable-new-issue: an optional description of what the issue should cover; with no input, derive it from the current conversation. Optionally `owner/repo` when the issue belongs elsewhere.
-
-## Steps
-
-### 1. Run fable-new-issue
-
-Invoke the `fable-new-issue` skill (Skill tool, `skill: fable-new-issue`) with the user's description (or conversation-derived scope). Let it run its full process — Fable 5 subagent draft, duplicate gate, spot-check, filing. Capture the created issue number from its report.
-
-### 2. Stop gate — cases the loop can't safely continue
-
-| Condition | Action |
-|---|---|
-| The subagent found an existing open issue/PR already covering it (no issue filed) | **STOP.** Report the duplicate and the offer to update/comment instead — whether to merge scopes is a human call. |
-| The conversation held several distinct candidates | If one clearly converged, file it and **continue the chain with it**; the unfiled candidates go in the final report. If none clearly converged, **STOP** — report the candidates and ask which to file. Never bundle, never auto-file the extras. |
-| The draft was structurally wrong and fable-new-issue paused for a human decision | **STOP.** Relay what's off — don't file or re-dispatch on your own. |
-| The scope check named unfiled follow-ups | Continue with the **core issue only**; relay the unfiled follow-ups in the final report. |
-
-Otherwise (one issue filed cleanly), continue.
-
-### 3. Hand off to validate-issue-loop
-
-Invoke the `validate-issue-loop` skill (Skill tool, `skill: validate-issue-loop`) with the issue from step 1 passed explicitly — don't let it default to "latest open issue" and risk racing another just-filed issue. If filed to a repo other than the current checkout, pass the full `owner/repo#N` reference, not the bare number. Its own scope gate (too large / infeasible / already-addressed) still applies and may stop the run; that's the designed behavior, not a failure.
-
-Validating an issue this chain just filed is not redundant: validate-issue re-traces the claims against the code independently, catching anything the Fable draft or the spot-check got wrong.
-
-### 4. Report
-
-Relay validate-issue-loop's final summary (PR URL, review cycles, verdict), prefixed with one line covering the front of the chain: issue number/URL filed (drafted by Fable 5), complexity score, and any unfiled follow-ups from step 2.
-
-**Cap the whole report at 55 words, plain simple English in ASD-STE100** — apply the Response Style rules in CLAUDE.md/AGENTS.md, written for a reader with no context on this codebase.
-
-## Red Flags — STOP
-
-| Situation | Action |
-|---|---|
-| Tempted to skip the Fable subagent and draft/file the issue yourself to go faster | Never — the draft coming from Fable 5 is the point of this skill |
-| fable-new-issue stopped on a duplicate or a structurally-wrong draft | Stop and report per step 2 — don't file anyway |
-| Tempted to hand off without an explicit issue reference | Always pass the issue from step 1 — `owner/repo#N` if filed cross-repo — "latest issue" can race |
-| validate-issue-loop's scope gate stops the run | Report its disposition faithfully — don't override and implement anyway |
+- **Step 1, front of the chain.** Invoke the `fable-new-issue` skill (Skill tool, `skill: fable-new-issue`) in place of `new-issue`. Let it run its full process (Fable 5 subagent draft, duplicate gate, spot-check, filing) and capture the created issue number from its report.
+- **Step 2, one extra stop row.** If the draft was structurally wrong and fable-new-issue paused for a human decision: **STOP.** Relay what is off. Do not file or re-dispatch on your own.
+- **Step 3, why validation still runs.** Validating an issue this chain just filed stays useful: validate-issue re-traces the claims against the code independently and catches anything the Fable draft or the spot-check got wrong.
+- **Step 4, report.** Mark the issue line as drafted by Fable 5.
+- **One extra Red Flag.** Tempted to skip the Fable subagent and draft or file the issue yourself to go faster: never. The draft coming from Fable 5 is the point of this skill.

--- a/skills/fable-new-issue-loop/SKILL.md
+++ b/skills/fable-new-issue-loop/SKILL.md
@@ -12,7 +12,13 @@ Chain fable-new-issue → validate-issue-loop into one autonomous run: a Fable 5
 ## Deltas from new-issue-loop
 
 - **Step 1, front of the chain.** Invoke the `fable-new-issue` skill (Skill tool, `skill: fable-new-issue`) in place of `new-issue`. Let it run its full process (Fable 5 subagent draft, duplicate gate, spot-check, filing) and capture the created issue number from its report.
-- **Step 2, one extra stop row.** If the draft was structurally wrong and fable-new-issue paused for a human decision: **STOP.** Relay what is off. Do not file or re-dispatch on your own.
+- **Step 2, stop gate.** new-issue-loop's stop gate applies with one extra row for the Fable draft; the effective table:
+
+| Condition | Action |
+|---|---|
+| The subagent found an existing open issue/PR already covering it (no issue filed) | **STOP.** Report the duplicate and the offer to update/comment instead — merging scopes is a human call. |
+| The conversation held several distinct candidates and none clearly converged | **STOP.** Report the candidates and ask which to file — never bundle, never auto-file the extras. |
+| The draft was structurally wrong and fable-new-issue paused for a human decision | **STOP.** Relay what is off. Do not file or re-dispatch on your own. |
 - **Step 3, why validation still runs.** Validating an issue this chain just filed stays useful: validate-issue re-traces the claims against the code independently and catches anything the Fable draft or the spot-check got wrong.
-- **Step 4, report.** Mark the issue line as drafted by Fable 5.
+- **Step 4, report.** Mark the issue line as drafted by Fable 5. **Cap the whole report at 55 words, plain simple English in ASD-STE100** — apply the Response Style rules in CLAUDE.md/AGENTS.md.
 - **One extra Red Flag.** Tempted to skip the Fable subagent and draft or file the issue yourself to go faster: never. The draft coming from Fable 5 is the point of this skill.

--- a/skills/fable-new-issue-loop/SKILL.md
+++ b/skills/fable-new-issue-loop/SKILL.md
@@ -16,8 +16,9 @@ Chain fable-new-issue → validate-issue-loop into one autonomous run: a Fable 5
 
 | Condition | Action |
 |---|---|
-| The subagent found an existing open issue/PR already covering it (no issue filed) | **STOP.** Report the duplicate and the offer to update/comment instead — merging scopes is a human call. |
-| The conversation held several distinct candidates and none clearly converged | **STOP.** Report the candidates and ask which to file — never bundle, never auto-file the extras. |
+| fable-new-issue found an existing open issue/PR already covering it (no issue filed) | **STOP.** Report the duplicate and the offer to update/comment instead — merging scopes is a human call. |
+| The conversation held several distinct candidates | If one clearly converged, file it and **continue the chain with it**; the unfiled candidates go in the final report. If none clearly converged, **STOP** — report the candidates and ask which to file. Never bundle, never auto-file the extras. |
+| fable-new-issue split the work and named unfiled follow-ups | Continue with the **core issue only**; relay the unfiled follow-ups in the final report. |
 | The draft was structurally wrong and fable-new-issue paused for a human decision | **STOP.** Relay what is off. Do not file or re-dispatch on your own. |
 - **Step 3, why validation still runs.** Validating an issue this chain just filed stays useful: validate-issue re-traces the claims against the code independently and catches anything the Fable draft or the spot-check got wrong.
 - **Step 4, report.** Mark the issue line as drafted by Fable 5. **Cap the whole report at 55 words, plain simple English in ASD-STE100** — apply the Response Style rules in CLAUDE.md/AGENTS.md.

--- a/skills/new-issue/SKILL.md
+++ b/skills/new-issue/SKILL.md
@@ -50,7 +50,7 @@ Include **acceptance criteria** an implementer can verify: observable behavior, 
 
 Load and apply the canonical score formula and routing table in `validate-issue` step 6. Do not restate or approximate them here. The score is a **model + effort routing signal**. It is not a time estimate; never put durations in the issue. Derive axes from the concrete touch-set in step 3, not vibes; count the surface that hides from the diff (tests, parity/offline paths, migrations, docs).
 
-From the score, also fix the **fableplan signal**: `fableplan: yes` when the score is ≥ 61 (a Fable 5 plan is posted before the build; the builder is Opus 5 at both plan bands: high at 61–80, xhigh at 81+); `no` below 61, which needs no separate plan. It goes on the rationale line in step 6 — always explicit, never omitted.
+From the score, set the **fableplan signal** per the fableplan rule in `github-issue-format`. It goes on the rationale line in step 6 and is always written explicitly.
 
 ### 5. Scope check — one issue or several?
 
@@ -58,36 +58,13 @@ If the deliverables are separable — parts that each land in their own PR, pass
 
 ### 6. Compose and file
 
-Title: `[C<score>] <title>` — the title is a clear plain-simple-English sentence in ASD-STE100 — it states the bug or deliverable precisely (component + behavior), no vague "improve X".
+Compose the title and body per `github-issue-format`. That skill owns the title convention, the complexity rationale line (which carries the score and the fableplan signal from step 4), the body section order, the `## Plain simple English` rule, and the attribution footer (full footer format: the `LLM Attribution Footer` section of CLAUDE.md; verb `Created`). Fill each section from the steps above:
 
-Body structure:
-
-```
-**Complexity: <score>/100** — Capability <k> (<driver>); Volume <v> — <model/effort from band> · fableplan: <yes|no>
-
-## Problem
-<Current behavior, grounded with file:line citations from step 2. What's wrong or missing and why it matters.>
-
-## Goal
-<The outcome in plain language — what's true after this lands.>
-
-## Approach
-<The optimal design from step 3: placement, touch-set, key decisions. Explicit that correctness/safety outrank diff size.>
-
-## Acceptance criteria
-- <observable behavior / test that must pass>
-- <…>
-
-## Plain simple English
-<One short paragraph under 55 words, ASD-STE100: what is wrong or missing and why it matters.>
-
----
-Created with LLM: <current model> | <effort> | Harness: <harness>
-```
-
-`## Plain simple English` is mandatory and is the **last prose section**, after the acceptance criteria — the full rule lives in `github-issue-format`, including where an Execution block sits when one is stamped. Write it for a reader who knows the product but not the code: state what is wrong or missing and why it matters. Do not restate the Approach there, do not list file paths or symbols, and never put a time or effort estimate in it.
-
-The complexity rationale is the **first line** of the body and matches the title prefix — same Capability/Volume form as `github-issue-format` (round-trips with the `[C<score>]` band, e.g. `[C58]` → `Capability 2 (…); Volume 8`), and always ends with the explicit fableplan signal from step 4 (`· fableplan: yes` iff score ≥ 61). The footer is the final lines, preceded by `---` on its own line — **Created** verb, `<effort>` one of `medium`/`high`/`xhigh` (or `low` when a Fable build actually ran at that discretionary tier; default `high`), `<harness>` = `Claude Code` for an interactive session. No `Co-authored-by`. **Project precedence:** a repo `CLAUDE.md` that defines its own issue/footer format overrides this default.
+- `## Problem` — current behavior, grounded with the file:line citations from step 2; what is wrong or missing and why it matters.
+- `## Goal` — the outcome in plain language; what is true after this lands.
+- `## Approach` — the optimal design from step 3: placement, touch-set, key decisions. State explicitly that correctness and safety outrank diff size.
+- `## Acceptance criteria` — the observable behaviors and required tests from step 3.
+- `## Plain simple English` — write it per the `github-issue-format` rule.
 
 File it:
 
@@ -112,9 +89,9 @@ Terse: issue URL, number, one-line summary of what it covers, complexity score, 
 | A claim about current behavior you haven't traced | Trace it or phrase it as unverified — never state a guess as fact |
 | Issue derived from conversation memory | Re-verify load-bearing file:line citations against the actual code before filing |
 | An existing open issue/PR already covers it | Stop; surface it and offer to update/comment instead |
-| The cheap design and the correct design diverge | Spec the correct one; cost, effort, and blast radius are not factors — only correctness and safety constrain |
+| The cheap design and the correct design diverge | Spec the correct one, per the best-solution principle at the top of this skill |
 | Touches money / data integrity / security / auto-protective logic | Spec the safest correct design from first principles; surface the risk in the body and Risk axis |
 | Tempted to include a time/effort estimate | Don't — complexity score only (Capability band + Volume), described via the axes |
-| Tempted to skip `## Plain simple English` because the body already explains it | Don't — it is mandatory on every issue; the technical sections are written for a specialist, that one is not |
-| The plain-language section only repeats the Approach or names files | Rewrite it — it states what is wrong and why it matters, under 55 words, no paths or symbols |
+| Tempted to skip `## Plain simple English` because the body already explains it | Don't — the section is mandatory per `github-issue-format` |
+| The plain-language section only repeats the Approach or names files | Rewrite it per the `github-issue-format` rule |
 | Repo has its own issue template or `CLAUDE.md` issue format | Follow the repo's format; it overrides this default |

--- a/skills/new-issue/SKILL.md
+++ b/skills/new-issue/SKILL.md
@@ -50,7 +50,7 @@ Include **acceptance criteria** an implementer can verify: observable behavior, 
 
 Load and apply the canonical score formula and routing table in `validate-issue` step 6. Do not restate or approximate them here. The score is a **model + effort routing signal**. It is not a time estimate; never put durations in the issue. Derive axes from the concrete touch-set in step 3, not vibes; count the surface that hides from the diff (tests, parity/offline paths, migrations, docs).
 
-From the score, set the **fableplan signal** per the fableplan rule in `github-issue-format`. It goes on the rationale line in step 6 and is always written explicitly.
+From the score, set the **fableplan signal** per the fableplan rule in `github-issue-format` (`yes` when the score is ≥ 61). It goes on the rationale line in step 6 and is always written explicitly.
 
 ### 5. Scope check — one issue or several?
 
@@ -58,13 +58,29 @@ If the deliverables are separable — parts that each land in their own PR, pass
 
 ### 6. Compose and file
 
-Compose the title and body per `github-issue-format`. That skill owns the title convention, the complexity rationale line (which carries the score and the fableplan signal from step 4), the body section order, the `## Plain simple English` rule, and the attribution footer (full footer format: the `LLM Attribution Footer` section of CLAUDE.md; verb `Created`). Fill each section from the steps above:
+Compose the title and body per `github-issue-format`. That skill owns the title convention, the complexity rationale line (which carries the score and the fableplan signal from step 4), the body section order, the plain-language section rule, and the attribution footer (full footer format: the `LLM Attribution Footer` section of CLAUDE.md; verb `Created`). Fill each section from the steps above:
 
-- `## Problem` — current behavior, grounded with the file:line citations from step 2; what is wrong or missing and why it matters.
-- `## Goal` — the outcome in plain language; what is true after this lands.
-- `## Approach` — the optimal design from step 3: placement, touch-set, key decisions. State explicitly that correctness and safety outrank diff size.
-- `## Acceptance criteria` — the observable behaviors and required tests from step 3.
-- `## Plain simple English` — write it per the `github-issue-format` rule.
+```
+**Complexity: <score>/100** — Capability <k> (<driver>); Volume <v> — <model/effort from band> · fableplan: <yes|no>
+
+## Problem
+<Current behavior, grounded with the file:line citations from step 2 — what is wrong or missing and why it matters.>
+
+## Goal
+<The outcome in plain language — what is true after this lands.>
+
+## Approach
+<The optimal design from step 3: placement, touch-set, key decisions. State explicitly that correctness and safety outrank diff size.>
+
+## Acceptance criteria
+- <observable behavior / test that must pass>
+
+## Plain simple English
+<One short paragraph under 55 words, per the `github-issue-format` rule.>
+
+---
+Created with LLM: <current model> | <effort> | Harness: <harness>
+```
 
 File it:
 


### PR DESCRIPTION
## Summary
- fable-new-issue-loop is now a delta list over new-issue-loop: it keeps only the Fable front of the chain, the full stop gate (new-issue-loop's three rows plus the structurally-wrong-draft row), the validation-still-runs note, the Fable report line, and the skip-the-subagent Red Flag.
- new-issue cites github-issue-format for the title, rationale line, body order, Plain simple English rule, and fableplan signal, and cites the CLAUDE.md LLM Attribution Footer section for the footer.
- The Plain-simple-English and best-solution rules inside new-issue are stated once each; guardrail rows compress to pointers.

## Verification
- Re-read all three files end to end. Every unique rule survives, and each citation resolves to a real section (the fableplan rule sits in github-issue-format lines 11–14).
- `bun test` passes: 235 tests, 0 failures.
- Net change per `git diff --stat origin/main...HEAD`: 20 insertions, 54 deletions.

## Plain simple English

The instruction files for issue creation repeated format rules that one owner file already states. Now they point to the owner file and keep only their own differences. The rules did not change. There is less text to read and one place to update.

---
Updated with LLM: Opus 5 | high | Harness: Claude Code

https://claude.ai/code/session_0165aPkQWpoao1cb5vGSVaek
