### PR TITLE
refactor(#209): shrink the validate-issue core under 8,000 bytes [C66, Fable 5, high]

### DIFF
--- a/skills/validate-issue/SKILL.md
+++ b/skills/validate-issue/SKILL.md
@@ -9,19 +9,19 @@ Validate every current-behavior claim against code. Input: a full issue URL, `#N
 
 ### 0. Default-branch baseline
 
-No worktree for validation or issue edits. Resolve `DEFAULT=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)`; run `git fetch origin "$DEFAULT"`; `git rev-list --left-right --count "origin/$DEFAULT...HEAD"`. Read working-tree files only at `0 0`, or when `git diff --name-only HEAD "origin/$DEFAULT"` excludes every inspected path; otherwise `git show "origin/$DEFAULT":<path>`. State the baseline in the verdict.
+No worktree for validation or issue edits. Resolve `DEFAULT=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)`; `git fetch origin "$DEFAULT"`; `git rev-list --left-right --count "origin/$DEFAULT...HEAD"`. Read working-tree files only at `0 0`, or when `git diff --name-only HEAD "origin/$DEFAULT"` excludes every inspected path; otherwise `git show "origin/$DEFAULT":<path>`. State the baseline in the verdict.
 
 ### 1. Fetch the issue and linked PRs
 
-Fetch body and comments with `gh issue view <N> --comments`; comments omit cross-referenced pull requests, so also read the paginated issue timeline API for `cross-referenced` events with `.source.issue.pull_request` set. Verify merged fixes against current code; recommend closure or reuse. List overlapping open work under Concerns.
+Fetch body and comments with `gh issue view <N> --comments`; comments omit cross-referenced PRs, so also read the paginated issue timeline API for `cross-referenced` events with `.source.issue.pull_request` set. Verify merged fixes against current code, recommend closure or reuse, and list overlapping open work under Concerns.
 
 ### 2. Extract claims and assertions
 
-List each concrete current-behavior claim (causes, citations, sets, negatives, benefit premises) and each proposal assertion (goals, lifetime, population timing, benefits, consumers, failure policy, deployment surface, touched sites). Steps 5a and 5b run for a new subsystem, shared state, cross-cutting refactor, deduplication, single source of truth, multi-consumer coordination, or infrastructure analogy.
+List each current-behavior claim (causes, citations, sets, negatives, benefit premises) and proposal assertion (goals, lifetime, population timing, benefits, consumers, failure policy, deployment surface, touched sites). Steps 5a and 5b run for a new subsystem, shared state, cross-cutting refactor, deduplication, single source of truth, multi-consumer coordination, or infrastructure analogy.
 
 ### 3. Verify claims
 
-Trace each scenario through its conditions and configuration; when code contradicts prose, trust the code. Verify independently even for the repo owner, recent changes, or runtime state machines. Apply every triggered depth rule:
+Trace each scenario through its conditions and config; when code contradicts prose, trust the code. Verify independently even for the repo owner, recent code, or runtime state machines. Apply every triggered depth rule:
 
 1. Named wrapper/helper: read its body and delegated or short-circuit paths.
 2. Set claim: find real call sites, establish membership, diff the claimed set.
@@ -36,7 +36,7 @@ Evidence outranks every verdict; reconcile it across bullets and paired findings
 
 ### 4. Mark claims
 
-Mark ✅ Verified, ❌ Refuted (name the real symbol if found), ⚠️ Conditional (name the config), or ❓ Unverified; cite `file:line` and retain every unresolved claim.
+Mark ✅ Verified, ❌ Refuted (name the real symbol), ⚠️ Conditional (name the config), or ❓ Unverified; cite `file:line` and retain every unresolved claim.
 
 ### 5. Assess the proposal
 
@@ -48,15 +48,15 @@ For every non-trivial proposal from step 2, read [architecture.md](architecture.
 
 #### 5b. Self-consistency
 
-Whenever 5a runs, also read [proposal-consistency.md](proposal-consistency.md) completely; apply it to the issue text.
+Whenever 5a runs, read [proposal-consistency.md](proposal-consistency.md) completely; apply it to the issue text.
 
 #### 5c. General checks
 
-Run `git log --since=7.days` on touched paths; check locking, migrations, reloads, idempotency, failure blast radius, parallel live/offline/admin paths, dual implementations, and regression of recent work. Material findings go under Concerns with `file:line`; any safety, recent-work, or parity defect requires an update.
+Run `git log --since=7.days` on touched paths; check locking, migrations, reloads, idempotency, failure blast radius, parallel live/offline/admin paths, dual implementations, and recent-work regression. Material findings go under Concerns with `file:line`; any safety, recent-work, or parity defect requires an update.
 
 ### 6. Score complexity
 
-Read [complexity-scoring.md](complexity-scoring.md) completely on every validation; derive axes from the traced edit and test list. The canonical formula is:
+Read [complexity-scoring.md](complexity-scoring.md) completely on every validation; derive axes from the traced edits and tests. The canonical formula is:
 
 1. Capability maps `max(Risk, Uncertainty)` as `0–1 → 0`, `2 → 1`, `3 → 2`, `4 → 3`. If **Coupling ≥ 3**, use at least Capability 2.
 2. Volume is `(Scope + Coupling + Verification) × 2`.
@@ -71,7 +71,7 @@ Read [complexity-scoring.md](complexity-scoring.md) completely on every validati
 | 4 | 71–80 | Fable 5 · medium | **Yes** | Opus 5 · high |
 | 5 | 81–99 | Fable 5 · high | **Yes** | Opus 5 · xhigh |
 
-The fableplan signal is yes when the score is 71 or higher. The **first review** escalates on a coarser scale; its rows start on band edges above.
+The fableplan signal is yes when the score is 71 or higher. The **first review** escalates on a coarser scale; rows start on band edges above.
 
 | Score | First review | Claude | Codex |
 |---|---|---|---|
@@ -80,11 +80,11 @@ The fableplan signal is yes when the score is 71 or higher. The **first review**
 | 71–80 | Opus 5 · high | `@claude opus review` | `@codex review` |
 | 81–99, or no score | Fable 5 · high | `@claude fable review effort:high` | `@codex review` |
 
-Blocking re-reviews step down one rung at a time, keyed to the reviewer that actually ran cycle 1, never to the score band; `skills/fix-pr-review/rereview-routing.md` owns the rungs and floor.
+Blocking re-reviews step down one rung at a time, keyed to the reviewer that actually ran cycle 1, never to the score band (`skills/fix-pr-review/rereview-routing.md`).
 
 ### 7. Scope disposition
 
-A high score alone is acceptable; Split and Umbrella must pass all three gates:
+A high score alone is acceptable; Split and Umbrella must pass three gates:
 
 1. Each part can ship, pass tests, and deliver value in its own PR.
 2. Fold parts below C41 into the parent; at least two remaining parts must each score C41 or higher, and any folded part forces Umbrella. With fewer than two, keep one issue, emit `OK — restructure as in-body checklist`, and require an update when the body lacks it.
@@ -114,7 +114,7 @@ Scope:  # only for a disposition
 <next-step line>
 ```
 
