### PR TITLE
docs(claude-md): add spec-authoring verification rules [C2, Kimi K3, high]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,15 @@
 - The `github-issue-format` skill owns the issue format — title convention, complexity rationale line, fableplan signal, complete-body rule, footer. Load it before creating or editing any issue.
 - **Issue body order:** complexity rationale line, `## Problem`, `## Goal`, `## Approach`, `## Acceptance criteria`, `## Plain simple English`, then any Execution block, then the attribution footer. The plain-language section is mandatory on every issue — the Plain simple English block, under 55 words, with no file paths. An edit that rewrites a body adds the section when it is missing.
 
+## Spec Authoring (PRDs and other executable specs)
+
+- A spec is executable: agents implement its lines literally. Every normative line must survive a literal reading — ask whether an agent can follow the line exactly as written and still produce the wrong thing.
+- **Verify API claims against the installed SDK or type definitions.** Before a spec names a property, type, or signature, read the declaration at the deployment target (`*.swiftinterface` under `xcrun --sdk iphoneos --show-sdk-path`, or the package's own `.d.ts`). Web documentation alone is insufficient evidence. A sample written against a legacy API (for example the `VN*` Vision types) proves nothing about its modern replacement.
+- **In-repo evidence outranks external documentation.** A code comment that records a compile failure is ground truth. Contradict it only by reproducing the compile.
+- **Terminology edits sweep every dependent.** After a spec renames or forbids a mechanism, search the spec and all open issues for each remaining mention: implementation orders, tables, checklists, acceptance criteria.
+- **Realtime-path lines name the mechanism per component.** When components differ in units, coordinate spaces, or timelines, give each its own explicit statement. A shared phrase that groups them invites a wrong literal reading.
+- Spec pull requests get the same review gate as code pull requests. A spec error multiplies across every issue that cites the section.
+
 ## Git Workflow (all repos)
 
 - **Unless otherwise specified, all changes land via git worktree + pull request — never commit directly to main, never work in the main checkout.** An explicit instruction from me (e.g. "commit directly to main") overrides this for that change only. Create a worktree off the latest `origin/main` for every change (the `EnterWorktree` tool, or `git worktree add`), do the work there, then open a PR from that branch.


### PR DESCRIPTION
## Summary

Adds a **Spec Authoring** section to CLAUDE.md, between GitHub Issues and Git Workflow. Origin: a PRD review in react-native-green-screen-camera caught two injected spec defects — an API claim verified against web docs that the installed SDK contradicted, and a terminology edit that left a stale alias in the implementation-order section.

The rules:

- API claims are verified against the installed SDK or `.d.ts` at the deployment target; web docs and legacy-API samples are insufficient evidence.
- In-repo evidence (a comment recording a compile failure) outranks external documentation; contradicting it requires reproducing the compile.
- Terminology edits sweep the spec and open issues for every remaining mention.
- Realtime-path lines name the mechanism per component when units, spaces, or timelines differ.
- Every normative line must survive a literal reading; spec PRs get the same review gate as code PRs.

## Verification

Docs-only change. Rules checked against the banned-rhetoric list in Response Style.

## Plain simple English

Agents treat spec files as instructions and follow them word for word. These rules make spec writers check API claims against the real SDK, trust the repo over the web, and update every section when a name changes, so wrong instructions stop reaching builders.

---
Created with LLM: Kimi K3 | high | Harness: Cursor