### PR TITLE
chore(#222): drop MultiEdit from the claude-run.yml allowlists [C6, Fable 5, low]

### DIFF
--- a/.github/workflows/claude-run.yml
+++ b/.github/workflows/claude-run.yml
@@ -129,15 +129,15 @@ jobs:
                 ALLOWED='Read,Glob,Grep,Bash(git status*),Bash(git log*),Bash(git tag --sort*),Bash(git fetch*),Bash(git rev-parse*),Bash(gh auth status),Bash(gh release create*),Bash(gh release view*)'
                 ;;
               *)
-                ALLOWED='Read,Edit,Write,MultiEdit,Glob,Grep,Bash(wc *),Bash(ls *),Bash(git status*),Bash(git log*),Bash(git diff*),Bash(git show*),Bash(git fetch*),Bash(git tag --sort*),Bash(git branch*),Bash(git rev-parse*),Bash(git checkout -b docs-sync/*),Bash(git checkout -b docs-release/*),Bash(git add*),Bash(git commit*),Bash(git push origin docs-sync/*),Bash(git push origin docs-release/*),Bash(gh pr create*),Bash(gh pr view*),Bash(gh issue view*)'
+                ALLOWED='Read,Edit,Write,Glob,Grep,Bash(wc *),Bash(ls *),Bash(git status*),Bash(git log*),Bash(git diff*),Bash(git show*),Bash(git fetch*),Bash(git tag --sort*),Bash(git branch*),Bash(git rev-parse*),Bash(git checkout -b docs-sync/*),Bash(git checkout -b docs-release/*),Bash(git add*),Bash(git commit*),Bash(git push origin docs-sync/*),Bash(git push origin docs-release/*),Bash(gh pr create*),Bash(gh pr view*),Bash(gh issue view*)'
                 ;;
             esac
           elif [ "$MODE" = "implement" ]; then
             PROMPT_FILE=$PROMPTS_DIR/issue-workflow.md
-            ALLOWED='Bash(git *),Bash(gh *),Read,Edit,Write,MultiEdit,Glob,Grep,Skill,EnterWorktree'
+            ALLOWED='Bash(git *),Bash(gh *),Read,Edit,Write,Glob,Grep,Skill,EnterWorktree'
           elif [ "$MODE" = "fix-pr" ] || [ "$MODE" = "fix-pr-review" ]; then
             PROMPT_FILE=$PROMPTS_DIR/fix-pr.md
-            ALLOWED='Bash(wc *),Bash(ls *),Bash(git status*),Bash(git log*),Bash(git diff*),Bash(git show*),Bash(git fetch*),Bash(git branch*),Bash(git rev-parse*),Bash(git checkout*),Bash(git switch*),Bash(git add*),Bash(git commit*),Bash(git push origin HEAD),Bash(gh pr checkout*),Bash(gh pr view*),Bash(gh pr diff*),Bash(gh pr comment*),Bash(gh issue view*),Bash(gh issue create*),Bash(gh api graphql*),Read,Edit,Write,MultiEdit,Glob,Grep'
+            ALLOWED='Bash(wc *),Bash(ls *),Bash(git status*),Bash(git log*),Bash(git diff*),Bash(git show*),Bash(git fetch*),Bash(git branch*),Bash(git rev-parse*),Bash(git checkout*),Bash(git switch*),Bash(git add*),Bash(git commit*),Bash(git push origin HEAD),Bash(gh pr checkout*),Bash(gh pr view*),Bash(gh pr diff*),Bash(gh pr comment*),Bash(gh issue view*),Bash(gh issue create*),Bash(gh api graphql*),Read,Edit,Write,Glob,Grep'
           else
             PROMPT_FILE=$PROMPTS_DIR/pr-review-format.md
             ALLOWED='Bash(git status*),Bash(git log*),Bash(git diff*),Bash(git show*),Bash(git fetch*),Bash(git branch*),Bash(git rev-parse*),Bash(gh pr view*),Bash(gh pr diff*),Bash(gh pr comment*),Bash(gh issue view*)'

--- a/tests/pr-review-contract.test.js
+++ b/tests/pr-review-contract.test.js
@@ -692,6 +692,21 @@ describe('PR review contract', () => {
     expect(workflow).toMatch(/extra_allowed_tools/)
   })
 
+  test('every claude-run.yml allowlist names only tools the pinned build has', async () => {
+    const workflow = await read('.github/workflows/claude-run.yml')
+    const allowlists = [...workflow.matchAll(/ALLOWED='([^']+)'/g)].map((m) => m[1])
+    expect(allowlists.length).toBeGreaterThanOrEqual(3)
+    for (const list of allowlists) {
+      const names = list.split(',')
+      expect(names, list).not.toContain('MultiEdit')
+      if (names.includes('Edit') || names.includes('Write')) {
+        expect(names, list).toContain('Edit')
+        expect(names, list).toContain('Write')
+      }
+    }
+    expect(workflow).not.toMatch(/MultiEdit/)
+  })
+
   test('the Codex review route selects the same guarded prompt, read-only', async () => {
     const workflow = await read('.github/workflows/codex-run.yml')
     expect(workflow).toContain('PROMPT_FILE="$PROMPTS_DIR/pr-review-format.md"')


### PR DESCRIPTION
Closes #222

## Summary

- Removed `MultiEdit` from the three `ALLOWED` lists in `.github/workflows/claude-run.yml` (sync-docs default, implement mode, fix-pr mode). `Edit` and `Write` remain in each.
- The only other `MultiEdit` mention in the repository is the historical record in `docs/contract-inventory.md`, which describes why the name left the review template. It stays, because it is the ground for this change.
- Added a regression test in `tests/pr-review-contract.test.js` that fails when any `claude-run.yml` allowlist names `MultiEdit`. It was run red on the unfixed workflow, then green after the fix.

## Verification

- `grep -rn MultiEdit .github/ templates/` returns nothing.
- `Bun.YAML.parse` reads `.github/workflows/claude-run.yml` without error.
- `bun test`: 362 pass, 0 fail.

No existing test was edited. No implementation plan was posted on the issue.

## Plain simple English

The shared bot workflow listed a tool named MultiEdit in three places. The bot version we pin does not have that tool, so the entries did nothing. This change removes them and adds a test that stops the name from coming back. The workflow and the review template now agree.

---
Created with LLM: Fable 5 | low | Harness: Claude Code