-Yes for a material ❌/⚠️ claim, architecture/consistency gap, material concern, missing scope, or required restructure; No only when accurate, feasible, consistent, complete, and ready.
+Yes for a material ❌/⚠️ claim, architecture/consistency gap, material concern, missing scope, or required restructure; No only when accurate, feasible, consistent, and complete.
 
 **Next-step line.** Post the first matching string verbatim; with fableplan no, drop that option and its connective (case 3: `or` moves before `"update issue"`):
 
@@ -124,7 +124,7 @@ Yes for a material ❌/⚠️ claim, architecture/consistency gap, material conc
 
 ### 9. Handle "work on issue"
 
-Invoke `work-on-issue` with the issue number; surface any step-7 scope disposition first.
+Invoke `work-on-issue` with the issue number; surface any step-7 disposition first.
 
 ### 10. Handle "fableplan"
 
@@ -132,4 +132,4 @@ Invoke `fableplan` with the issue number; honor an explicit request even at sign
 
 ### 11. Handle "update issue"
 
-Read [issue-editing.md](issue-editing.md) completely; apply its verified title/body procedure from the current checkout, no worktree.
+Read [issue-editing.md](issue-editing.md) completely; apply its verified title/body procedure from the checkout, no worktree.

--- a/skills/validate-issue/SKILL.md
+++ b/skills/validate-issue/SKILL.md
@@ -1,88 +1,68 @@
 ---
 name: validate-issue
