### PR TITLE
feat(wans): add /wans next-steps skill [C12, Opus 5, high]

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Every new issue records direct predecessors as `**Depends on:** #<n>[, #<n>…] 
 | Skill | What it does |
 |-------|--------------|
 | `tldr` | Recaps the previous answer in ASD-STE100 (Simplified Technical English) under 55 words, one sentence per line. |
+| `wans` | Answers "what are next steps?" for the current work: up to five ordered steps in ASD-STE100 (Simplified Technical English), each one line, each marked `You:` or `Me:`, with any blocker named. |
 
 ### Review bot prerequisite
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Every new issue records direct predecessors as `**Depends on:** #<n>[, #<n>…] 
 | Skill | What it does |
 |-------|--------------|
 | `tldr` | Recaps the previous answer in ASD-STE100 (Simplified Technical English) under 55 words, one sentence per line. |
-| `wans` | Answers "what are next steps?" for the current work in ASD-STE100 (Simplified Technical English) — a numbered list when there are several steps, each marked `You:` or `Me:`. |
+| `wans` | Answers "what are next steps?" for the current work in ASD-STE100 (Simplified Technical English) — a numbered list when there are several steps, ordered by sequence where one step must follow another and by importance where the order is free, each marked `You:` or `Me:`. |
 
 ### Review bot prerequisite
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Every new issue records direct predecessors as `**Depends on:** #<n>[, #<n>…] 
 | Skill | What it does |
 |-------|--------------|
 | `tldr` | Recaps the previous answer in ASD-STE100 (Simplified Technical English) under 55 words, one sentence per line. |
-| `wans` | Answers "what are next steps?" for the current work: up to five ordered steps in ASD-STE100 (Simplified Technical English), each marked `You:` or `Me:`. |
+| `wans` | Answers "what are next steps?" for the current work in ASD-STE100 (Simplified Technical English) — a numbered list when there are several steps, each marked `You:` or `Me:`. |
 
 ### Review bot prerequisite
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Every new issue records direct predecessors as `**Depends on:** #<n>[, #<n>…] 
 | Skill | What it does |
 |-------|--------------|
 | `tldr` | Recaps the previous answer in ASD-STE100 (Simplified Technical English) under 55 words, one sentence per line. |
-| `wans` | Answers "what are next steps?" for the current work: up to five ordered steps in ASD-STE100 (Simplified Technical English), each one line, each marked `You:` or `Me:`, with any blocker named. |
+| `wans` | Answers "what are next steps?" for the current work: up to five ordered steps in ASD-STE100 (Simplified Technical English), each marked `You:` or `Me:`. |
 
 ### Review bot prerequisite
 

--- a/skills/wans/SKILL.md
+++ b/skills/wans/SKILL.md
@@ -9,6 +9,6 @@ Answer one question: what are the next steps?
 
 ## Rules
 
-1. **Write it in ASD-STE100 (Simplified Technical English)** per the Response Style rules in CLAUDE.md/AGENTS.md. Give a numbered list of five steps or fewer, most important first, one short sentence for each. No preamble.
+1. **Write it in ASD-STE100 (Simplified Technical English)** per the Response Style rules in CLAUDE.md/AGENTS.md. If there are multiple steps, give a numbered list, most important first. Use one short sentence for each step. No preamble.
 2. **Take the steps from the session.** Do not invent work the conversation or the code does not support.
 3. **Say who acts.** Start each line with `You:` or `Me:`. If nothing is open, say so in one line.

--- a/skills/wans/SKILL.md
+++ b/skills/wans/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: wans
+description: Use when the user types /wans to get the next steps for the current work, written in ASD-STE100, as a short numbered list.
+---
+
+# WANS
+
+Answer one question: what are the next steps?
+
+## Rules
+
+1. **Take the steps from the session.** Use the work in progress, the open questions, and the decisions the user must make. Every step must come from what the conversation or the code shows. If a step depends on a fact you did not check, check it first or mark it as unknown.
+2. **Write it in ASD-STE100 (Simplified Technical English)** per the Response Style rules in CLAUDE.md/AGENTS.md. Use a numbered list, one step for each line. Start each step with an action verb. Keep each step to one sentence of 20 words or less. No headers, and no preamble like "Here are the next steps".
+3. **Give five steps or fewer**, in the order to do them. Put the step that unblocks the most work first.
+4. **Name the owner of each step.** Start the line with `You:` when the user must act, or `Me:` when you can do the step. A step that only the user can do — an approval, a credential, a product decision — must say so.
+5. **Name each blocker with its step.** If a step cannot start, add one clause that tells what stops it.
+6. **Stay at the architecture and behavior altitude.** Do not use raw symbols or `file:line`, and do not show code. Use a file path only when the step has no meaning without it.
+7. **Tell the user when there is nothing to do.** If the work is complete and no step is open, write one line that says so. If the session has no work in progress, write one line and ask what to plan.

