### PR TITLE
chore(#216): pin every workflow action to a verified SHA at its current major [C68, Opus 5, high]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore(actions)
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/claude-run.yml
+++ b/.github/workflows/claude-run.yml
@@ -54,12 +54,12 @@ jobs:
       BOT_LOGIN: ${{ inputs.mode == 'review' && 'github-actions[bot]' || 'claude[bot]' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
       - name: Checkout rk-skills (shared prompts and scripts)
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: richkuo/rk-skills
           ref: main
@@ -86,7 +86,7 @@ jobs:
 
       - name: Set up Go (gofmt only)
         if: inputs.go_version != ''
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ inputs.go_version }}
 
@@ -200,7 +200,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -292,7 +292,7 @@ jobs:
 
       - name: Revise CLAUDE.md with session learnings
         if: inputs.mode == 'implement' && steps.claude.outcome == 'success' && steps.claude_changes.outputs.made_commits == 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: "Use the Skill tool to invoke the 'claude-md-management:revise-claude-md' skill. Review the changes made in this session (use git log and git diff to inspect them) and update CLAUDE.md with any new patterns, conventions, or important context learned. If you modified CLAUDE.md, you MUST persist it: commit it on the current branch following the repository commit conventions and push with git push origin HEAD — an uncommitted edit is discarded when this job ends."

--- a/.github/workflows/codex-run.yml
+++ b/.github/workflows/codex-run.yml
@@ -90,19 +90,19 @@ jobs:
       - name: Mint the GitHub App installation token
         if: inputs.mode != 'review'
         id: app_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.CODEX_APP_ID }}
           private-key: ${{ secrets.CODEX_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ steps.app_token.outputs.token || github.token }}
 
       - name: Checkout rk-skills (shared prompts, scripts, and skills)
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: richkuo/rk-skills
           ref: main
@@ -134,7 +134,7 @@ jobs:
 
       - name: Set up Go (gofmt only)
         if: inputs.go_version != ''
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ inputs.go_version }}
 
@@ -279,7 +279,7 @@ jobs:
 
       - name: Run Codex
         id: codex
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1.12
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
         with:
@@ -354,7 +354,7 @@ jobs:
 
       - name: Revise AGENTS.md with session learnings
         if: inputs.mode == 'implement' && steps.codex.outcome == 'success' && steps.codex_changes.outputs.made_commits == 'true'
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1.12
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
 

--- a/templates/claude-review.yml
+++ b/templates/claude-review.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -53,7 +53,7 @@ jobs:
           }
           EOF
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ github.token }}

--- a/templates/codex-review.yml
+++ b/templates/codex-review.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -43,7 +43,7 @@ jobs:
             printf '%s\n' "# Prior review cycles unavailable: gh pr view failed" > "$CYCLES_FILE"
           fi
 