-description: Use when the user asks to validate, review, or check whether a GitHub issue is valid. Accepts an issue reference or defaults to the latest open issue, verifies every factual claim against current code, assesses non-trivial proposals, scores complexity, and returns a cited update decision.
+description: Use when the user asks to validate, review, or check a GitHub issue against the code. Returns a cited update decision with a complexity score.
 ---
 
 # validate-issue
 
-Validate every current-behavior claim against code. Treat cited roots, lines, fixes, and prior verdicts as claims that need independent proof. Return one decision that covers behavior, cause, evidence, proposal, scope, and fix.
+Validate every current-behavior claim against code. Input: a full issue URL, `#N`, `N`, or `owner/repo#N` — with none, take the newest open issue and state the number.
 
-## Input
+### 0. Default-branch baseline
 
-Accept a full issue URL, `#N`, `N`, or `owner/repo#N`. With no input, resolve the newest open issue in the current repo and state the selected number.
+No worktree for validation or issue edits. Resolve `DEFAULT=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)`; run `git fetch origin "$DEFAULT"`; `git rev-list --left-right --count "origin/$DEFAULT...HEAD"`. Read working-tree files only at `0 0`, or when `git diff --name-only HEAD "origin/$DEFAULT"` excludes every inspected path; otherwise `git show "origin/$DEFAULT":<path>`. State the baseline in the verdict.
 
-### 0. Establish the default-branch baseline
+### 1. Fetch the issue and linked PRs
 
-Do not create a worktree for validation or issue edits. Resolve and refresh the current default branch:
+Fetch body and comments with `gh issue view <N> --comments`; comments omit cross-referenced pull requests, so also read the paginated issue timeline API for `cross-referenced` events with `.source.issue.pull_request` set. Verify merged fixes against current code; recommend closure or reuse. List overlapping open work under Concerns.
 
-```bash
-DEFAULT=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
-git fetch origin "$DEFAULT"
-git branch --show-current
-git rev-list --left-right --count "origin/$DEFAULT...HEAD"
-```
+### 2. Extract claims and assertions
 
-Read working-tree files only at `0 0`, or when `git diff --name-only HEAD "origin/$DEFAULT"` excludes every inspected path. Otherwise use `git show "origin/$DEFAULT":<path>`. State the baseline in the verdict.
+List each concrete current-behavior claim (causes, citations, sets, negatives, benefit premises) and each proposal assertion (goals, lifetime, population timing, benefits, consumers, failure policy, deployment surface, touched sites). Steps 5a and 5b run for a new subsystem, shared state, cross-cutting refactor, deduplication, single source of truth, multi-consumer coordination, or infrastructure analogy.
 
-### 1. Fetch the issue and linked pull requests
+### 3. Verify claims
 
-Always fetch the body and comments with `gh issue view <N> --comments`. For omitted input, first resolve `gh issue list --limit 1 --json number --jq '.[0].number'`. Then inspect the issue timeline for cross-referenced pull requests; comment output does not include them:
+Trace each scenario through its conditions and configuration; when code contradicts prose, trust the code. Verify independently even for the repo owner, recent changes, or runtime state machines. Apply every triggered depth rule:
 
-```bash
-gh api "repos/<owner>/<repo>/issues/<N>/timeline" --paginate \
-  --jq '.[] | select(.event == "cross-referenced" and .source.issue.pull_request) | .source.issue'
-```
+1. Named wrapper/helper: read its body and delegated or short-circuit paths.
+2. Set claim: find real call sites, establish membership, diff the claimed set.
+3. Benefit claim: prove the broken baseline still exists (code, comments, history).
+4. Conjunction/negative: split atomic assertions; prove absence on all paths.
+5. Negative over a window: trace the event-to-boundary dispatch and every producer.
+6. Superlative, method-over-set, or cited baseline: establish population, tool coverage, source history.
+7. Aggregate/dedupe/prorate/shared state: verify partition boundary and key against the scope.
+8. Missing/undocumented/unhandled surface: read surrounding content, find stale copy, diff deliverables.
 