--- a/skills/wans/SKILL.md
+++ b/skills/wans/SKILL.md
@@ -9,10 +9,6 @@ Answer one question: what are the next steps?
 
 ## Rules
 
-1. **Take the steps from the session.** Use the work in progress, the open questions, and the decisions the user must make. Every step must come from what the conversation or the code shows. If a step depends on a fact you did not check, check it first or mark it as unknown.
-2. **Write it in ASD-STE100 (Simplified Technical English)** per the Response Style rules in CLAUDE.md/AGENTS.md. Use a numbered list, one step for each line. Start each step with an action verb. Keep each step to one sentence of 20 words or less. No headers, and no preamble like "Here are the next steps".
-3. **Give five steps or fewer**, in the order to do them. Put the step that unblocks the most work first.
-4. **Name the owner of each step.** Start the line with `You:` when the user must act, or `Me:` when you can do the step. A step that only the user can do — an approval, a credential, a product decision — must say so.
-5. **Name each blocker with its step.** If a step cannot start, add one clause that tells what stops it.
-6. **Stay at the architecture and behavior altitude.** Do not use raw symbols or `file:line`, and do not show code. Use a file path only when the step has no meaning without it.
-7. **Tell the user when there is nothing to do.** If the work is complete and no step is open, write one line that says so. If the session has no work in progress, write one line and ask what to plan.
+1. **Write it in ASD-STE100 (Simplified Technical English)** per the Response Style rules in CLAUDE.md/AGENTS.md. Give a numbered list of five steps or fewer, most important first, one short sentence for each. No preamble.
+2. **Take the steps from the session.** Do not invent work the conversation or the code does not support.
+3. **Say who acts.** Start each line with `You:` or `Me:`. If nothing is open, say so in one line.

--- a/skills/wans/SKILL.md
+++ b/skills/wans/SKILL.md
@@ -9,6 +9,6 @@ Answer one question: what are the next steps?
 
 ## Rules
 
-1. **Write it in ASD-STE100 (Simplified Technical English)** per the Response Style rules in CLAUDE.md/AGENTS.md. If there are multiple steps, give a numbered list. Order the steps by sequence when one step must come after another. If the order is free, put the most important step first. Use one short sentence for each step. No preamble.
+1. **Write it in ASD-STE100 (Simplified Technical English)** per the Response Style rules in CLAUDE.md/AGENTS.md. If there are multiple steps, give a numbered list. Order the steps by sequence when one step must come after another. If the order is free, put the most important step first. No preamble.
 2. **Take the steps from the session.** Do not invent work the conversation or the code does not support.
 3. **Say who acts.** Start each line with `You:` or `Me:`. If nothing is open, say so in one line.

--- a/skills/wans/SKILL.md
+++ b/skills/wans/SKILL.md
@@ -9,6 +9,6 @@ Answer one question: what are the next steps?
 
 ## Rules
 
-1. **Write it in ASD-STE100 (Simplified Technical English)** per the Response Style rules in CLAUDE.md/AGENTS.md. If there are multiple steps, give a numbered list, most important first. Use one short sentence for each step. No preamble.
+1. **Write it in ASD-STE100 (Simplified Technical English)** per the Response Style rules in CLAUDE.md/AGENTS.md. If there are multiple steps, give a numbered list. Order the steps by sequence when one step must come after another. If the order is free, put the most important step first. Use one short sentence for each step. No preamble.
 2. **Take the steps from the session.** Do not invent work the conversation or the code does not support.
 3. **Say who acts.** Start each line with `You:` or `Me:`. If nothing is open, say so in one line.


### PR DESCRIPTION
## Summary

Adds `wans`, a utility skill that answers one question: what are the next steps?

Three rules: write in ASD-STE100, and use a numbered list when there are multiple steps — ordered by sequence where one step must follow another, and by importance where the order is free; take the steps from the session and do not invent work; start each line with `You:` or `Me:`.

`wans` is a sibling of `tldr`. `tldr` looks back at the last answer, and `wans` looks forward at the work.

## Verification

- `bun test` — 265 pass, 0 fail. No test edits.
- Install needs no change: `install.sh` links every directory under `skills/`.

## Files

- `skills/wans/SKILL.md` (new)
- `README.md` — one row in the Utility skills table.

## Plain simple English

You can now type `/wans` to get the next steps for the work in the session, in plain simple English. Each step tells who does it. Several steps come as a numbered list in the order you can do them.

https://claude.ai/code/session_0186f8u9SBDp424nZXuv3oGa

---
Updated with LLM: Opus 5 | high | Harness: Claude Code
