### PR TITLE
refactor(#203): shrink the fix-pr-review skill below its size caps [C66, Fable 5, high]

### DIFF
--- a/skills/fix-pr-review/SKILL.md
+++ b/skills/fix-pr-review/SKILL.md
@@ -1,199 +1,89 @@
 ---
 name: fix-pr-review
-description: Use when the user asks to fix, address, or respond to a PR review — "fix the PR review", "address the review comments", "/fix-pr-review". Takes an optional PR number/URL (defaults to the current branch's PR) and an optional `codex` argument, in either order, to select Codex as the review bot (e.g. "/fix-pr-review 123 codex"). Fetches every unaddressed review channel (formal reviews, review-style issue comments, inline diff threads, already-failed CI checks), RE-VALIDATES each finding against the actual code before touching anything (never blind-implements), fixes what survives, and derives and implements the absolute-best solution for judgment calls and optional improvements without pausing. Then resolves base-branch merge conflicts, commits and pushes, posts a per-finding disposition comment, and triggers a fresh re-review from the selected bot (@claude by default, @codex when selected).
+description: Use when the user asks to fix, address, or respond to a PR review — "fix the PR review", "/fix-pr-review". Optional PR number/URL (defaults to the current branch's PR); optional `codex` argument selects Codex as the review bot.
 ---
 
 # fix-pr-review
 
-Resolve every unaddressed review finding on a pull request autonomously: validate each one, fix or refute it, implement the judgment calls and the optional improvements to the absolute-best-solution standard, report back on the PR, and request a re-review. Don't stop to ask the user; do the work.
-
-**The review is a hypothesis, not a work order.** A reviewer (human or `@claude`) can cite a stale line, misread a conditional, or flag a non-bug. Implementing a wrong suggestion ships a regression with a reviewer's blessing. So every finding is traced to current `file:line` and confirmed *before* you change anything. You are not performing agreement — you are verifying claims and acting only on the ones that hold.
+Resolve every unaddressed review finding autonomously: validate, fix or refute, implement judgment calls and optional improvements, and request a re-review. Don't stop to ask the user. **The review is a hypothesis, not a work order**: trace every finding to current `file:line` and confirm it *before* changing anything.
 
 ## Input
 
-The user provides, in any order:
-- An optional PR reference: `#<N>` / `<N>` / full URL / `owner/repo#N`. Omit it to **default to the PR for the current branch** (`gh pr view`).
-- An optional literal bot token, `codex` (case-insensitive), selecting Codex as this cycle's re-review bot (step 10). A token that is neither a PR reference nor `codex` is not a bot selection.
-
-A token matching neither category (a typo like `codexx`, a malformed reference like `#abc`, a stray extra word) doesn't block resolution: ignore it for parsing — fall back to the current-branch PR if no valid reference was given, and to `@claude` if `codex` wasn't given — but name it in the step 11 report as an unrecognized argument, so a mistyped intent doesn't silently produce the wrong outcome.
-
-If the current branch has no PR and none was given, say so and stop — there's nothing to fix.
+In any order: an optional PR reference (number or URL; default = the current branch's PR) and an optional literal `codex` token selecting Codex as this cycle's re-review bot. Any other token doesn't block — use the defaults and name it in the step 11 report as an unrecognized argument. No PR found and none given → say so and stop.
 
 ## Steps
 
-### 0. Resolve the PR and sync the branch
+### 0. Resolve the PR and sync
 
-```bash
-gh pr view <N|--> --json number,headRefName,headRepositoryOwner,baseRefName,url,state,isDraft,mergeable,mergeStateStatus
-git fetch origin
-git branch --show-current
-```
-
-- Confirm you are **on the PR's head branch** (`headRefName`); if not, check it out with `gh pr checkout <N>`, which handles fork-hosted heads and sets upstream tracking. Fixes land on the branch the PR tracks. Never fix a review by committing to the base branch.
-- Note whether the PR is from a **fork** (`headRepositoryOwner` differs from the base repo's owner) — its head lives in the fork, so pulls and pushes go to the tracked upstream rather than `origin`.
-- Pull the latest head so you fix against what the reviewer saw: `git pull --ff-only` on the tracked upstream (if it can't fast-forward, stop and tell the user the branch diverged).
-- Note the PR state. If it's already `merged` or `closed`, stop and report — don't reopen work on a closed PR without the user.
-- Note `mergeable`/`mergeStateStatus`. If the PR is `CONFLICTING`/`DIRTY`, resolving the conflict is part of this run (step 7) — a reviewed PR that can't merge isn't done.
+`gh pr view <N|--> --json headRefName,headRepositoryOwner,baseRefName,state,mergeable,mergeStateStatus`, then `git fetch origin`. Be **on the PR's head branch** (`gh pr checkout <N>` if not; never fix a review on the base branch); on a **fork** PR (`headRepositoryOwner` differs), pull and push to the tracked upstream, never assume `origin`. `git pull --ff-only` — can't fast-forward → stop and report. `merged`/`closed` → stop and report. `CONFLICTING`/`DIRTY` → step 7 is part of this run.
 
 ### 1. Fetch all unaddressed review feedback
 
-Review feedback arrives through three channels: formal GitHub PR reviews, plain issue comments (the `@claude` bot posts the verdict-and-sections format as an issue comment), and **inline diff comments** (line-level threads, where human reviewers most often comment). Fetch all three with the queries in [fetch-recipes.md](fetch-recipes.md) — read it completely; it includes the GraphQL thread query with resolution state and the pagination rule.
+Three channels: formal reviews, issue comments, and inline diff threads. Fetch and select the unaddressed set per [fetch-recipes.md](fetch-recipes.md) — read it completely; it defines the cutoff and collection rules. **Never delete, edit, or bury a disposition comment**: the next review reads them on purpose. State what you picked and **note whether the set contains any blocking finding** (a `Needs Fixing` / `Requires Human Review` item, a thread asserting a real defect, or a failing check) — this drives step 10.
 
-Determine the **cutoff**: the timestamp of your most recent disposition comment on the PR (or the last commit you pushed addressing a review). Then collect:
-
-- Every formal review or review-formatted issue comment **newer than the cutoff** (no cutoff → everything since the PR opened) — it opens with a `LGTM` / `Needs Updates` verdict, contains review sections like `### Needs Fixing`, or is otherwise clearly review feedback. **If multiple reviews landed — e.g. two reviewers — address all of them**, not just the latest. Skip `DISMISSED` reviews.
-- Every **unresolved** inline thread (`isResolved: false`), **regardless of age** — resolution state, not timestamp, decides whether a thread is open work. A thread from before the cutoff that the reviewer never resolved is still open. Exception: if the thread's last comment is your own disposition reply and no one has responded since, it's awaiting the reviewer — skip it. `isOutdated` alone doesn't mean resolved. Treat each thread as one finding.
-- Ignore your own prior disposition comments and `@claude review` trigger comments. That scoping is the fixer's alone — it skips its own words when collecting *new* work. The reviewer reads those same disposition comments on purpose, because `pr-review` requires the prior-cycle read before it drafts, so never delete, edit, or bury a disposition comment to keep the next review clean.
-
-State what you picked (authors + timestamps) so the user can confirm it's the right set.
-
-**Note whether the collected set contains any blocking finding** — a `Needs Fixing` or `Requires Human Review` item from any review, an inline thread asserting a real defect (classified in step 3), or any failing CI check from step 2. This drives the re-review routing in step 10.
-
-**If the only new feedback is `LGTM` with no blocking sections,** nothing is blocking, but the non-blocking items are still this run's work:
-- Implement each `Recommended Optional` item per step 6, and file each `Create Follow-up Issue` item as an issue per step 3's bar — step 6 edits no code for it, unless scope rule 1 claims it (a defect in code this PR adds or changes, or a hazard it creates), which is fixed here. Don't invent work the review never raised.
-- **Bare `LGTM`, no finding items, no open inline threads** — a `**Verification limitation:**` line does not count as a finding, and step 3 owns that rule: report the PR approved and stop, naming every such line in the step 11 report.
-- **Exception:** if step 0 flagged merge conflicts, still run step 7 (resolve, verify, push, disposition comment) so the approved PR is actually mergeable.
+**LGTM with no blocking sections** still gets its non-blocking items: implement `Recommended Optional` per step 6, file `Create Follow-up Issue` items (fixed here only under scope rule 1). **Bare `LGTM`, no finding items, no open threads** — a `**Verification limitation:**` line is not a finding — report approved and stop, naming such lines; conflicts still get step 7.
 
 ### 2. Fetch failing CI checks
 
-Take one snapshot of check status with `gh pr checks` (command in [fetch-recipes.md](fetch-recipes.md)). This is a point-in-time read, never a wait or a poll.
-
-`bucket` normalizes `state` into `pass`/`fail`/`pending`/`skipping`/`cancel`:
-- `bucket: pending` or `skipping` — **skip it entirely.** A check still running is not this run's problem; the next pass catches it. Don't retry the call, and don't treat "not done yet" as a finding.
-- `bucket: cancel` — skip unless the run log shows a real upstream failure caused the cancel; apply the cancelled-check attribution procedure in [fetch-recipes.md](fetch-recipes.md) to decide whether it becomes its own finding, and never invent an unverified upstream cause.
-- `bucket: fail` — pull just the failing detail, not the whole log, via the fail-bucket recipes in [fetch-recipes.md](fetch-recipes.md).
-- Each failing check becomes one finding: **CI Failure — `<check name>`**.
+One `gh pr checks` snapshot, never a wait or a poll; bucket handling, failing detail, and cancelled-check attribution per [fetch-recipes.md](fetch-recipes.md). Each `fail`-bucket check is one finding: **CI Failure — `<check name>`**.
 
 ### 3. Extract findings
 
-Parse all collected feedback — structured reviews, inline diff threads, and failing CI checks alike — into discrete findings, tagged by section:
-- **Needs Fixing** — blocking; reviewer asserts a real defect. Every CI Failure from step 2 starts here by default — a red check is real until step 4 proves otherwise.
-- **Requires Human Review** — blocking; reviewer couldn't decide (a genuine tradeoff or missing context).
-- **Recommended Optional** — non-blocking improvement.
-- **Create Follow-up Issue** — out-of-scope, track separately. Wherever this run files one (step 1's LGTM-only path, or the disposition's deferred section), the issue gets a complete body per `github-issue-format`, which owns the full rule — including a `## Plain simple English` section under 55 words. Never file a stub.
+Parse everything into atomic findings — split compound feedback, merge duplicates across sources noting all — tagged: **Needs Fixing** (blocking; every CI Failure starts here), **Requires Human Review** (blocking; the reviewer couldn't decide), **Recommended Optional** (non-blocking), **Create Follow-up Issue** (track separately; any issue this run files gets a complete body per `github-issue-format`, including a `## Plain simple English` section under 55 words — never a stub).
 
-A `**Verification limitation:**` line is not a finding. Skip every such line when classifying — do not bucket it, dispose it, rebut it, or treat it as remaining work. It does not block the approved-and-stop path and does not count toward "findings still listed."
+A `**Verification limitation:**` line is never a finding — skip it when classifying. Free-form feedback classifies into the same buckets by substance.
 
-For free-form feedback with no sections — including inline diff comments — classify each point yourself into the same four buckets by its substance. Keep each finding atomic — split compound feedback ("fix X and also Y") into separate findings so each gets its own verdict. When the same defect is raised by more than one source — reviewer, thread, *or* a CI Failure finding from step 2 (e.g. a reviewer flags "this breaks the type check" while the type-check job is already `bucket: fail`) — merge into one finding and note all sources, including the check name alongside the reviewer(s).
+### 4. Re-validate each finding
 
-### 4. Re-validate each finding against the code (the core step)
+For **every** finding, trace the claim to current code and assign a verdict with your own `file:line`: ✅ **Confirmed** (code matches → fix it, step 6); ❌ **Refuted** (the claim or its remedy doesn't hold → no change; record a code-grounded rebuttal); ⚠️ **Partial** (real but narrower/broader → fix the true part; note the correction); ❓ **Judgment** (a real tradeoff → derive and **implement** the best solution, below).
 
-For **every** finding — including ones that read as obviously correct — trace the claim to current code and assign a verdict. Endorsement is a verification act, not a relay: re-derive the finding from the code with your own `file:line`, don't transcribe the reviewer's reasoning.
+A `### Needs Fixing` item's stated `**Reachability:**` precondition is part of its claim — trace it to current code. On a code-grounded refutation of the trigger, the blocking status is refuted while the defect may still stand: re-route the finding to `### Recommended Optional`, scope-test its remedy, and record it under `### Corrected scope (partial)` in the disposition. A finding never re-routes on a likelihood judgment of your own; with no stated precondition it is validated as written.
 
-| Verdict | Meaning | Action |
-|---------|---------|--------|
-| ✅ **Confirmed** | Code at `file:line` matches the finding; the defect/improvement is real | Fix it (step 6) |
-| ❌ **Refuted** | Code does not do what the finding claims, or the suggested change would itself be wrong/regressive | Do **not** change; record a one-line, code-grounded rebuttal for the reply |
-| ⚠️ **Partial** | Real but narrower/broader than stated, or true only on one path. A `### Needs Fixing` item's stated `**Reachability:**` precondition is part of its claim: trace that trigger to current code, and on a refutation of that trigger the finding's **blocking status** is refuted while the defect itself may still stand | Fix the true part; note the correction. On a refuted precondition, re-route the finding to `### Recommended Optional`, run the scope rules below on its remedy like any other optional item, and record the re-route under `### Corrected scope (partial)` per [disposition-comment.md](disposition-comment.md). Only a code-grounded refutation of the stated trigger re-routes a finding. A finding never re-routes on a likelihood judgment of your own, and a finding that states no precondition is validated exactly as written |
-| ❓ **Judgment** | A real tradeoff or a decision the reviewer couldn't make (most `Requires Human Review` items) | Derive the absolute-best solution and **implement it** — the paragraph below owns the rule |
-
-Validation discipline (this is where fixing a review goes wrong):
-- **Read the body, not just the cited line.** A name states intent; open the function and trace the conditional fully before agreeing.
-- **Prove negatives by reading the path.** "X is never validated / never freed / not awaited" — confirm the absence across *all* relevant paths, not the one the reviewer looked at; the behavior may be produced elsewhere.
-- **A suggested fix is its own claim.** "Just add a lock here" can deadlock; "default it to N" can break a caller. Verify the *remedy* is correct for this codebase, not only that the *problem* exists. Derive the right fix from first principles if the suggested one is suboptimal — correctness and safety outrank matching the reviewer's wording.
-- **Safety carve-out** — money, data integrity, security, or an auto-protective mechanism. Such a finding gets fixed or escalated to the user even at low confidence; never silently dropped as Refuted unless you can prove from code it's a non-issue.
-- **CI Failures validate differently — there's no reviewer to be wrong, only the log to explain.** Read the failing step's actual error/assertion, not just the job name. ✅ Confirmed if the failure traces to this PR's diff — fix it (and reproduce the exact failing command locally where feasible, so step 6's verification actually exercises it). ❌ Refuted only with evidence it's *not* this PR's doing — pre-existing on `<baseRefName>` (check CI history / reproduce on base) or a one-off infra flake (timeout/network blip unrelated to any path this PR touches) — don't patch around it; note it in the disposition and flag it to the user, since a flaky or broken base branch is worth knowing about independent of this PR.
+Apply the validation-discipline list in [red-flags-and-mistakes.md](red-flags-and-mistakes.md): whole-body reads and negative proofs, a suggested fix verified as its own claim, the **safety carve-out** (money, data integrity, security, auto-protective mechanisms — fix or escalate even at low confidence, never silently drop without code proof), and CI-failure attribution (fix only failures this PR's diff caused).
 
 #### Scope: the second axis on every finding
 
-A verdict says whether a finding is real. It does not say whether its remedy belongs in this pull request. Decide both, because a real finding whose remedy is a new subsystem is how a two-line fix becomes a thousand-line one, one justified round at a time. **The scope yardstick** is what the rules read "asked for" against: the issue(s) this PR closes — the union of their asks when it closes several — or, when the PR closes no issue or its linked issue was deleted, the PR body's own stated scope (its Summary and verification/acceptance statements), so the test always has a defined result.
+A verdict says whether a finding is real; scope says whether its remedy belongs in this PR. **The yardstick**: the issue(s) this PR closes (union of asks), else the PR body's stated scope. Classify each ✅/⚠️/❓ finding's **remedy** — except one the reviewer routed to `### Create Follow-up Issue`, which is **filed and never implemented**; Rule 1 is that exclusion's only exception (the disposition says so). Apply in order — first match decides; rule 1 outranks everything later:
 
-Classify each ✅/⚠️/❓ finding's **remedy** — except one the reviewer already routed to `### Create Follow-up Issue`, which is **filed and never implemented**, whatever the rules below would say. Rule 1 is that exclusion's only exception: when the defect lives in code this PR adds or changes, or this PR creates the hazard, rule 1 outranks the reviewer's routing, the fix lands here, and the disposition says so. Apply the rules **in order — the first match decides**, and rule 1 outranks everything later in this skill:
+1. **PR-caused — always in scope.** The defect lives in code this PR adds or changes, or this PR creates the hazard → implement it, however much mechanism the fix needs; no later rule or step may reclassify it.
+2. **New mechanism the yardstick never asked for — out of scope.** The remedy introduces a mechanism the PR lacks (a new persistent store, lifecycle scheme, cross-cutting invariant, retry path, a new subsystem) → file a follow-up issue, naming a deferred pre-existing hazard plainly.
+3. **Everything else — in scope**, including a pre-existing defect whose remedy needs no new mechanism → implement it (step 6).
 
-| # | Rule | Test | Action |
-|---|---|---|---|
-| 1 | **PR-caused — always in scope** | The defect lives in code this PR adds or changes, or this PR itself creates the hazard (a new race, a destructive power handed to existing callers) | Implement it (step 6), however much mechanism the fix needs. No later rule, step, or growth check may reclassify it out of scope — shipping a known hazard to defer work is never the trade. |
-| 2 | **New mechanism the yardstick never asked for — out of scope** | The remedy introduces a mechanism the PR does not have — a new persistent store, a new lifecycle or generation scheme, a new cross-cutting invariant, a retry or recovery path, a new subsystem — and the scope yardstick does not ask for it | File a follow-up issue; do not implement. When the deferred defect is a pre-existing hazard, the issue says so plainly. |
-| 3 | **Everything else — in scope** | Includes a pre-existing defect whose remedy needs no new mechanism — the trivially-fixable same-bug-class instance `pr-review` routes into the PR | Implement it (step 6) |
+**Remedy size never decides scope, in either direction**, and **a reviewer's `Recommended Optional` carries no authority to enlarge the PR** — same test, file the out-of-scope ones.
 
-**The size of the remedy never decides scope, in either direction.** "It is only a few lines" does not open the gate for a new mechanism — rule 2 files it however small the patch looks. "The fix is huge" does not evict a defect this PR caused — rule 1 keeps it however large the remedy. The questions are "did this PR cause it" and "does the remedy need a mechanism the PR lacks", never "how big is the patch". Rule 1 is the safety carve-out in scope form; a pre-existing hazard the PR merely reveals takes rule 2 or rule 3 like any other finding — a mechanism-free fix to it lands here (rule 3), and a mechanism-shaped one is filed (rule 2) with the hazard named.
+**Growth check — once per invocation, before step 6.** Measure growth and cycle count per the Growth check section of [rereview-routing.md](rereview-routing.md) — base-excluded diff against the first push, and `pr_cycle_count` (never the loop's in-memory `review_count`). Past roughly 3x the first push, or at cycle 4+: state both numbers in the step 11 report and the disposition's `Growth check:` line, and re-run the scope test on every finding you were about to implement; sustained growth means the test is applied too loosely.
 
-**A reviewer's `Recommended Optional` is a suggestion, not a work order.** It carries no authority to enlarge the PR: run the same test on it, and file the out-of-scope ones. An optional finding that arrives with an out-of-scope remedy is the single most common start of unbounded growth — in the case this rule comes from, one optional durability suggestion about **pre-existing** state produced four further review cycles and a persisted journal the issue never asked for — a rule-2 remedy (a new persistent store the yardstick never asked for), so it is filed. Had that same durability gap sat in code the PR itself added, rule 1 would have matched first and the journal would have been built here.
+**For every ❓ Judgment finding, do the analysis the reviewer couldn't and implement the result** — never hand the tradeoff back or pause. Derive the absolute-best solution per the global rule in CLAUDE.md/AGENTS.md (a **Recommended proposed solution:** line is verified like any remedy), and record the decision, `file:line` reasoning, and rejected alternatives in the disposition. In-scope `Recommended Optional` items get the same standard; the scope test runs first.
 
-**Growth check — run it once per invocation, before step 6.** Compare the PR's own diff against the base now with the same reading taken at its first push — `git diff --stat $(git merge-base origin/<baseRefName> HEAD)..HEAD` against `git diff --stat $(git merge-base origin/<baseRefName> <first-push-sha>)..<first-push-sha>` — and count the review cycles so far; both inputs come from the PR itself, so a resumed loop reads the same values. **Both readings exclude the base branch**, so the base commits a step 7 merge brings into the head are never counted as growth of this PR; never measure growth with a plain `<first-push-sha>..HEAD` two-dot diff, which carries every base change since the branch point. `<first-push-sha>` is, from `gh pr view <N> --json commits`, the newest commit whose `committedDate` is at or before the cycle-1 trigger comment's timestamp ([rereview-routing.md](rereview-routing.md)'s earliest-trigger rule names that comment; with no trigger comment, use the PR's `createdAt` as the cutoff) — a first push of several commits resolves to the last of them. The cycle count — `pr_cycle_count`, the name fix-pr-review-loop's divergence brake uses for it, never the loop's in-memory `review_count` — is the PR's `@<bot> … review` trigger comments read chronologically per that same file, skipping the cheap non-blocking re-triggers, plus one when review feedback predates every trigger comment (fix-pr-review-loop step 1's "unaddressed feedback already present" branch). When the diff has grown past roughly three times its first push, or this is cycle 4 or later, state both numbers in the step 11 report and in the disposition comment's `Growth check:` line, and re-run the scope test on every finding you were about to implement. Sustained growth across cycles is evidence the scope test is being applied too loosely, not evidence the PR is thorough.
+### 5. Delegate implementation?
 
-**For every ❓ Judgment finding, do the analysis the reviewer couldn't and implement the result — don't hand the tradeoff back.** Trace the code, enumerate the viable approaches, and derive the **absolute-best solution** per the global "absolute best solution" rule in CLAUDE.md/AGENTS.md, then implement it (step 6) in this same run. Do **not** pause to ask the user. A **Recommended proposed solution:** line is the reviewer's preferred option: verify it against the code and that same standard, then implement it if it holds, or implement the better alternative and say why. Record the decision in the disposition comment — the chosen solution, the code-grounded reasoning (`file:line`), and the rejected alternatives in one line each — so the human can override after the fact if they disagree.
-
-The same standard governs `Recommended Optional` improvements: implement the in-scope ones too. This paragraph sets *how well* a remedy is derived; the scope test above decides *whether* it is derived here at all, and it runs first.
-
-### 5. Decide whether to delegate implementation
-
-Steps 3–4 always run inline in this session — validation is the hard thinking, so it never gets delegated. Now decide whether steps 6–11 run inline or get delegated to a subagent. Delegation never picks a model — the subagent inherits the session model; its value is a fresh context window for implementation when the session is already long. If a parent harness (a workflow or another skill) wants a specific model for implementation, it passes one down through its own dispatch — this skill doesn't choose.
-
-Stay inline when this gate applies:
-- Any ❓ Judgment call whose remedy is still open-ended, or any finding under step 4's safety carve-out — open decisions and high blast radius never get delegated.
-
-Otherwise, delegate **only when the session is already long** — enough context has been consumed that a fresh window genuinely helps; on a short session, run steps 6–11 inline and skip the handoff cost. Delegate with the Agent tool (`subagent_type: general-purpose`, synchronous — `run_in_background: false`), and a prompt telling the subagent to read this SKILL.md and execute steps 6 through 11 exactly for PR `<N>`, skipping steps 0–5 (no re-validation, no recursive dispatch). Paste in the findings and verdicts you produced in steps 3–4, including the pinned-down remedies and any derived best-solution designs, so it implements your analysis rather than re-deciding. Its **LLM Attribution Footers** (commit + disposition comment) name the model actually running it. Relay its step 11 report verbatim; don't redo its work.
+Steps 3–4 always run inline — validation never gets delegated. Steps 6–11 may go to a synchronous `general-purpose` subagent, inheriting the session model, only on a long session, never for an open-ended ❓ Judgment or safety carve-out finding; hand it the verdicts and remedies, its footers name its own model, and relay its report verbatim.
 
 ### 6. Implement the fixes
 
-Implement every **in-scope** finding that calls for a change: ✅ Confirmed, ⚠️ Partial (the true part), ❓ Judgment (the absolute-best solution you derived), and `Recommended Optional` (best-solution standard). Skip ❌ Refuted items, `Create Follow-up Issue` items — file them, never implement them, with scope rule 1 the only exception (a defect in code this PR adds or changes, or a hazard it creates, is fixed here however the reviewer routed it, and the disposition says so) — and every finding step 4's scope test put out of scope.
+Implement every in-scope ✅/⚠️/❓/`Recommended Optional` finding. Never implement ❌ Refuted or `Create Follow-up Issue` items — file the latter, rule 1 the only exception.
 
-- File each out-of-scope finding as an issue per `github-issue-format` — complete body, never a stub — and carry its number into the disposition comment, with the basis that placed it — the scope rule you applied, or the reviewer's own `### Create Follow-up Issue` routing for an item step 4's exclusion filed without running one — so the reviewer can see the work was placed rather than dropped. A finding you neither implement nor file is a finding you dropped. **Search before you file:** `gh issue list --search "<keywords>" --state all` — an earlier cycle, or another reviewer's copy of the same finding, may already have filed it. When an existing issue covers the finding, cite that issue's number in the disposition instead of filing a duplicate; when a human closed it, say so rather than reopening or re-filing.
-- Read the surrounding code and follow existing conventions before editing.
-- Keep each fix scoped to its finding; don't smuggle in unrelated refactors.
-- **When implementation reveals that an in-scope remedy cannot work without a new mechanism, re-run step 4's scope rules in order — discovery changes the classification only where those rules allow it.** A rule-1 finding (a defect in code this PR adds or changes, or a hazard this PR creates) stays in scope, and the mechanism gets built here. A rule-3 finding that turns out to need a mechanism moves to rule 2: stop implementing and file it — do not build the mechanism and carry on.
-- After all fixes, **verify**: run the project's tests/build/lint (check the repo's `CLAUDE.md` / `package.json` / Makefile for the commands — e.g. `bun test`, `go test -race ./...`, `bun run build`). Evidence before assertions: do not claim a fix works without running verification, and report any failures honestly rather than papering over them.
-- If a fix turns out infeasible or reveals the finding was actually Refuted, move it to the Refuted bucket with the reason.
-- **A test the fix makes stale follows the CLAUDE.md/AGENTS.md rule "The optimal solution comes first, and the tests follow it".** Edit an existing test only under one of its three cases — **Outdated**, **Wrong**, or **Obsolete** — and name that case's checkable ground before you touch the test; a confirmed finding is the ground for a test its fix makes outdated. The rule covers fixtures, snapshots, and helper expectations as well as assertions. **A test that breaks in another location is checked before it is edited.** The refute check runs first: a red test may show the finding itself was wrong, and that finding moves to the Refuted bucket with no test edit. When the finding stands, read the test and decide whether it is Outdated (the fix deliberately replaces the tested behavior), Obsolete (the behavior is deleted, or another test covers it), or Wrong (the test was never correct, and passed only because the code shared its defect). One of those is rewritten or removed under that case with its ground. A test that is none of the three means the fix broke real behavior, so leave the test as it is and fix the code. Not every fix needs a new test; write one when it guards behavior that can regress. **A test with no ground stays as it is, and tests are still a correctness floor.** Your own reading that a test is wrong is the claim under test and never its own ground. Never delete, skip, loosen, or narrow a test to reach a green tree. When the correct fix still cannot make an ungrounded test pass, do not commit: stop before step 8, leave the branch as it is, and report the test with its `file:line`, what it asserts, and why the correct fix conflicts with it (step 11). Findings already fixed in this run stay uncommitted with it, so the next cycle lands them together once the maintainer answers. **Disclose every test edit** in the commit message (step 8) and under `### Test edits` in the disposition comment (step 9): the test, its case, that case's ground, and what the replacement asserts. A removal gives the ground in place of the replacement, and for the redundancy ground it names the surviving test.
+- File each out-of-scope finding per `github-issue-format`, carrying its number plus the basis (the scope rule applied, or the reviewer's routing) into the disposition. A finding you neither implement nor file is a finding you dropped. **Search before filing:** `gh issue list --search "<keywords>" --state all` — cite an existing issue instead of duplicating; when a human closed it, say so.
+- Follow existing conventions; keep each fix scoped to its finding. When implementation reveals an in-scope remedy needs a new mechanism, re-run the scope rules in order: rule 1 stays and the mechanism gets built here; a rule-3 finding moves to rule 2 — stop and file it.
+- After all fixes, **verify**: run the project's tests/build/lint and report failures honestly; an infeasible fix moves its finding to Refuted with the reason.
+- **A stale test follows the CLAUDE.md/AGENTS.md rule "The optimal solution comes first, and the tests follow it"** — edit one only as **Outdated**, **Wrong**, or **Obsolete**, naming that case's checkable ground first — a confirmed finding grounds a test its fix makes outdated; fixtures and snapshots included. **A test that breaks in another location is checked before it is edited.** The refute check runs first: a red test may show the finding was wrong — it moves to Refuted with no test edit. When the finding stands, decide: Outdated (the fix deliberately replaces the tested behavior), Obsolete (the behavior is deleted, or another test covers it — name the surviving test carrying every assertion), or Wrong (the test was never correct). A test that is none of the three means the fix broke real behavior — leave the test and fix the code; a test with no ground stays as it is — your own reading is never a ground — and never delete, skip, loosen, or narrow a test for a green tree. When the correct fix cannot pass an ungrounded test, do not commit: stop before step 8 and report the test, `file:line`, and the conflict (step 11). **Disclose every test edit** in the commit message and under `### Test edits` in the disposition: the test, its case, the ground, and what the replacement asserts (a removal gives the ground instead).
 
-### 7. Resolve merge conflicts with the base branch
+### 7. Resolve merge conflicts
 
-If step 0 flagged the PR as conflicting (or the PR turns `CONFLICTING` after your fixes because the base moved mid-run — re-check before pushing if step 0 was a while ago), resolve the conflicts on the head branch — never on the base:
-
-```bash
-git fetch origin <baseRefName>
-git merge origin/<baseRefName>        # merge base INTO the head branch; don't rebase a pushed PR branch
-```
-
-- Resolve each conflicted file by reading both sides and preserving the *intent* of both changes — never mechanically take `ours`/`theirs` for a whole file. If base-branch changes overlap the code you just fixed, re-derive the fix on top of the new base code.
-- A conflict inside step 4's safety carve-out gets the same treatment as a finding: resolve from first principles, and if the two sides are irreconcilable in intent, stop and surface to the user rather than guessing.
-- After resolving, re-run the step 6 verification (tests/build/lint) — a textual resolution can still be semantically wrong.
-- Prefer merge over rebase: the branch is already pushed and reviewed; rebasing rewrites history and breaks the reviewer's context and any pending inline threads.
-- Report the conflict resolution as its own line in the disposition comment and the user report (which files, how each side was reconciled).
+If the PR is `CONFLICTING`: `git fetch origin <baseRefName> && git merge origin/<baseRefName>` on the head branch — never rebase a pushed PR branch, never blanket `ours`/`theirs`; preserve the intent of both sides, re-deriving your fix on new base code where they overlap. An irreconcilable conflict in safety-class code → stop and surface to the user. Re-run verification after resolving; give the resolution its own line in the disposition and the report.
 
 ### 8. Commit and push
 
-Only after verification passes:
+Only after verification passes: `git status`; stage **each fix file by name** (never `git add -A`); `git commit -F <msg-file>`; `git push` to the tracked upstream (a fork's head is not on `origin`). Message: "Address review on #<N>: <summary>" plus the LLM Attribution Footer — verb **Updated**, per the global CLAUDE.md/AGENTS.md rule, `Harness: Claude Code`.
 
-```bash
-git status                      # confirm only the files you edited are dirty
-git add <specific files>        # stage each file you changed for the fixes — never `git add -A` or `git add .`
-git commit -F <msg-file>        # see footer below
-git push                        # to the branch's tracked upstream — never assume `origin`
-```
+### 9. Post the disposition comment
 
-A fork PR's head lives in the fork, so `git push origin <headRefName>` would be wrong. If the branch has no upstream set (manual checkout instead of `gh pr checkout`), push explicitly to the PR's **head repository** remote.
-
-Staging explicitly keeps unrelated dirty files, scratch files, and untracked artifacts out of the commit. If `git status` shows changes you didn't make, leave them unstaged and mention them in the report.
-
-Commit message: a concise summary of what review findings were addressed (reference the PR, e.g. "Address review on #<N>: <one-line summary>"). This is a revision to an existing PR, so the footer uses the **Updated** verb:
-
-```
----
-Updated with LLM: <current model> | <effort> | Harness: Claude Code
-```
-
-The global LLM Attribution Footer rule in CLAUDE.md/AGENTS.md owns the field values; this skill only fixes the verb to **Updated**.
-
-### 9. Post the disposition comment back to the PR
-
-Post one comment that tells the reviewer exactly what happened to each finding — this is how a refuted finding gets its pushback on the record. Compose and post it per [disposition-comment.md](disposition-comment.md) — read it completely; it holds the template with its five sections, the slotting rules for CI Failure findings, the inline-thread reply recipe, the posting command, and the comment footer.
+Post one comment stating what happened to each finding, per [disposition-comment.md](disposition-comment.md), read completely.
 
 ### 10. Trigger the re-review
 
-Post one trigger comment asking the selected review bot for a fresh review. Compose and post it per [rereview-routing.md](rereview-routing.md) — read it completely; it holds the bot-selection rule, the rule for identifying the cycle-1 reviewer from the earliest trigger comment on the PR, the step-down ladder and its floor, the fallback table that applies only when no trigger comment exists, the non-blocking shorthand, and the posting commands for both bots. The step-down is keyed to the reviewer that actually ran cycle 1, at any score — never to a band.
-
-Two rules that decide everything there: route by whether the addressed set contained **any blocking finding** (noted in step 1), never by the newest review's verdict alone; and post the trigger as its **own** comment, never bundled into the disposition comment.
+Post one trigger comment per [rereview-routing.md](rereview-routing.md), read completely. The step-down is keyed to the reviewer that actually ran cycle 1, never to a band; route by whether the addressed set contained **any blocking finding** (step 1), never by the newest verdict alone; the trigger is its **own** comment, never bundled into the disposition.
 
 ### 11. Report to the user
 
-Terse summary: which reviews/threads you acted on, counts per disposition (fixed / partial / refuted / judgment-resolved / optional / deferred), the commit SHA, verification result, and that a re-review was requested (note which model it was routed to). Name every test edit with its case and ground. When step 6 stopped the run on an ungrounded test, say that no commit and no push exist, name the test with its `file:line`, and state what it asserts and why the correct fix conflicts with it. When step 4's growth check fired, include both of its numbers — the diff ratio against the first push and the cycle count — and omit them when it did not. When the review carried any `**Verification limitation:**` lines, name each unverified source in the report — omit that field when none. When the invocation carried an unrecognized argument (Input section), name it too — omit that field when none. Flag the resolved judgment calls so the user can override if they disagree — but the work is already done, not waiting on them.
-
-## Red Flags — STOP
-
-Before acting on any edge case, read the Red Flags table in [red-flags-and-mistakes.md](red-flags-and-mistakes.md) — it lists every stop condition and the required action.
-
-## Common Mistakes
-
-Read the Common Mistakes list in [red-flags-and-mistakes.md](red-flags-and-mistakes.md) — it names the failure patterns this skill exists to avoid.
+Terse summary: reviews/threads acted on, per-disposition counts, commit SHA, verification result, and the re-review reviewer. Name every test edit with its case and ground. If step 6 stopped on an ungrounded test, say no commit or push exists and name the test, its `file:line`, what it asserts, and the conflict. Include growth-check numbers, `**Verification limitation:**` sources, and any unrecognized argument only when present. Flag resolved judgment calls for override — the work is done. Edge cases: the stop-condition table in [red-flags-and-mistakes.md](red-flags-and-mistakes.md).

--- a/skills/fix-pr-review/SKILL.md
+++ b/skills/fix-pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-pr-review
-description: Use when the user asks to fix, address, or respond to a PR review — "fix the PR review", "/fix-pr-review". Optional PR number/URL (defaults to the current branch's PR); optional `codex` argument selects Codex as the review bot.
+description: Use when the user asks to fix, address, or respond to a PR review — "fix the PR review", "/fix-pr-review". Optional PR number/URL (defaults to the current branch's PR); optional `codex` argument selects Codex.
 ---
 
 # fix-pr-review
@@ -9,7 +9,7 @@ Resolve every unaddressed review finding autonomously: validate, fix or refute, 
 
 ## Input
 
-In any order: an optional PR reference (number or URL; default = the current branch's PR) and an optional literal `codex` token selecting Codex as this cycle's re-review bot. Any other token doesn't block — use the defaults and name it in the step 11 report as an unrecognized argument. No PR found and none given → say so and stop.
+In any order: an optional PR reference (number or URL; default = the current branch's PR) and an optional literal `codex` token selecting Codex as this cycle's re-review bot. Any other token doesn't block — use the defaults and name it in the step 11 report. No PR found and none given → say so and stop.
 
 ## Steps
 
@@ -74,7 +74,7 @@ If the PR is `CONFLICTING`: `git fetch origin <baseRefName> && git merge origin/
 
 ### 8. Commit and push
 
-Only after verification passes: `git status`; stage **each fix file by name** (never `git add -A`); `git commit -F <msg-file>`; `git push` to the tracked upstream (a fork's head is not on `origin`). Message: "Address review on #<N>: <summary>" plus the LLM Attribution Footer — verb **Updated**, per the global CLAUDE.md/AGENTS.md rule, `Harness: Claude Code`.
+Only after verification passes: `git status`; stage **each fix file by name** (never `git add -A`); `git commit -F <msg-file>`; `git push` to the tracked upstream (a fork's head is not on `origin`). Message: "Address review on #<N>: <summary>" plus the **Updated**-verb LLM Attribution Footer per the global CLAUDE.md/AGENTS.md rule, `Harness: Claude Code`.
 
 ### 9. Post the disposition comment
 
@@ -86,4 +86,4 @@ Post one trigger comment per [rereview-routing.md](rereview-routing.md), read co
 
 ### 11. Report to the user
 
-Terse summary: reviews/threads acted on, per-disposition counts, commit SHA, verification result, and the re-review reviewer. Name every test edit with its case and ground. If step 6 stopped on an ungrounded test, say no commit or push exists and name the test, its `file:line`, what it asserts, and the conflict. Include growth-check numbers, `**Verification limitation:**` sources, and any unrecognized argument only when present. Flag resolved judgment calls for override — the work is done. Edge cases: the stop-condition table in [red-flags-and-mistakes.md](red-flags-and-mistakes.md).
+Terse summary: reviews/threads acted on, per-disposition counts, commit SHA, verification result, and the re-review reviewer. Name every test edit with its case and ground. If step 6 stopped on an ungrounded test, say no commit or push exists and name the test, its `file:line`, what it asserts, and the conflict. Include growth-check numbers, unexpected dirty files left unstaged (step 8), `**Verification limitation:**` sources, and any unrecognized argument only when present. Flag resolved judgment calls for override — the work is done. Edge cases: the stop-condition table in [red-flags-and-mistakes.md](red-flags-and-mistakes.md).

--- a/skills/fix-pr-review/disposition-comment.md
+++ b/skills/fix-pr-review/disposition-comment.md
@@ -1,10 +1,8 @@
 # Disposition comment
 
-Reference for SKILL.md step 9: the template, section slotting rules, inline-thread replies, and posting mechanics.
+Reference for SKILL.md step 9.
 
 ## Template
-
-Write the comment as direct, scannable status:
 
 ```
 Addressed review feedback (<reviewer(s)> · <timestamp(s)>) in <commit-sha>.
@@ -12,7 +10,7 @@ Addressed review feedback (<reviewer(s)> · <timestamp(s)>) in <commit-sha>.
 Growth check: diff <lines> lines vs <lines> at first push (<ratio>x); cycle <N>.
 
 ### Fixed
-1. **<finding title>** — <what changed> (`file:line`). <Scope rule 1 note, required only when this item kept a finding in the PR that a routing or a rule would have filed: what this PR adds, changes, or endangers that makes rule 1 match.>
+1. **<finding title>** — <what changed> (`file:line`). <Scope rule 1 note when required — see below.>
 
 ### Corrected scope (partial)
 1. **<finding title>** — <what was real and fixed vs. what wasn't | blocking status refuted: the stated Reachability precondition <trigger>, refuted by <what the code does>; the defect <stands | does not stand>; re-routed to `### Recommended Optional`> (`file:line`).
@@ -21,10 +19,10 @@ Growth check: diff <lines> lines vs <lines> at first push (<ratio>x); cycle <N>.
 1. **<finding title>** — <code-grounded reason the suggestion doesn't apply> (`file:line`).
 
 ### Resolved judgment calls (was Requires Human Review)
-1. **<finding title>** — implemented <the absolute-best solution and why, `file:line`>. Alternatives rejected: <one line each>. Override if you'd prefer one of these.
+1. **<finding title>** — implemented <the best solution and why, `file:line`>. Alternatives rejected: <one line each>.
 
 ### Deferred to follow-up
-1. **<finding title>** — out of scope, basis <scope rule <N>: the mechanism the remedy needs that this PR lacks, and the yardstick that does not ask for it | reviewer-routed to `### Create Follow-up Issue`>; filed as #<issue>.
+1. **<finding title>** — out of scope, basis <scope rule <N>: the mechanism the remedy needs and the yardstick that does not ask for it | reviewer-routed to `### Create Follow-up Issue`>; filed as #<issue>.
 
 ### Test edits
 1. **<test name>** (`file:line`) — <Outdated | Wrong | Obsolete>; ground: <the finding, issue, contract, or instruction that authorizes it>; now asserts <what the replacement asserts, or the ground alone for a removal, naming the surviving test for the redundancy case>.
@@ -32,30 +30,23 @@ Growth check: diff <lines> lines vs <lines> at first push (<ratio>x); cycle <N>.
 
 ## Slotting rules
 
-- **Copy `<finding title>` verbatim from the review comment** — the reviewer's own bold one-sentence title, word for word, with no paraphrase or shortening. The next reviewer matches its findings to these dispositions by claim (`pr-review` requires that read before it drafts), and a reworded title breaks that match, so a settled finding comes back.
-- Every **Not changed (refuted)** and **Corrected scope (partial)** item states the verdict through its section heading and carries a code-grounded rebuttal with its `file:line` — that rebuttal is the evidence a later reviewer must answer before it re-raises the finding, so make it stand on its own without the thread around it.
-- **A blocking finding whose stated `**Reachability:**` precondition the code refutes goes under `### Corrected scope (partial)`, and nowhere else.** No new section is added for it: `pr-review`'s prior-cycle rule settles a finding only on the dispositions it already names, and `Corrected scope (partial)` is one of them, so a re-route recorded under any other heading settles nothing and the next review re-raises the blocking status. The item names the precondition the review stated, the `file:line` that refutes it, whether the defect itself still stands, and the section the finding moves to. When the re-routed remedy is in scope and gets fixed in this same push, it also gets its own **Fixed** item; this item records the routing change alone.
+- **Copy `<finding title>` verbatim from the review comment** — the reviewer's bold one-sentence title, word for word. The next reviewer matches findings to these dispositions by claim; a reworded title brings a settled finding back.
+- Every **Not changed (refuted)** and **Corrected scope (partial)** item carries a code-grounded rebuttal with its `file:line` that stands on its own — what a later reviewer must answer before re-raising.
+- **A blocking finding whose stated `**Reachability:**` precondition the code refutes goes under `### Corrected scope (partial)`, and nowhere else** — `pr-review`'s prior-cycle rule settles findings only on the dispositions it names, so a re-route recorded elsewhere settles nothing. The item names the stated precondition, the `file:line` that refutes it, whether the defect still stands, and the section the finding moves to. When the re-routed remedy is fixed in this same push, it also gets its own **Fixed** item; this item records the routing change alone.
 - Omit any empty section. Keep each item one line with a `file:line` anchor.
-- **Every test edit in the push appears under `### Test edits`** with its case, that case's checkable ground, and what the replacement asserts; a removal gives the ground in place of the replacement. The reviewer reads this section to tell a deliberate behavior change from a weakened test, so a test edit missing from it reads as undisclosed.
-- The `Growth check:` line appears only when SKILL.md step 4's growth check fired (diff past ~3x the first push, or cycle 4+); omit it otherwise. It is the one place in this comment those numbers live — never fold them into a finding item.
-- **Every Deferred to follow-up item names both its basis and the issue number.** The basis has exactly two admissible values, and every deferred item carries one of them: **the fixer scope rule it applied** — rule 2, with the mechanism the remedy needs and the yardstick that does not ask for it — or **the reviewer's own `### Create Follow-up Issue` routing**, where SKILL.md step 4's exclusion filed the item without running a fixer scope rule on it. A reviewer-routed item whose remedy also meets rule 2 may name both. Rule 1 never appears here: it keeps the finding in the PR, so that item is disposed under **Fixed** with the rule-1 note, never deferred. That pair — basis and issue — is the deferral's rationale, and `pr-review` settles the finding on it exactly as it settles a code-grounded rebuttal — the next reviewer re-raises it only by naming the deferral and showing from current code why it fails. A deferral missing either half settles nothing, so the same blocking finding returns next cycle.
-- **A Fixed item that kept a finding in the PR against something that would have filed it carries a scope rule 1 note.** Exactly two cases require it: the reviewer routed the finding to `### Create Follow-up Issue` and SKILL.md step 4's exclusion-exception pulled it back, or the fixer's own rule 2 would have filed the remedy and rule 1 matched first. The note names scope rule 1 and states, from code, what this PR adds or changes that causes the defect, or the hazard this PR creates — the same evidence the rule itself reads. It is the counterpart of the deferral's basis: without it a later reviewer cannot tell a legitimate rule-1 override from unexplained growth, which is the ambiguity this format exists to close. Every other Fixed item overrides nothing and carries no note — a `Needs Fixing` item, or a `Recommended Optional` item whose remedy needed no mechanism this PR lacks.
-- A **Deferred to follow-up** item that matched an issue an earlier cycle already filed cites that existing issue rather than a new one.
-- CI Failure findings slot into the same sections — fixed ones under **Fixed**, pre-existing/flaky ones under **Not changed (refuted)** with the base-branch or flake evidence in place of a code citation.
+- **Every test edit appears under `### Test edits`** with its case, ground, and replacement assertion (a removal gives the ground instead); an edit missing from it reads as undisclosed.
+- The `Growth check:` line appears only when step 4's growth check fired; it is the one place those numbers live.
+- **Every Deferred to follow-up item names both its basis and the issue number.** The basis has exactly two admissible values: the fixer scope rule applied (rule 2, with the mechanism the remedy needs and the yardstick that does not ask for it), or the reviewer's own `### Create Follow-up Issue` routing, where step 4's exclusion filed the item without running one. Rule 1 never appears here — it keeps the finding in the PR, under **Fixed** with the rule-1 note. `pr-review` settles the finding on that pair as on a rebuttal; a deferral missing either half settles nothing, so the finding returns next cycle. An item matching an issue an earlier cycle filed cites that existing issue.
+- **A Fixed item that kept a finding in the PR against something that would have filed it carries a scope rule 1 note** — required exactly when the reviewer routed it to `### Create Follow-up Issue` and the exclusion-exception pulled it back, or when rule 2 would have filed it and rule 1 matched first. The note names rule 1 and states, from code, what this PR adds or changes that causes the defect (or the hazard it creates). Other Fixed items carry no note.
+- CI Failure findings slot into the same sections — fixed under **Fixed**, pre-existing/flaky under **Not changed (refuted)** with the base-branch or flake evidence in place of a code citation.
 
 ## Inline-thread replies
 
-For findings that came from inline diff threads, also post a one-line reply in the thread itself — use the root comment's `databaseId` from the thread query in [fetch-recipes.md](fetch-recipes.md): `gh api repos/{owner}/{repo}/pulls/<N>/comments/<databaseId>/replies -f body=...` — that's where the reviewer is watching.
+For findings from inline diff threads, also post a one-line reply in the thread — `gh api repos/{owner}/{repo}/pulls/<N>/comments/<databaseId>/replies -f body=...` using the root comment's `databaseId` from the thread query in [fetch-recipes.md](fetch-recipes.md).
 
 ## Posting
 
-Post the main comment via:
-
-```bash
-gh pr comment <N> --body-file <file>
-```
-
-Footer on the comment uses the **Created** verb (it's a new comment):
+`gh pr comment <N> --body-file <file>`, ending with the **Created**-verb footer (it's a new comment):
 
 ```
 ---

--- a/skills/fix-pr-review/fetch-recipes.md
+++ b/skills/fix-pr-review/fetch-recipes.md
@@ -1,13 +1,13 @@
 # Fetch recipes
 
-Reference for SKILL.md steps 1–2: the exact queries for the three review-feedback channels and the CI-check detail procedures.
+Reference for SKILL.md steps 1–2: channel queries, collection rules, CI-check procedures.
 
 ## Review-feedback channels (step 1)
 
 ```bash
 # PR reviews (formal review events) — state included so DISMISSED reviews can be skipped
 gh api repos/{owner}/{repo}/pulls/<N>/reviews --paginate --jq '.[] | {id, user: .user.login, state, submitted_at, body}'
-# Issue comments on the PR (where @claude review output usually lands) — REST + --paginate for completeness
+# Issue comments on the PR (where @claude review output usually lands)
 gh api repos/{owner}/{repo}/issues/<N>/comments --paginate --jq '.[] | {author: .user.login, created_at, body}'
 # Inline diff threads WITH resolution state — REST can't report isResolved, so use GraphQL
 gh api graphql -F owner='{owner}' -F repo='{repo}' -F pr=<N> -f query='
@@ -18,19 +18,28 @@ gh api graphql -F owner='{owner}' -F repo='{repo}' -F pr=<N> -f query='
 
 (If `hasNextPage` is true, paginate with `endCursor` — don't silently drop threads past 100.)
 
+### Collection rules
+
+**Cutoff** = the timestamp of your most recent disposition comment on the PR (or the last commit you pushed addressing a review); no cutoff → everything since the PR opened. Collect:
+
+- Every formal review or review-formatted comment **newer than the cutoff** — one opening with an `LGTM` / `Needs Updates` verdict, carrying review sections like `### Needs Fixing`, or otherwise clearly review feedback. **If multiple reviews landed, address all of them**, not just the latest. Skip `DISMISSED` reviews.
+- Every **unresolved** inline thread (`isResolved: false`) **regardless of age** — resolution state, not timestamp, decides; `isOutdated` alone doesn't mean resolved. Exception: a thread whose last comment is your own disposition reply with no response since is awaiting the reviewer — skip it. Each thread is one finding.
+- Skip your own prior disposition comments and `@<bot> … review` trigger comments when collecting new work.
+
 ## CI check snapshot (step 2)
 
 ```bash
 gh pr checks <N> --json name,state,bucket,link,startedAt,completedAt
 ```
 
-### Pulling detail for a `bucket: fail` check
+`bucket` normalizes `state` into `pass`/`fail`/`pending`/`skipping`/`cancel`:
 
-Pull just the failing detail, not the whole log:
-
-- GitHub Actions: resolve the run ID from the check's `link`, then `gh run view <run-id> --log-failed` for the failing step(s) only.
-- Non-Actions / external CI: `gh api` only auto-fills `{owner}`/`{repo}`/`{branch}` — `{sha}` is not one of them, so get the head commit explicitly first: `gh pr view <N> --json headRefOid --jq .headRefOid`. Substitute that for `<sha>`: `gh api repos/{owner}/{repo}/commits/<sha>/check-runs --jq '.check_runs[] | select(.conclusion=="failure") | {name, output}'` for whatever summary the provider publishes.
+- `pending` / `skipping` — **skip entirely.** A running check is the next pass's problem; don't retry, wait, or treat "not done yet" as a finding.
+- `cancel` — see the attribution procedure below.
+- `fail` — pull just the failing detail, not the whole log:
+  - GitHub Actions: resolve the run ID from the check's `link`, then `gh run view <run-id> --log-failed`.
+  - External CI: `gh api` doesn't auto-fill `{sha}`, so get it first (`gh pr view <N> --json headRefOid --jq .headRefOid`), then `gh api repos/{owner}/{repo}/commits/<sha>/check-runs --jq '.check_runs[] | select(.conclusion=="failure") | {name, output}'`.
 
 ### Attributing a `bucket: cancel` check
 
-Skip a cancelled check unless the run log shows it was cancelled by a real failure upstream (e.g. a required prior job failed) rather than a manual/administrative cancel. When it was, check this same snapshot for a `bucket: fail` entry on that upstream job first: if one exists, skip the cancelled check entirely — the `fail`-bucket path above already turns that upstream job into its own CI Failure finding, and citing both would duplicate it. Only when the real upstream failure is *not* otherwise visible as its own `fail`-bucket entry in this snapshot does the cancelled check get a finding of its own. To source the detail concretely, resolve the run ID from the cancelled check's `link` and run `gh run view <run-id>` — that lists every job in the same workflow run with its conclusion, so a job that failed there but isn't surfaced as its own PR check shows up; pull its failing detail via the `fail`-bucket procedure above and cite that job's name (not the cancelled one). If even that yields no concrete failed job, don't invent an upstream cause — record the finding against the cancelled check's own name with its run link and flag it for human review, rather than guessing at an unverified cause.
+Skip a cancelled check unless its run log shows a real upstream failure caused the cancel rather than a manual one. When it did, and this snapshot already has a `fail`-bucket entry for that upstream job, skip the cancelled check — the `fail` path covers it. Otherwise resolve the run ID from its `link`, `gh run view <run-id>` to find the failed job, pull its detail via the `fail` procedure, and cite that job's name. If no concrete failed job surfaces, never invent an upstream cause — record the finding against the cancelled check's own name with its run link and flag it for human review.

--- a/skills/fix-pr-review/red-flags-and-mistakes.md
+++ b/skills/fix-pr-review/red-flags-and-mistakes.md
@@ -1,43 +1,33 @@
-# Red Flags and Common Mistakes
+# Red Flags, Validation Discipline, and Common Mistakes
 
-Reference for SKILL.md: the stop conditions and the failure patterns this skill exists to avoid. Step numbers refer to SKILL.md.
+Reference for SKILL.md; step numbers refer to it.
+
+## Validation discipline (step 4)
+
+- **Read the body, not just the cited line.** A name states intent; open the function and trace the conditional fully before agreeing.
+- **Prove negatives by reading the path.** "X is never validated / never freed / not awaited" — confirm the absence across *all* relevant paths; the behavior may be produced elsewhere.
+- **A suggested fix is its own claim.** Verify the *remedy* is correct for this codebase, and derive the right fix from first principles if the suggested one is suboptimal.
+- **Safety carve-out** — money, data integrity, security, auto-protective mechanisms: fix or escalate even at low confidence; never silently drop as Refuted without code proof it's a non-issue.
+- **CI Failures**: read the failing step's actual error, not just the job name. ✅ Confirmed if it traces to this PR's diff (reproduce the failing command locally where feasible). ❌ Refuted only with evidence — pre-existing on the base branch (check CI history or reproduce on base) or a one-off infra flake — don't patch around it; note it in the disposition and flag it to the user.
 
 ## Red Flags — STOP
 
 | Situation | Action |
 |-----------|--------|
-| Finding cites a line that no longer matches current code | Re-validate against current `file:line`; it may already be fixed — mark Refuted with the reason |
-| Suggested fix would touch money/data/security/auto-protective logic | Never blind-apply; verify the remedy from first principles and implement the safest correct design |
-| Reviewer's remedy is plausible but you can't confirm it's correct here | Don't implement on faith — trace it, then implement the absolute-best solution you can stand behind from the code |
-| A collected "review" is actually your own prior disposition comment or an `@claude review` trigger | Skip it; act only on *actual* review feedback |
-| Only some feedback channels checked (e.g. formal reviews but not inline diff threads or CI) | Fetch every review-feedback channel (step 1) and the CI snapshot (step 2) before extracting findings — inline threads are where human reviewers usually comment, and a red check is a finding too |
-| CI check's `bucket` is `pending` or `skipping` | Skip it — take the `gh pr checks` snapshot as-is, don't wait or poll; a run that finishes later gets caught on the next pass |
-| CI failure doesn't trace to this PR's diff (pre-existing on the base branch, or a one-off flake) | Don't fix around it — mark Refuted with the base-branch/flake evidence and flag it to the user; only fix failures this PR actually caused |
-| `git status` shows dirty files you didn't edit | Stage only your fix files; leave the rest and mention them in the report |
-| You're on `main` or a divergent branch, not the PR head | Check out the PR head first; never commit review fixes to the base branch |
-| Branch can't fast-forward to its upstream head | Stop — the branch diverged; surface to the user, don't force anything |
-| PR is from a fork | Check out with `gh pr checkout` and push to the tracked upstream — `origin` is the wrong remote for the head branch |
-| All findings refuted | Still post the disposition comment with the rebuttals and request re-review — don't silently no-op |
-| `Requires Human Review` item | Prefer the item's **Recommended proposed solution:** when present; still verify against the step 4 best-solution standard. Implement the chosen solution; document the decision + rejected alternatives in the comment so the user can override. Never pause for confirmation, punt the bare tradeoff, or guess blindly |
+| Finding cites a line that no longer matches current code | Re-validate against current `file:line`; it may already be fixed — Refuted with the reason |
+| Suggested fix touches money/data/security/auto-protective logic | Never blind-apply; implement the safest correct design from first principles |
+| Only some feedback channels checked | Fetch every channel (step 1) and the CI snapshot (step 2) before extracting findings |
+| `git status` shows dirty files you didn't edit | Stage only your fix files; mention the rest in the report |
+| On the base branch or a divergent branch | Check out the PR head first; never commit review fixes to the base |
+| All findings refuted | Still post the disposition with the rebuttals and request re-review — never silently no-op |
+| `Requires Human Review` item | Verify the **Recommended proposed solution:** against the step 4 standard, implement the chosen solution, document decision + rejected alternatives. Never pause, punt, or guess blindly |
 | Tests/build fail after fixes | Report the failure; don't push or claim success |
-| A failing test looks wrong to you and no checkable ground says so | Leave it and fix the code — your reading is not a ground. Check first whether the red test refutes the finding. If the correct fix still cannot make it pass, stop before step 8 and report the test with its `file:line` and the conflict |
-| PR is `CONFLICTING` with the base branch | Resolve via step 7 (merge base into head, reconcile intent of both sides, re-verify) — never rebase a pushed PR branch, never resolve by blanket `ours`/`theirs`, never leave an approved PR unmergeable |
-| Conflict sides are irreconcilable in intent (esp. money/data/security/auto-protective code) | Stop and surface to the user instead of guessing a resolution |
+| A failing test looks wrong and no checkable ground says so | Leave it and fix the code — your reading is not a ground. Check first whether the red test refutes the finding; if the correct fix still can't pass, stop before step 8 and report the test with its `file:line` |
+| PR `CONFLICTING` with the base | Resolve via step 7 (merge base into head, reconcile intent, re-verify) — never rebase a pushed branch or blanket `ours`/`theirs` |
+| Conflict sides irreconcilable in intent (esp. safety-class code) | Stop and surface to the user instead of guessing |
 
 ## Common Mistakes
 
-- **Blind-implementing the review.** Performative agreement ships regressions. Validate first, every time.
-- **Delegating validation.** Steps 3–4 always run inline — the delegation gate keys off *validated* verdicts. Dispatch only steps 6–11 (open judgment/safety findings stay inline), and never split one review across subagents. The subagent's footers must name the model that actually ran (normally the same session model).
-- **Missing inline diff comments or CI.** Fetching only formal reviews and issue comments skips the line-level threads where human reviewers usually comment, and skipping step 2 misses failing CI checks. Fetch every channel in steps 1 and 2.
-- **Waiting or polling on in-progress CI.** Step 2 is a single snapshot; skip anything whose `bucket` is `pending` or `skipping` rather than blocking the run on it.
-- **Patching around a pre-existing or flaky CI failure.** Verify the failure traces to this PR's diff before touching code — otherwise it's Refuted with evidence, not a fix target.
-- **Addressing only the latest review when several landed.** Every review newer than your last disposition and every unresolved inline thread (any age) gets addressed.
-- **Routing the re-review by the newest verdict.** A later `LGTM` from one reviewer doesn't erase another's blocking findings — route by whether any blocking finding was addressed.
-- **`git add -A`.** Stage the fix files explicitly; a blanket add can commit unrelated dirty or untracked files.
-- **Dropping a refuted finding silently.** Push back on the record in the comment with a code-grounded reason — that's how the reviewer learns it was wrong.
-- **Committing to the base branch.** Fixes land on the PR head branch only.
-- **Skipping verification before push.** Run the tests/build; report real results.
-- **Pausing or punting on a judgment call.** Do the analysis the reviewer couldn't and *implement* the absolute-best solution (step 4 standard); document it for override. Don't stop to ask, don't relay the bare tradeoff, don't guess blindly.
-- **Skipping the optional improvements.** `Recommended Optional` items get implemented to the same standard, not deferred.
-- **Ignoring merge conflicts because "the review is addressed".** An unmergeable PR isn't done — check `mergeable` in step 0 and resolve conflicts in step 7, with the same verification and safety discipline as findings.
-- **Bundling the re-review trigger into the disposition comment.** Keep `@claude review` as its own comment so the bot fires reliably.
+- **Blind-implementing the review** — performative agreement ships regressions; validate first, every time.
+- **Delegating validation** — steps 3–4 always run inline; dispatch only steps 6–11, and never split one review across subagents.
+- **Addressing only the latest review when several landed** — every review newer than your last disposition and every unresolved thread gets addressed.

--- a/skills/fix-pr-review/red-flags-and-mistakes.md
+++ b/skills/fix-pr-review/red-flags-and-mistakes.md
@@ -16,12 +16,9 @@ Reference for SKILL.md; step numbers refer to it.
 |-----------|--------|
 | Finding cites a line that no longer matches current code | Re-validate against current `file:line`; it may already be fixed — Refuted with the reason |
 | Suggested fix touches money/data/security/auto-protective logic | Never blind-apply; implement the safest correct design from first principles |
-| Only some feedback channels checked | Fetch every channel (step 1) and the CI snapshot (step 2) before extracting findings |
-| `git status` shows dirty files you didn't edit | Stage only your fix files; mention the rest in the report |
 | On the base branch or a divergent branch | Check out the PR head first; never commit review fixes to the base |
 | All findings refuted | Still post the disposition with the rebuttals and request re-review — never silently no-op |
 | `Requires Human Review` item | Verify the **Recommended proposed solution:** against the step 4 standard, implement the chosen solution, document decision + rejected alternatives. Never pause, punt, or guess blindly |
-| Tests/build fail after fixes | Report the failure; don't push or claim success |
 | A failing test looks wrong and no checkable ground says so | Leave it and fix the code — your reading is not a ground. Check first whether the red test refutes the finding; if the correct fix still can't pass, stop before step 8 and report the test with its `file:line` |
 | PR `CONFLICTING` with the base | Resolve via step 7 (merge base into head, reconcile intent, re-verify) — never rebase a pushed branch or blanket `ours`/`theirs` |
 | Conflict sides irreconcilable in intent (esp. safety-class code) | Stop and surface to the user instead of guessing |

--- a/skills/fix-pr-review/rereview-routing.md
+++ b/skills/fix-pr-review/rereview-routing.md
@@ -52,7 +52,8 @@ Post a **separate** comment (`gh pr comment <N> --body "@claude review"` etc.) �
 
 ## Growth check
 
-Inputs for fix-pr-review step 4's growth check, both read from the PR itself so a resumed loop sees the same values:
+For fix-pr-review step 4's growth check, all read from the PR itself so a resumed loop sees the same values:
 
 - **`<first-push-sha>`** — from `gh pr view <N> --json commits`, the newest commit whose `committedDate` is at or before the cycle-1 trigger comment's timestamp; with no trigger comment, use the PR's `createdAt`. A first push of several commits resolves to the last of them.
+- **Measurement** — `git diff --stat $(git merge-base origin/<baseRefName> HEAD)..HEAD` against the same reading at `<first-push-sha>`. Never a plain `<first-push-sha>..HEAD` two-dot diff, which counts every base change since the branch point — including commits a step 7 merge brought in — as PR growth.
 - **`pr_cycle_count`** — the PR's `@<bot> … review` trigger comments read chronologically per the cycle-1 rule, skipping the cheap non-blocking re-triggers, plus one when review feedback predates every trigger comment. This is never the loop's in-memory `review_count`.

--- a/skills/fix-pr-review/rereview-routing.md
+++ b/skills/fix-pr-review/rereview-routing.md
@@ -1,89 +1,58 @@
 # Re-review routing (fix-pr-review step 10)
 
-The complete routing procedure for the re-review trigger fix-pr-review posts after it pushes its fixes. Read it whole before posting the trigger — guessing a phrase from memory posts a trigger no Action answers.
+The routing procedure for the re-review trigger. Read it whole before posting — a guessed phrase posts a trigger no Action answers.
 
 ## 1. Pick the bot, then the model
 
-The re-review goes to the review bot of the **current cycle**, and the default is `@claude`. Use `@codex` only when this cycle selected Codex — one of: the user said so ("review with Codex", "use Codex"), a caller argument named it (`reviewBot: codex`), the invocation included the literal `codex` argument (the skill's Input section), or this run itself was started by an `@codex` GitHub comment. A `codex.yml` merely existing in the repo does **not** select Codex. Once a cycle has a bot, every re-review in that cycle stays on it — never switch mid-cycle.
+The re-review goes to the **current cycle's** review bot; the default is `@claude`. Use `@codex` only when this cycle selected Codex: the user said so, a caller argument named it, the invocation carried the literal `codex` argument, or this run started from an `@codex` comment. A `codex.yml` merely existing does **not** select Codex. Once a cycle has a bot, never switch mid-cycle.
 
 ## 2. Route by blocking vs non-blocking
 
-Route by whether the set you addressed contained **any blocking finding** (noted in step 1). Never route by the newest review's verdict alone: with multiple reviewers, a later `LGTM` from one does not erase another's `Needs Updates`.
-
-A finding is blocking when it is a `Needs Fixing` or `Requires Human Review` item from any review, an inline thread that validated as a real defect, or any CI Failure finding from step 2 — **counted regardless of its verdict**, whether you fixed it or refuted it as pre-existing or flaky, exactly as the reviewer clauses count regardless of verdict.
-
-A CI failure you refuted still counts as blocking on purpose: if that refutation was wrong, the heavier re-review is what catches the real regression you dismissed.
+Route by whether the addressed set contained **any blocking finding** (fix-pr-review step 1), never by the newest review's verdict alone — a later `LGTM` from one reviewer does not erase another's `Needs Updates`. Blocking = a `Needs Fixing` or `Requires Human Review` item from any review, an inline thread that validated as a real defect, or any CI Failure finding — **counted regardless of its verdict**, fixed or refuted. A refuted CI failure still counts on purpose: a wrong refutation is what the heavier re-review catches.
 
 ### Blocking — route on the reviewer that ran cycle 1
 
-**The step-down is keyed to the reviewer that actually ran cycle 1.** The score band does not decide it. Before you read a band row, identify the cycle-1 reviewer: list the PR's comments in chronological order and take the **EARLIEST** one whose entire body is an `@<bot> … review` trigger line, **skipping every cheap non-blocking re-trigger** (`@claude sonnet review` on Claude, `@codex luna review` on Codex) — **unless the cheap phrase is what cycle 1 itself would have used**, in which case the earliest such comment IS cycle 1 and you must not skip it. Two things make it cycle 1: the PR's band is the owner table's cheapest first-review row, which selects that same phrase as a first review; or a stamped `PR review:` line in the linked issue names the cheap reviewer — `sonnet` or `haiku` on Claude, either of those mapped to `luna` on Codex — which posts that same phrase as cycle 1 **at any band**. Read the stamp before you apply the skip. That comment is cycle 1. Never take a later trigger comment for it — a step-down rung is a later trigger comment, so reading the newest one would send a C90 PR's blocking findings to the cheapest tier.
+**The step-down is keyed to the reviewer that actually ran cycle 1** — the score band does not decide it. Identify cycle 1 first: take the **EARLIEST** `@<bot> … review` trigger comment on the PR (one whose entire body is the trigger line), **skipping every cheap non-blocking re-trigger** (`@claude sonnet review` on Claude, `@codex luna review` on Codex) — **unless the cheap phrase is what cycle 1 itself would have used**, in which case that earliest comment IS cycle 1. Two things make it cycle 1: the PR's band is the owner table's cheapest first-review row, or a stamped `PR review:` line in the linked issue names the cheap reviewer (`sonnet`/`haiku` on Claude, either mapped to `luna` on Codex), which posts that phrase as cycle 1 at any band. **Read the stamp before applying the skip** — a stamped cheap trigger is byte-identical to the non-blocking phrase, and skipping it would discard the genuine cycle 1. Never take a later trigger comment as cycle 1 — a step-down rung is itself a later trigger comment.
 
-**Why the cheap shorthand is skipped:** a non-blocking pass posts it at any band, and a PR's first review can arrive with no trigger comment at all — a human reviewer, or fix-pr-review-loop step 1's "unaddressed feedback is already present" branch, which sets `review_count = 1` and posts nothing. On a C90 PR that pair makes `@claude sonnet review` the earliest trigger comment on the PR, and reading it as cycle 1 would pin every later blocking re-review to the cheapest reviewer. Inside the cheapest band the skip is unnecessary and would change nothing: the band row posts the same phrase, so either reading gives the same trigger. Under a cheap stamp the skip is not merely unnecessary, it is **wrong at any band above the cheapest**: a stamped `@claude sonnet review` with no `effort:<tier>` is byte-identical to the non-blocking phrase, so skipping it discards the genuine cycle 1, leaves no trigger comment, and drops the PR onto the fallback table — which posts `@claude review` and breaks the guarantee below that a Sonnet cycle 1 keeps its own trigger. That is why the stamp is read first. When skipping leaves no trigger comment at all, the PR has no genuine cycle 1 to key on — take the fallback table below. Then: if cycle 1 ran on Fable or on Opus — selected by the owner table's row for that band, or by a stamped `PR review:` line naming Fable or Opus at any score, which the read order puts first — take the step-down ladder instead of the fallback row. A first review on the standard trigger or on Sonnet sits at or below the ladder floor and keeps its own trigger for every blocking re-review, whatever its band. So a C55 PR whose issue stamps `@claude fable review effort:high` takes the ladder rather than a fallback row, and a C10 PR stamped `@claude opus review` takes the ladder too and drops to `@claude review` for every blocking re-review.
+When skipping leaves no trigger comment at all, take the fallback table below. Otherwise: a cycle 1 on Fable or Opus — selected by the owner table's row for its band, or by a stamped `PR review:` line naming Fable or Opus at any score — takes the step-down ladder. A first review on the standard trigger or on Sonnet sits at or below the ladder floor and keeps its own trigger for every blocking re-review, whatever its band.
 
-On a Claude cycle a stamped `haiku` posts `@claude sonnet review`: `claude.yml` resolves only `opus`, `sonnet` and `fable`, and an unresolved shorthand becomes the route keyword, which sends a trusted-author PR to the write-capable fix-pr job instead of the reviewer.
+On a Claude cycle a stamped `haiku` posts `@claude sonnet review`: `claude.yml` resolves only `opus`, `sonnet` and `fable`, and an unresolved shorthand becomes the route keyword, routing a trusted-author PR to the write-capable fix-pr job.
 
-**On a Codex cycle the same stamp rule applies in Codex's own vocabulary.** Never post a `@claude` rung on a Codex cycle, and never discard the stamp back to the band. Map the stamped model onto the Codex column: a stamped `sonnet` or `haiku` becomes `@codex luna review`, and a stamped `opus` or `fable` becomes the bare `@codex review`, each followed by `effort:<tier>` when the stamped line carries one. Codex exposes one flagship and has no Fable tier, so it has no step-down ladder at all — its cycle-1 trigger simply repeats for every blocking re-review. A C60 Codex PR stamped `@claude sonnet review` therefore stays on `@codex luna review` at every cycle, and an unstamped C90 one keeps the bare `@codex review` and never reaches `luna`.
+**On a Codex cycle apply the stamp rule in Codex's vocabulary.** Never post a `@claude` rung on a Codex cycle, and never discard the stamp back to the band: a stamped `sonnet`/`haiku` becomes `@codex luna review`, a stamped `opus`/`fable` the bare `@codex review`, each keeping a stamped `effort:<tier>`. Codex exposes one flagship and has no step-down ladder — its cycle-1 trigger repeats for every blocking re-review.
 
-**The fallback table below applies ONLY when the PR carries no cycle-1 trigger comment** — no `@<bot> … review` comment at all, or none left after the cheap non-blocking re-triggers are skipped. It is the table that *selected* cycle 1, so once a genuine cycle-1 trigger comment exists on the PR, that comment decides and no row here overrides it. Reach for a row when a review arrived by some other route, or when every trigger comment on the PR is a non-blocking re-trigger outside the cheapest band.
-
-**This table carries no boundary numbers of its own.** Its rows are the rows of the first-review table in `validate-issue` step 6, which owns every boundary; read the band there and take the matching row here. The triggers below are the *re-review* forms, which deviate from that table's first-review triggers on purpose.
+**The fallback table applies ONLY when the PR carries no cycle-1 trigger comment** — none at all, or none left after the cheap non-blocking re-triggers are skipped. Once a genuine cycle-1 trigger comment exists, that comment decides. **This table carries no boundary numbers of its own**: its rows are the rows of the first-review table in `validate-issue` step 6, which owns every boundary — read the band there and take the matching row here. Read the score from the `[C<score>, …]` bracket in the PR title, then the `[C<score>]` prefix of the issue the PR closes; a stamped `PR review:` line is not a score source — it selects the reviewer directly.
 
 | Owner's first-review row | Claude fallback trigger | Codex fallback trigger |
 |---|---|---|
 | the sonnet row | `@claude sonnet review` | `@codex luna review` |
 | the standard-trigger row | `@claude review` | `@codex review` |
-| the opus row | `@claude opus review`, but only when no `@claude opus review` comment already exists on the PR; `@claude review` otherwise | `@codex review` |
-| the fable row, or no score | `@claude opus review`, but only when no `@claude opus review` comment already exists on the PR; `@claude review` otherwise — a first review already ran by some other route, so never open a Fable cycle on a re-review | `@codex review` at every cycle |
+| the opus row | `@claude opus review`, only when no `@claude opus review` comment already exists on the PR; `@claude review` otherwise | `@codex review` |
+| the fable row, or no score | as the opus row — a first review already ran by some other route, so never open a Fable cycle on a re-review | `@codex review` at every cycle |
 
-**Why the two heavy rows are guarded.** Fable and Opus each review one cycle only. A row that handed out a fresh Opus cycle every time the fallback was reached would let a PR that already spent its Opus rung restart at Opus indefinitely, which is the cost the ladder exists to bound. The guard reuses the rung-counting rule below: scan the PR for an `@claude opus review` comment before you post one.
-
-Codex exposes one flagship, so every row above the sonnet row collapses onto its
-bare trigger, and the heaviest row stays there — it never reaches `luna`. Only the
-sonnet row and the non-blocking re-review use the cheap shorthand.
-
-When a fallback row does apply, read the score from the `[C<score>, …]` bracket in the PR title, then from the `[C<score>]` prefix of the issue the PR closes. A stamped `PR review:` line carries a trigger and no score, so it is not a score source — it selects the reviewer directly, which is the cycle-1 rule above. `validate-issue` step 6 owns the authoritative band table.
+The two heavy rows are guarded because Fable and Opus each review one cycle only. On Codex, every row above the sonnet row collapses onto the bare trigger; only the sonnet row and the non-blocking re-review use `@codex luna review`.
 
 ### After a Fable or an Opus first review — the step-down ladder (Claude cycles only)
 
-This ladder is Claude's. Its rungs are `@claude` triggers, which section 1 forbids on a Codex cycle, and Codex exposes one flagship with no tier to step down from — on Codex the cycle-1 trigger repeats instead, per the mapping above.
-
-**Every reviewer above the standard trigger runs one blocking cycle only.** Each blocking re-review steps down one rung. The ladder floor is `@claude review`, which repeats for every blocking cycle after it. So whenever a Claude cycle 1 ran on Fable or on Opus — selected by the owner table's row for that band, or by a stamped `PR review:` line naming Fable or Opus at any score — the reviewer steps down:
+**Every reviewer above the standard trigger runs one blocking cycle only.** Each blocking re-review steps down one rung; the floor is `@claude review`, which repeats for every blocking cycle after it:
 
 | Cycle-1 reviewer | Blocking cycle 2 | Blocking cycle 3 and after |
 |---|---|---|
 | `@claude fable review effort:high` | `@claude opus review` | `@claude review` |
 | `@claude opus review` | `@claude review` | `@claude review` |
 
-Neither the fable trigger nor the opus trigger is ever repeated on a blocking re-review.
-
-The ladder **stops at `@claude review`**. It never steps down to sonnet, however many cycles it takes — a change that earned a capable first review keeps one to the end. **Sonnet sits below the floor and takes no rung:** a cycle 1 on `@claude sonnet review` repeats that trigger for every blocking re-review, and the ladder never steps *up* from it. A cycle 1 on the standard `@claude review` is already at the floor and repeats too.
-
-Decide which rung you are on from the PR's own trigger comments, reading them in chronological order from that **earliest** cycle-1 comment: after a fable cycle 1, a prior `@claude opus review` posted since means the next rung is `@claude review`; after an opus cycle 1, the single rung is `@claude review` for the first blocking re-review and every one after it. Ignore any `@claude sonnet review` comment while counting rungs — that is a non-blocking re-trigger, which consumes no rung and is never a ladder position.
+Neither the fable nor the opus trigger is ever repeated on a blocking re-review. The ladder **never steps down to sonnet**, however many cycles it takes; Sonnet sits below the floor and takes no rung — a sonnet cycle 1 repeats its own trigger, as does a cycle 1 already on `@claude review`. Decide the rung from the trigger comments after cycle 1: a prior `@claude opus review` after a fable cycle 1 means the next rung is `@claude review`. Ignore `@claude sonnet review` comments while counting rungs — a non-blocking re-trigger consumes no rung.
 
 ### Non-blocking only
 
-When the pass addressed only optional improvements or follow-ups, the PR was already in good shape. Route to the cheap model shorthand — `@claude sonnet review` on Claude, `@codex luna review` on Codex. The band does not apply, and a non-blocking cycle consumes no rung.
+A pass that addressed only optional improvements or follow-ups routes to the cheap shorthand — `@claude sonnet review` on Claude, `@codex luna review` on Codex — in any band, consuming no rung.
 
 ## 3. Post it as its own comment
 
-Post a **separate** comment so the bot triggers cleanly on its own line. Never bundle the trigger into the disposition comment — a trigger buried in a longer body does not fire.
+Post a **separate** comment (`gh pr comment <N> --body "@claude review"` etc.) — a trigger buried in a longer body does not fire, so never bundle it into the disposition comment. If the repo uses a different trigger phrase, match its `.github/workflows/claude.yml` / `codex.yml`. A trigger comment is a one-line mention, not authored content — no footer.
 
-```bash
-# whatever ran cycle 1, repeated when it is at or below the ladder floor — or, after a
-# fable or an opus cycle 1, the next rung down; a fallback row only when the PR carries
-# no trigger comment at all
-gh pr comment <N> --body "@claude review"
-gh pr comment <N> --body "@claude opus review"
+## Growth check
 
-# any pass that addressed only non-blocking items, in any band
-gh pr comment <N> --body "@claude sonnet review"
+Inputs for fix-pr-review step 4's growth check, both read from the PR itself so a resumed loop sees the same values:
 
-# the same cases when this cycle selected Codex — every band above the cheapest collapses
-# onto the bare trigger; the cheapest band and the non-blocking pass keep the shorthand
-gh pr comment <N> --body "@codex review"
-gh pr comment <N> --body "@codex luna review"
-```
-
-If this repo uses a different review trigger phrase or model-shorthand syntax, match it — check the repo's `.github/workflows/claude.yml` or `codex.yml` for how it resolves the shorthand, and recent PR comments for the convention.
-
-A trigger comment is a one-line mention, not authored content — no footer.
+- **`<first-push-sha>`** — from `gh pr view <N> --json commits`, the newest commit whose `committedDate` is at or before the cycle-1 trigger comment's timestamp; with no trigger comment, use the PR's `createdAt`. A first push of several commits resolves to the last of them.
+- **`pr_cycle_count`** — the PR's `@<bot> … review` trigger comments read chronologically per the cycle-1 rule, skipping the cheap non-blocking re-triggers, plus one when review feedback predates every trigger comment. This is never the loop's in-memory `review_count`.


### PR DESCRIPTION
## Summary

Closes #203.

- Core `skills/fix-pr-review/SKILL.md`: 31,343 → 11,995 bytes (the issue's 12,000-byte fallback cap; the unique-rule list below documents why the 8,000-byte target could not hold every unique safety procedure).
- Directory markdown total: 59,133 → 30,812 bytes, under the 30,817 cap (48 percent smaller; the files had grown past the sizes quoted in the issue, which were measured at 51,362).
- No new companion file. Detail moved into the existing companions: collection rules and CI bucket handling into `fetch-recipes.md`, growth-check inputs (`<first-push-sha>`, `pr_cycle_count`) into `rereview-routing.md`, and the validation-discipline list into `red-flags-and-mistakes.md`.
- `rereview-routing.md` solely owns the trigger tables and cycle-1 identification; the core points at it. The core points at the CLAUDE.md/AGENTS.md best-solution rule instead of restating it.
- Step numbering (0–11) is unchanged — `fix-pr-review-loop` and `work-on-issue-loop` reference steps 1, 3, 4, 5, 7, and 10 by number.

## Unique rules kept in the core (why 8,000 bytes did not fit)

The contract tests (`tests/pr-review-contract.test.js`, `tests/issue-plain-simple-english-contract.test.js`) pin these rules to `SKILL.md` itself, so they cannot move to a companion: the Verification-limitation not-a-finding carve-out; the Outdated/Wrong/Obsolete broken-test cases with the breaks-in-another-location relevance check; scope rules 1–3 with the always-in-scope, no-reclassify, remedy-size, duplicate-search, nothing-dropped, and exclusion-exception sentences; the Reachability-precondition re-route rule; the never-delete-a-disposition rule; the cycle-1-keyed step-down statement; and the Plain-simple-English issue-body requirement. Together with the operative step skeleton they exceed 8,000 bytes.

## Verification

`bun test`: 265 pass, 0 fail (the full suite, including the pr-review contract, boundary-drift, loop-pipeline, and plain-simple-english contract tests).

Acceptance criteria: `wc -c SKILL.md` = 11,995 ≤ 12,000 with the unique-rule list above; directory sum 30,812 ≤ 30,817; scope rules 1–3, the growth check, and the re-validate-before-edit rule remain in the directory; the core no longer restates the best-solution paragraph.

## Test edits

None. The issue anticipated an Outdated edit to the under-200-line cap test, but that cap no longer exists on `main` (PR 225 removed the wording pins), so no test needed changing.

## Plain simple English

The review-fix skill file was too large. We cut repeated text and moved details into its helper files. All rules still exist, the checks still pass, and the main file is now much smaller and easier to follow.

---
Created with LLM: Fable 5 | high | Harness: Claude Code