-Verify merged fixes against current code and recommend closure or reuse. List overlapping open work under Concerns.
+Evidence outranks every verdict; reconcile it across bullets and paired findings.
 
-### 2. Extract claims and proposal assertions
+### 4. Mark claims
 
-List each concrete current-behavior claim, including named causes, citations, sets, negatives, and benefit premises. Separately extract proposal goals, lifetime, population timing, benefits, consumers, failure policy, deployment surface, and touched sites. Run steps 5a and 5b for a new subsystem, shared state, cross-cutting refactor, deduplication, single source of truth, multi-consumer coordination, or infrastructure analogy.
-
-### 3. Verify every claim
-
-Trace each scenario through its conditions and configuration. Apply every triggered depth rule:
-
-1. **Named wrapper/helper:** read its body and delegated or short-circuit paths.
-2. **Set claim:** find real call sites, establish membership, and diff the claimed set.
-3. **Benefit claim:** prove the broken baseline still exists with code, comments, and relevant history.
-4. **Conjunction or negative:** split atomic assertions and prove absence across all paths.
-5. **Negative over a window:** trace the complete event-to-boundary dispatch and every possible producer.
-6. **Superlative, method-over-set, or cited baseline:** establish the full population, actual tool coverage, and source history.
-7. **Aggregate, dedupe, prorate, or shared state:** verify its partition boundary and key against the proposed scope.
-8. **Missing, undocumented, or unhandled surface:** read surrounding content, find stale old copy, and diff the deliverable file list.
-
-Evidence outranks every verdict. Reconcile evidence across all bullets and your own paired findings before finalizing.
-
-### 4. Mark each claim
-
-Use ✅ Verified, ❌ Refuted, ⚠️ Conditional, or ❓ Unverified. Cite `file:line` for each located path, name conditions, and retain every unresolved claim.
+Mark ✅ Verified, ❌ Refuted (name the real symbol if found), ⚠️ Conditional (name the config), or ❓ Unverified; cite `file:line` and retain every unresolved claim.
 
 ### 5. Assess the proposal
 
-Lead Proposal with a ≤55-word ASD-STE100 Goal that states the outcome. Assess claims before design; a refuted premise can make the proposal unnecessary.
+Lead Proposal with a ≤55-word ASD-STE100 Goal stating the outcome; a refuted premise can make the proposal unnecessary.
 
 #### 5a. Architecture
 
-For every non-trivial proposal identified in step 2, read [architecture.md](architecture.md) completely and apply it after claim tracing.
+For every non-trivial proposal from step 2, read [architecture.md](architecture.md) completely; apply it after claim tracing.
 
 #### 5b. Self-consistency
 
-Whenever step 5a runs, also read [proposal-consistency.md](proposal-consistency.md) completely and apply it to the issue text.
+Whenever 5a runs, also read [proposal-consistency.md](proposal-consistency.md) completely; apply it to the issue text.
 
 #### 5c. General checks
 
-Use `git log --since=7.days` on touched paths. Check locking, migrations, reloads, idempotency, failure blast radius, parallel live/offline/admin paths, dual implementations, and regression of recent work. Put each material finding under Concerns with `file:line`; any safety, recent-work, or parity defect makes the issue require an update.
+Run `git log --since=7.days` on touched paths; check locking, migrations, reloads, idempotency, failure blast radius, parallel live/offline/admin paths, dual implementations, and regression of recent work. Material findings go under Concerns with `file:line`; any safety, recent-work, or parity defect requires an update.
 
 ### 6. Score complexity
 
-Read [complexity-scoring.md](complexity-scoring.md) completely on every validation. Derive axes from the traced edit and test list. The canonical formula is:
+Read [complexity-scoring.md](complexity-scoring.md) completely on every validation; derive axes from the traced edit and test list. The canonical formula is:
 
 1. Capability maps `max(Risk, Uncertainty)` as `0–1 → 0`, `2 → 1`, `3 → 2`, `4 → 3`. If **Coupling ≥ 3**, use at least Capability 2.
 2. Volume is `(Scope + Coupling + Verification) × 2`.
