### PR TITLE
feat(skills): lead the validate verdict with the recommended next step [C12, Opus 5, high]

### DIFF
--- a/skills/validate-issue-loop/SKILL.md
+++ b/skills/validate-issue-loop/SKILL.md
@@ -5,7 +5,7 @@ description: Use when the user asks to validate a GitHub issue and then autonomo
 
 # validate-issue-loop
 
-Chain validate-issue → (conditional) update issue → work-on-issue-loop into one autonomous run, so an issue goes from "reported" to "PR through N rounds of review" without a human in the loop between steps. This is validate-issue's normal interactive handoff (`→ Reply "work on issue"`) made unattended: the loop reads its own verdict and decides what to do next, instead of waiting for the user to type a reply.
+Chain validate-issue → (conditional) update issue → work-on-issue-loop into one autonomous run, so an issue goes from "reported" to "PR through N rounds of review" without a human in the loop between steps. This is validate-issue's normal interactive handoff (its `→` next-step line) made unattended: the loop reads its own verdict and decides what to do next, instead of waiting for the user to type a reply.
 
 **Do not skip validation.** Auto-implementing an issue whose factual claims or proposal you haven't traced against the code just reproduces the issue's own mistakes in a PR. Every step of validate-issue still runs; only the "wait for the user's reply" step is replaced by a decision table.
 