-      - uses: openai/codex-action@v1
+      - uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1.12
         id: codex
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/tests/action-pinning.test.js
+++ b/tests/action-pinning.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test'
+import { readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const root = new URL('../', import.meta.url)
+const read = (path) => Bun.file(new URL(path, root)).text()
+
+const SCANNED_ROOTS = ['.github/workflows', 'templates']
+const OWN_REPO = 'richkuo/rk-skills'
+const USES = /^\s*(?:-\s+)?uses:\s*(\S+)/gm
+const PINNED = /^[^@]+@[0-9a-f]{40}$/
+
+function walk(relDir) {
+	const absolute = fileURLToPath(new URL(relDir, root))
+	const found = []
+	for (const entry of readdirSync(absolute, { withFileTypes: true })) {
+		const child = `${relDir}/${entry.name}`
+		if (entry.isDirectory()) found.push(...walk(child))
+		else if (/\.ya?ml$/.test(entry.name)) found.push(child)
+	}
+	return found.sort()
+}
+
+const workflowFiles = SCANNED_ROOTS.flatMap((dir) => walk(dir))
+
+const references = (
+	await Promise.all(
+		workflowFiles.map(async (path) => {
+			const source = await read(path)
+			return [...source.matchAll(USES)].map((match) => ({ path, ref: match[1] }))
+		}),
+	)
+).flat()
+
+const isOwnWorkflow = (ref) => ref.startsWith(`${OWN_REPO}/`)
+
+describe('GitHub Actions pinning contract', () => {
+	test('scans both workflow trees and finds references in each', () => {
+		expect(workflowFiles.length).toBeGreaterThan(0)
+		for (const dir of SCANNED_ROOTS) {
+			expect(references.some(({ path }) => path.startsWith(`${dir}/`))).toBe(true)
+		}
+	})
+
+	test('pins every third-party action to a full commit SHA', () => {
+		const mutable = references
+			.filter(({ ref }) => !isOwnWorkflow(ref))
+			.filter(({ ref }) => !PINNED.test(ref))
+			.map(({ path, ref }) => `${path}: ${ref}`)
+
+		expect(mutable).toEqual([])
+	})
+
+	test('labels every pinned SHA with the version it came from', async () => {
+		const unlabelled = []
+		for (const path of workflowFiles) {
+			const source = await read(path)
+			for (const line of source.split('\n')) {
+				const match = /^\s*(?:-\s+)?uses:\s*(\S+)(.*)$/.exec(line)
+				if (match === null || isOwnWorkflow(match[1])) continue
+				if (!/^\s+#\s*\S/.test(match[2])) unlabelled.push(`${path}: ${line.trim()}`)
+			}
+		}
+
+		expect(unlabelled).toEqual([])
+	})
+
+	test('keeps the reusable-workflow self-references on a branch ref', () => {
+		const own = references.filter(({ ref }) => isOwnWorkflow(ref))
+
+		expect(own.length).toBeGreaterThan(0)
+		for (const { ref } of own) expect(ref.endsWith('@main')).toBe(true)
+	})
+
+	test('rejects a mutable tag reintroduced into either tree', () => {
+		const mutated = 'uses: actions/checkout@v7'
+		const match = /^\s*(?:-\s+)?uses:\s*(\S+)/.exec(mutated)
+
+		expect(PINNED.test(match[1])).toBe(false)
+	})
+
+	test('keeps the harness attribution strings on a readable tag', async () => {
+		const harnesses = [
+			['.github/workflows/claude-run.yml', 'anthropics/claude-code-action@v1'],
+			['.github/workflows/codex-run.yml', 'openai/codex-action@v1'],
+		]
+
+		for (const [path, expected] of harnesses) {
+			expect(await read(path)).toContain(`CLAUDE_HARNESS: ${expected}\n`)
+		}
+	})
+})

--- a/tests/action-pinning.test.js
+++ b/tests/action-pinning.test.js
@@ -1,11 +1,11 @@
 import { describe, expect, test } from 'bun:test'
-import { readdirSync } from 'node:fs'
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
 const root = new URL('../', import.meta.url)
 const read = (path) => Bun.file(new URL(path, root)).text()
 
-const SCANNED_ROOTS = ['.github/workflows', 'templates']
+const SCANNED_ROOTS = ['.github/workflows', '.github/actions', 'templates']
 const OWN_REPO = 'richkuo/rk-skills'
 const USES = /^\s*(?:-\s+)?uses:\s*(\S+)/gm
 const PINNED = /^[^@]+@[0-9a-f]{40}$/
@@ -13,7 +13,14 @@ const PINNED = /^[^@]+@[0-9a-f]{40}$/
 function walk(relDir) {
 	const absolute = fileURLToPath(new URL(relDir, root))
 	const found = []
-	for (const entry of readdirSync(absolute, { withFileTypes: true })) {
+	let entries
+	try {
+		entries = readdirSync(absolute, { withFileTypes: true })
+	} catch (err) {
+		if (err.code === 'ENOENT') return found
+		throw err
+	}
+	for (const entry of entries) {
 		const child = `${relDir}/${entry.name}`
 		if (entry.isDirectory()) found.push(...walk(child))
 		else if (/\.ya?ml$/.test(entry.name)) found.push(child)
@@ -35,10 +42,29 @@ const references = (
 const isOwnWorkflow = (ref) => ref.startsWith(`${OWN_REPO}/`)
 
 describe('GitHub Actions pinning contract', () => {
-	test('scans both workflow trees and finds references in each', () => {
+	test('scans every declared root and finds references where they exist', () => {
 		expect(workflowFiles.length).toBeGreaterThan(0)
-		for (const dir of SCANNED_ROOTS) {
+		for (const dir of ['.github/workflows', 'templates']) {
 			expect(references.some(({ path }) => path.startsWith(`${dir}/`))).toBe(true)
+		}
+	})
+
+	test('catches a mutable ref added under a scanned-but-currently-empty root', () => {
+		const fixtureDir = fileURLToPath(new URL('.github/actions/_pinning-test-fixture', root))
+		mkdirSync(fixtureDir, { recursive: true })
+		writeFileSync(`${fixtureDir}/action.yml`, 'runs:\n  using: composite\n  steps:\n    - uses: actions/checkout@v7\n')
+		try {
+			const fixtureFiles = walk('.github/actions')
+			expect(fixtureFiles).toContain('.github/actions/_pinning-test-fixture/action.yml')
+
+			const fixtureRefs = fixtureFiles.flatMap((path) => {
+				const source = readFileSync(fileURLToPath(new URL(path, root)), 'utf8')
+				return [...source.matchAll(USES)].map((match) => match[1])
+			})
+			const mutable = fixtureRefs.filter((ref) => !isOwnWorkflow(ref) && !PINNED.test(ref))
+			expect(mutable).toEqual(['actions/checkout@v7'])
+		} finally {
+			rmSync(fixtureDir, { recursive: true, force: true })
 		}
 	})
 

--- a/tests/ci-workflow.test.js
+++ b/tests/ci-workflow.test.js
@@ -25,7 +25,7 @@ describe('Bun test workflow contract', () => {
     const workflow = await readWorkflow()
 
     expect(topLevelBlock(workflow, 'permissions')).toBe(readOnlyPermissions)
-    expect(workflow).toContain('uses: actions/checkout@v4')
+    expect(workflow).toMatch(/uses: actions\/checkout@[0-9a-f]{40} # v\d+\.\d+\.\d+$/m)
     expect(workflow).not.toMatch(/^\s+ref:/m)
   })
 
@@ -47,7 +47,7 @@ describe('Bun test workflow contract', () => {
   test('pins Bun and runs the repository test command', async () => {
     const workflow = await readWorkflow()
 
-    expect(workflow).toContain('uses: oven-sh/setup-bun@v2')
+    expect(workflow).toMatch(/uses: oven-sh\/setup-bun@[0-9a-f]{40} # v\d+\.\d+\.\d+$/m)
     expect(workflow).toContain('bun-version: 1.3.14')
     expect(workflow).toContain('run: bun run test')
   })

--- a/tests/codex-workflow.test.js
+++ b/tests/codex-workflow.test.js
@@ -173,7 +173,7 @@ describe('Codex workflow bundle', () => {
       expect(block).toContain('CODEX_APP_ID')
       expect(block).toContain('CODEX_APP_PRIVATE_KEY')
       expect(block).toContain('exit 1')
-      expect(runBody).toContain('uses: actions/create-github-app-token@v2')
+      expect(runBody).toMatch(/uses: actions\/create-github-app-token@[0-9a-f]{40} # v\d+\.\d+\.\d+$/m)
       expect(runBody).toMatch(
         /- name: Mint the GitHub App installation token\n\s+if: inputs\.mode != 'review'/,
       )


### PR DESCRIPTION
Closes #216

## Summary

Every `uses:` reference in this repository named a mutable tag. A tag can be repointed by the action owner at any time, which is the supply-chain vector behind the `tj-actions/changed-files`, `trivy-action`, and `kics-github-action` compromises. These jobs hold `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, a GitHub App private key, and `NPM_TOKEN`.

All 19 third-party references across 6 files now name a full 40-character commit SHA with a trailing version comment, at the current major:

| Reference | Was | Now | SHA |
|---|---|---|---|
| `actions/checkout` | v4 | v7.0.1 | `3d3c42e5aac5ba805825da76410c181273ba90b1` |
| `actions/setup-go` | v5 | v7.0.0 | `b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` |
| `actions/setup-node` | v4 | v7.0.0 | `820762786026740c76f36085b0efc47a31fe5020` |
| `actions/create-github-app-token` | v2 | v3.2.0 | `bcd2ba49218906704ab6c1aa796996da409d3eb1` |
| `oven-sh/setup-bun` | v2 | v2.2.0 | `0c5077e51419868618aeaa5fe8019c62421857d6` |
| `anthropics/claude-code-action` | v1 | v1.0.210 | `a874e9ecd7bb36efdad65429c6b35815f5a08f10` |
| `openai/codex-action` | v1 | v1.12 | `86365089eb2b84e0a8fb0717b304f8bdcb13b20e` |

Each SHA was re-resolved from its tag at build time and confirmed through `GET /repos/{owner}/{repo}/commits/{sha}` to be a real commit in the named repository. This is the check PR #215 skipped: the SHA it proposed for `claude-code-action` returns 422 and exists in no ref.

Also adds `.github/dependabot.yml` (weekly, grouped) and `tests/action-pinning.test.js`.

## Deliberately unchanged

1. **`CLAUDE_HARNESS` stays on `@v1`.** `claude-run.yml:53` and `codex-run.yml:64` set it to `anthropics/claude-code-action@v1` and `openai/codex-action@v1`. These are human-readable attribution strings that reach PR bodies, commit messages, and review comments through `compose_claude_comment.py`. A blanket replace would put 40 hex characters into every attribution footer. The new test asserts both stay readable.
2. **The 12 `richkuo/rk-skills/…@main` reusable-workflow calls stay on `main`.** They point at this repository, so the tag-repointing threat does not apply, and both `templates/*/README.md` document `@main` as the live-propagation contract: an rk-skills change reaches every consumer repo on its next run. The new test asserts this by an explicit owner check rather than by accident.

## Dependabot coverage

Dependabot's `github-actions` ecosystem scans only `.github/workflows` and a root `action.yml`/`action.yaml` (confirmed against the GitHub options reference). It does not reach `templates/`. The guard test covers that tree instead, so drift there fails CI rather than going unnoticed.

## Verification

- `bun run test` — 332 pass, 0 fail (was 330 pass / 2 fail before the test edits below).
- `python3 -m unittest discover -s templates/claude-workflow/scripts` — 91 tests, OK.
- `python3 -m unittest discover -s templates/codex-workflow/scripts` — 55 tests, OK.
- All 11 workflow and Dependabot YAML files parse.
- `tests/action-pinning.test.js` proven red → green: stashed the pins, ran it against the unpinned tree, 2 of 6 tests failed listing all 19 mutable references; restored the pins, 6 of 6 pass.
- `actions/checkout` v7.0.0 blocks checking out a fork PR under `pull_request_target` and `workflow_run`. No workflow here uses either trigger — the two run bodies are `workflow_call`, the two bot workflows are `issue_comment`, `test.yml` is `pull_request`/`push`, `publish.yml` is `release`. The upgrade is behaviour-neutral.

## Test edits

All three are **Outdated**: they assert the literal mutable tag that this change deliberately replaces. **Ground:** the acceptance criteria of issue #216, which require every third-party reference to be a pinned SHA.

1. `tests/ci-workflow.test.js:28` asserted `toContain('uses: actions/checkout@v4')`. Replacement asserts `/uses: actions\/checkout@[0-9a-f]{40} # v\d+\.\d+\.\d+$/m` — still proves the workflow checks out, and now also proves it is pinned and labelled.
2. `tests/ci-workflow.test.js:50` asserted `toContain('uses: oven-sh/setup-bun@v2')`. Same form of replacement.
3. `tests/codex-workflow.test.js:176` asserted `toContain('uses: actions/create-github-app-token@v2')`. Same form of replacement; the surrounding test still proves the write route fails closed without App credentials.

No test was weakened, skipped, or removed. `tests/codex-workflow.test.js:212`, which asserts the `CLAUDE_HARNESS` string, was left as it is and still passes.

## Issue discrepancy

The issue body says "20 third-party references". The actual count is 19; the issue's own per-file list is correct, and only the total was wrong. The issue also under-counted the reusable-workflow self-references as nine; there are twelve.

## Plain simple English

The automation jobs called outside tools by a moving name. The tool owner could change what that name points to at any time, and the job would then run different code while our secret keys were available to it. Each tool is now locked to one exact version. A new test fails if a moving name comes back.

---
Created with LLM: Opus 5 | high | Harness: Claude Code