-3. Score is `25 × Capability + Volume` (0–99 under current axis bounds).
+3. Score is `25 × Capability + Volume`.
 
-| Band | Score band | Validate | fableplan first | Build |
+| Band | Score | Validate | fableplan | Build |
 |---|---|---|---|---|
 | 0 | 0–9 | Opus 5 · medium | No | Sonnet 5 · high |
 | 1 | 10–20 | Opus 5 · high | No | Sonnet 5 · xhigh |
@@ -91,99 +71,65 @@ Read [complexity-scoring.md](complexity-scoring.md) completely on every validati
 | 4 | 71–80 | Fable 5 · medium | **Yes** | Opus 5 · high |
 | 5 | 81–99 | Fable 5 · high | **Yes** | Opus 5 · xhigh |
 
-The fableplan signal is yes when the score is 71 or higher. It is no below 71.
+The fableplan signal is yes when the score is 71 or higher. The **first review** escalates on a coarser scale; its rows start on band edges above.
 
-The **first review** escalates on its own, coarser scale. Its boundaries fall on the band edges above, so each first-review row groups whole bands rather than cutting across them. It is still a separate table, but each row must start on a band edge above, so a band change that moves an edge this table uses moves this table with it, while a band split that only adds a new edge leaves it unchanged.
-
-| Score | First review | Claude trigger | Codex trigger |
+| Score | First review | Claude | Codex |
 |---|---|---|---|
 | 0–20 | Sonnet 5 · high | `@claude sonnet review` | `@codex luna review` |
-| 21–70 | the reviewer's default model | `@claude review` (standard trigger, no pinned model) | `@codex review` |
+| 21–70 | reviewer default | `@claude review` | `@codex review` |
 | 71–80 | Opus 5 · high | `@claude opus review` | `@codex review` |
 | 81–99, or no score | Fable 5 · high | `@claude fable review effort:high` | `@codex review` |
 
-Codex exposes one flagship and no Fable tier, so every row above 0–20 collapses onto the bare `@codex review`. The cheap `@codex luna review` covers the 0–20 row and the non-blocking re-review only.
+Blocking re-reviews step down one rung at a time, keyed to the reviewer that actually ran cycle 1, never to the score band; `skills/fix-pr-review/rereview-routing.md` owns the rungs and floor.
 
-A missing score reviews on the heaviest row (Fable) because the complexity is unknown. "Missing" means the title carries no `[C<score>]` prefix at all. A literal `[C0]` is a real score — every axis graded 0 — so it takes the `0–9` build band and the `0–20` first-review row like any other score.
+### 7. Scope disposition
 
-**Every reviewer above the standard trigger runs one blocking cycle only.** Each blocking re-review steps down one rung. The ladder floor is `@claude review`, which repeats for every blocking cycle after it:
+A high score alone is acceptable; Split and Umbrella must pass all three gates:
 
-| Cycle-1 reviewer | Blocking cycle 2 | Blocking cycle 3 and after |
-|---|---|---|
-| `@claude fable review effort:high` | `@claude opus review` | `@claude review` |
-| `@claude opus review` | `@claude review` | `@claude review` |
+1. Each part can ship, pass tests, and deliver value in its own PR.
+2. Fold parts below C41 into the parent; at least two remaining parts must each score C41 or higher, and any folded part forces Umbrella. With fewer than two, keep one issue, emit `OK — restructure as in-body checklist`, and require an update when the body lacks it.
+3. The combined diff is roughly above 500 changed lines, parts route to different bands, or a part has money, data-integrity, or security risk.
 