@@ -23,7 +23,7 @@ Invoke the `validate-issue` skill for the target issue (Skill tool, `skill: vali
 **#<N>: Update issue description? <Yes|No>**  ·  Complexity: <score>/100 — Capability <k> (<driver>); Volume <v> · fableplan: <yes|no>  ·  Scope: <OK | too large — split/umbrella/narrow>
 ```
 
-Its final `→ Reply "work on issue"...` line is written for interactive use — in this loop, treat the verdict block as structured output to parse yourself, not a prompt to wait on. Don't ask the user to confirm; decide from the table in step 2.
+Its final `→` next-step line is written for interactive use — in this loop, treat the verdict block as structured output to parse yourself, not a prompt to wait on. Don't ask the user to confirm; decide from the table in step 2.
 
 ### 2. Scope gate — stop if the issue is unsafe to auto-implement
 

--- a/skills/validate-issue/SKILL.md
+++ b/skills/validate-issue/SKILL.md
@@ -124,10 +124,18 @@ Scope:                                # only when too large or checklist restruc
 - <disposition> — <reason and parts>
 **#<N>: Update issue description? <Yes | No>** · Complexity: <score>/100 — Capability <k> (<driver>); Volume <v> · fableplan: <yes|no> · Scope: <OK | too large — split/umbrella/narrow>
 <specific edits when Yes>
-→ Reply "work on issue" to proceed, "update issue" to edit, "fableplan" when offered, or "split issue" when flagged.
+→ <next-step line — see the rule below>
 ```
 
 Set Yes for a material ❌/⚠️ claim, architecture or consistency gap, material concern, missing scope, or required checklist restructure. Set No only when the issue is accurate, feasible, consistent, complete, and ready. Always offer `fableplan` when its signal is yes; if the user chooses work first, ask once whether to plan or build directly.
+
+**Next-step line.** The line always leads with the action this verdict recommends, then lists the other options. Pick the recommendation in this order:
+
+1. Scope disposition is split or umbrella → `→ Recommend "split issue" to restructure; or "update issue" to edit, "work on issue" to build as-is, "fableplan" when offered.`
+2. Update issue description is Yes → `→ Recommend "update issue" to apply the edits above; or "work on issue" to build as-is, "fableplan" when offered.`
+3. Otherwise → `→ Reply "work on issue" to proceed, "update issue" to edit, or "fableplan" when offered.`
+
+Drop `"fableplan" when offered` from the line when the fableplan signal is no.
 
 ### 9. Handle "work on issue"
 

--- a/skills/validate-issue/SKILL.md
+++ b/skills/validate-issue/SKILL.md
@@ -124,18 +124,22 @@ Scope:                                # only when too large or checklist restruc
 - <disposition> — <reason and parts>
 **#<N>: Update issue description? <Yes | No>** · Complexity: <score>/100 — Capability <k> (<driver>); Volume <v> · fableplan: <yes|no> · Scope: <OK | too large — split/umbrella/narrow>
 <specific edits when Yes>
-→ <next-step line — see the rule below>
+<next-step line — see the rule below; it carries its own leading arrow>
 ```
 
 Set Yes for a material ❌/⚠️ claim, architecture or consistency gap, material concern, missing scope, or required checklist restructure. Set No only when the issue is accurate, feasible, consistent, complete, and ready. Always offer `fableplan` when its signal is yes; if the user chooses work first, ask once whether to plan or build directly.
 
-**Next-step line.** The line always leads with the action this verdict recommends, then lists the other options. Pick the recommendation in this order:
+**Next-step line.** The line always leads with the action this verdict recommends, then lists the other options. Match the first case that applies, then take the variant for the fableplan signal, and post that line verbatim — each one already carries its leading `→` and is complete as written. Never assemble the line by deleting words from another variant.
 
-1. Scope disposition is split or umbrella → `→ Recommend "split issue" to restructure; or "update issue" to edit, "work on issue" to build as-is, "fableplan" when offered.`
-2. Update issue description is Yes → `→ Recommend "update issue" to apply the edits above; or "work on issue" to build as-is, "fableplan" when offered.`
-3. Otherwise → `→ Reply "work on issue" to proceed, "update issue" to edit, or "fableplan" when offered.`
-
-Drop `"fableplan" when offered` from the line when the fableplan signal is no.
+1. Scope disposition is split or umbrella:
+   - fableplan yes → `→ Recommend "split issue" to restructure; or "update issue" to edit, "work on issue" to build as-is, "fableplan" to plan first.`
+   - fableplan no → `→ Recommend "split issue" to restructure; or "update issue" to edit, "work on issue" to build as-is.`
+2. Update issue description is Yes:
+   - fableplan yes → `→ Recommend "update issue" to apply the edits above; or "work on issue" to build as-is, "fableplan" to plan first.`
+   - fableplan no → `→ Recommend "update issue" to apply the edits above; or "work on issue" to build as-is.`
+3. Otherwise:
+   - fableplan yes → `→ Reply "work on issue" to proceed, "update issue" to edit, or "fableplan" to plan first.`
+   - fableplan no → `→ Reply "work on issue" to proceed, or "update issue" to edit.`
 
 ### 9. Handle "work on issue"
 

--- a/skills/work-on-issue/SKILL.md
+++ b/skills/work-on-issue/SKILL.md
@@ -7,7 +7,7 @@ description: Use when the user says "work on issue", "work on this issue", "impl
 
 Take a GitHub issue from "validated" to "PR open", autonomously and end-to-end: isolate the work in a fresh worktree, implement the fix to the codebase's conventions, verify it really works, commit and push, then open a pull request that closes the issue. The skill ends with the open PR — requesting review is the caller's job (work-on-issue-loop does it; standalone, the user decides). Don't stop to ask the user between steps — do the work and report at the end.
 
-**This is the natural follow-on to validate-issue** — when it ends with `→ Reply "work on issue"`, the user replying "work on issue" lands here. The skill is also valid standalone, without a prior validation pass.
+**This is the natural follow-on to validate-issue** — when its next-step line offers or recommends "work on issue", the user replying "work on issue" lands here. The skill is also valid standalone, without a prior validation pass.
 
 **Implement the issue, not your memory of it.** Re-read the issue and any validation findings before writing code; the description can be stale or wrong (that's what validate-issue exists to catch). Build the fix the traced code supports, not the one the prose suggests.
 


### PR DESCRIPTION
## Summary

The `validate-issue` step-8 verdict block ended with one static options line, so a verdict that answered "Update issue description? **Yes**" still gave no recommendation. This adds a **Next-step line** rule that leads with the recommended action, then lists the other options:

1. Scope is split or umbrella → recommend `split issue`
2. Update issue description is Yes → recommend `update issue`
3. Otherwise → the existing `Reply "work on issue" to proceed...` line

The `"fableplan" when offered` option drops out of the line when the fableplan signal is no.

Every Fable and loop wrapper (`fable-validate`, `fable-validate-fableplan`, `validate-issue-loop`, `fable-validate-loop`, `validate-fableplan-loop`) presents the verdict in the validate-issue step-8 format, so they inherit this rule with no change of their own.

## Verification

- `bun test` — 245 pass, 0 fail
- `grep` over the repo for the old literal line: the two remaining references (`work-on-issue`, `validate-issue-loop`) now name the next-step line generically instead of quoting the old text

## Plain simple English

When a validation says an issue needs edits, the last line now tells you to reply "update issue" first. Before, it always showed the same list of choices and gave no recommendation.

---
Created with LLM: Opus 5 | high | Harness: Claude Code