-The ladder never steps down to Sonnet, because a change that earned a capable first review keeps one however many cycles it takes. Sonnet sits below the floor and takes no rung: a Sonnet cycle 1 repeats `@claude sonnet review` for every blocking re-review, and the ladder never steps up from it. The step-down is keyed to the reviewer that actually ran cycle 1, and the score band does not decide it: a stamped `PR review:` line naming Fable or Opus at any score steps down exactly like a band-selected one. A pass that addressed only non-blocking findings drops to `@claude sonnet review` without consuming a rung. Codex has no ladder — its cycle-1 trigger repeats for every blocking re-review.
-
-Report only `N/100 — Capability <k> (<driver>); Volume <v> · fableplan: <yes|no>` plus the traced edit list.
-
-### 7. Decide scope disposition
-
-A high score alone is acceptable. Narrow speculative scope whenever needed. Split and Umbrella candidates must pass all three gates:
-
-1. Each part can ship, pass tests, and deliver value in its own pull request.
-2. Fold each part below C41 into the parent. At least two remaining parts must each score C41 or higher. Any folded part forces Umbrella. If fewer than two remain, keep one issue; emit `OK — restructure as in-body checklist` and require an update when its body lacks that checklist.
-3. The combined diff is roughly above 500 changed lines, the parts route to different score bands, or one part has money, data-integrity, or security risk.
-
-Keep one issue when any gate fails or one root cause requires one diff. Use **Split** for independent parts with no folded work and **Umbrella** for coordinated parts or any folded work. **Narrow** remains available regardless of these gates; cut to the core and move optional work to a Future note. Every proposed child needs its own scored title, problem, and acceptance criteria. Scope and description-update decisions remain independent.
+Keep one issue when any gate fails or one root cause needs one diff. **Split** = independent parts, none folded; **Umbrella** = coordinated or folded parts; **Narrow** always available — cut to the core, move extras to a Future note. Every child needs its own scored title, problem, and acceptance criteria; scope and update decisions stay independent.
 
 ### 8. Output the verdict
 
-Use this structure and omit empty optional sections:
+Omit empty optional sections:
 
 ```text
 Claims:
 - <status> <claim> — <evidence>
-Architecture:                         # only when 5a ran
+Architecture:  # only when 5a ran
 - <status> <placement/owner/medium> (<dispatch file:line>)
 - Optimal: <required for ⚠️/❌>
-Concerns:                             # only when present
+Concerns:  # only when present
 - <concern> (<file:line>)
 Proposal:
 - Goal: <plain simple English, ≤55 words>
-- <status> <consistency gap>          # only when 5b is not ✅
-Scope:                                # only when too large or checklist restructure applies
+- <status> <consistency gap>  # only when 5b is not ✅
+Scope:  # only for a disposition
 - <disposition> — <reason and parts>
 **#<N>: Update issue description? <Yes | No>** · Complexity: <score>/100 — Capability <k> (<driver>); Volume <v> · fableplan: <yes|no> · Scope: <OK | too large — split/umbrella/narrow>
 <specific edits when Yes>
-<next-step line — see the rule below; it carries its own leading arrow>
+<next-step line>
 ```
 
-Set Yes for a material ❌/⚠️ claim, architecture or consistency gap, material concern, missing scope, or required checklist restructure. Set No only when the issue is accurate, feasible, consistent, complete, and ready. Always offer `fableplan` when its signal is yes; if the user chooses work first, ask once whether to plan or build directly.
+Yes for a material ❌/⚠️ claim, architecture/consistency gap, material concern, missing scope, or required restructure; No only when accurate, feasible, consistent, complete, and ready.
 
-**Next-step line.** The line always leads with the action this verdict recommends, then lists the other options. Match the first case that applies, then take the variant for the fableplan signal, and post that line verbatim — each one already carries its leading `→` and is complete as written. Never assemble the line by deleting words from another variant.
+**Next-step line.** Post the first matching string verbatim; with fableplan no, drop that option and its connective (case 3: `or` moves before `"update issue"`):
 
-1. Scope disposition is split or umbrella:
-   - fableplan yes → `→ Recommend "split issue" to restructure; or "update issue" to edit, "work on issue" to build as-is, "fableplan" to plan first.`
-   - fableplan no → `→ Recommend "split issue" to restructure; or "update issue" to edit, "work on issue" to build as-is.`
-2. Update issue description is Yes:
-   - fableplan yes → `→ Recommend "update issue" to apply the edits above; or "work on issue" to build as-is, "fableplan" to plan first.`
-   - fableplan no → `→ Recommend "update issue" to apply the edits above; or "work on issue" to build as-is.`
-3. Otherwise:
-   - fableplan yes → `→ Reply "work on issue" to proceed, "update issue" to edit, or "fableplan" to plan first.`
-   - fableplan no → `→ Reply "work on issue" to proceed, or "update issue" to edit.`
+1. Split/umbrella scope: `→ Recommend "split issue" to restructure; or "update issue" to edit, "work on issue" to build as-is, "fableplan" to plan first.`
+2. Update is Yes: `→ Recommend "update issue" to apply the edits above; or "work on issue" to build as-is, "fableplan" to plan first.`
+3. Otherwise: `→ Reply "work on issue" to proceed, "update issue" to edit, or "fableplan" to plan first.`
 
 ### 9. Handle "work on issue"
 
-Invoke `work-on-issue` with the issue number. It owns worktree creation through the open closing pull request. Surface any step-7 scope disposition before handoff.
+Invoke `work-on-issue` with the issue number; surface any step-7 scope disposition first.
 
 ### 10. Handle "fableplan"
 
-Invoke `fableplan` with the issue number. It owns planning, posting the issue comment, and asking whether to build. Honor an explicit request even when the signal is no.
+Invoke `fableplan` with the issue number; honor an explicit request even at signal no.
 
 ### 11. Handle "update issue"
 
-Read [issue-editing.md](issue-editing.md) completely, then apply its verified title/body procedure from the current checkout without a worktree.
-
-## Red flags
-
-| Situation | Action |
-|---|---|
-| Named function does not exist | Mark ❌ and name the actual symbol if found. |
-| Claim holds for one configuration | Mark ⚠️ and name that configuration. |
-| Author owns the repo | Verify every claim independently. |
-| Code changed recently | Inspect relevant history. |
-| Claim depends on runtime cycles | Trace the state machine. |
-| Code contradicts issue prose | Trust the code. |
-| Shared/global/central state has no owner | Require step 5a ownership details. |
-| Cross-cutting proposal has verified claims | Still run steps 5a and 5b. |
+Read [issue-editing.md](issue-editing.md) completely; apply its verified title/body procedure from the current checkout, no worktree.


### PR DESCRIPTION
Closes #209

## Summary

- `skills/validate-issue/SKILL.md` drops from 12,896 to 7,983 bytes (acceptance: at or under 8,000). Directory markdown total drops from 24,925 to 20,012 bytes (acceptance ceiling: 23,295). Companion files are unchanged.
- The canonical copies stay in the core: the scoring formula, the validate/build band table, the first-review table, and the verdict-block template with Update, Complexity, Capability, Volume, fableplan, and Scope fields.
- Removed prose that restated owned content elsewhere: the step-down ladder table and its long paragraph (`skills/fix-pr-review/rereview-routing.md` owns the rungs; `complexity-scoring.md` routing details restate them), the Codex-collapse and missing-score paragraphs (also restated in `complexity-scoring.md`), and the Red flags table (each row repeated a step; the unique rows folded into steps 3 and 4).
- The six next-step variants collapse to three canonical strings plus one deterministic rule that drops the fableplan option when the signal is no. The core keeps the cycle-1 ladder keying sentence and every step number that other skills reference (0, 5a/5b/5c, 6, 7, 8, 9, 10, 11).

Deviation from the issue's Approach, with ground: the Approach said to keep "the six strings in a compact list", but the 8,000-byte acceptance criterion could not be met while also keeping every unique procedure the Approach requires to stay. The acceptance criteria are the checkable contract, so three strings plus a deterministic transformation rule replace the six verbatim strings.

## Verification

- `git show HEAD:skills/validate-issue/SKILL.md | wc -c` → 7,983 (measured on the committed artifact after the review fix; the first push mis-measured with a character count).
- `wc -c skills/validate-issue/*.md` sum → 20,012.
- `bun test` → 265 pass, 0 fail. No test edits were needed: the contract markers (formula patterns, six band rows, four first-review rows, verdict fields, "keyed to the reviewer that actually ran cycle 1", 5a/5b/5c labels) all held.

## Plain simple English

The validate skill's main file was too long. It repeated rules that other files already own. This change removes the repeated text and keeps the score formula, the routing tables, and the verdict template in place. All tests pass without changes.

---
Created with LLM: Fable 5 | high | Harness: Claude Code

