### PR TITLE
refactor(fix-pr-review): tighten the skill and shrink its files [C64, Fable 5.1, high]

### DIFF
--- a/skills/fix-pr-review/SKILL.md
+++ b/skills/fix-pr-review/SKILL.md
@@ -5,85 +5,83 @@ description: Use when the user asks to fix, address, or respond to a PR review �
 
 # fix-pr-review
 
-Resolve every unaddressed review finding autonomously: validate, fix or refute, implement judgment calls and optional improvements, and request a re-review. Don't stop to ask the user. **The review is a hypothesis, not a work order**: trace every finding to current `file:line` and confirm it *before* changing anything.
+Resolve every unaddressed review finding autonomously: validate, fix or refute, implement judgment calls and optional improvements, request a re-review. Never stop to ask the user. **The review is a hypothesis**: trace every finding to current `file:line` before changing anything.
 
 ## Input
 
-In any order: an optional PR reference (number or URL; default = the current branch's PR) and an optional literal `codex` token selecting Codex as this cycle's re-review bot. Any other token doesn't block — use the defaults and name it in the step 11 report. No PR found and none given → say so and stop.
+In any order: an optional PR reference (number or URL; default = the current branch's PR) and an optional literal `codex` token selecting Codex as this cycle's re-review bot. Any other token is ignored and named in the step 11 report. No PR found → say so and stop.
 
 ## Steps
 
 ### 0. Resolve the PR and sync
 
-`gh pr view <N|--> --json headRefName,headRepositoryOwner,baseRefName,state,mergeable,mergeStateStatus`, then `git fetch origin`. Be **on the PR's head branch** (`gh pr checkout <N>` if not; never fix a review on the base branch); on a **fork** PR (`headRepositoryOwner` differs), pull and push to the tracked upstream, never assume `origin`. `git pull --ff-only` — can't fast-forward → stop and report. `merged`/`closed` → stop and report. `CONFLICTING`/`DIRTY` → step 7 is part of this run.
+`gh pr view [<N>] --json number,headRefName,headRefOid,headRepositoryOwner,baseRefName,state,mergeable,mergeStateStatus`, then `git fetch origin`. `MERGED`/`CLOSED` → stop and report. Be **on the PR's head branch** (`gh pr checkout <N>` if not; never fix a review on the base branch). On a **fork** PR (`headRepositoryOwner` differs) pull from and push to the tracked upstream, which may differ from `origin`. `git pull --ff-only`; no fast-forward → stop and report. `CONFLICTING`/`DIRTY` → step 7 runs this invocation.
 
 ### 1. Fetch all unaddressed review feedback
 
-Three channels: formal reviews, issue comments, and inline diff threads. Fetch and select the unaddressed set per [fetch-recipes.md](fetch-recipes.md) — read it completely; it defines the cutoff and collection rules. **Never delete, edit, or bury a disposition comment**: the next review reads them on purpose. State what you picked and **note whether the set contains any blocking finding** (a `Needs Fixing` / `Requires Human Review` item, a thread asserting a real defect, or a failing check) — this drives step 10.
+Three channels: formal reviews, issue comments, inline diff threads. Fetch and select the unaddressed set per [fetch-recipes.md](fetch-recipes.md), read completely — it owns the cutoff and collection rules. **Never delete, edit, or bury a disposition comment**: the next review reads them on purpose. Record **whether the set contains any blocking finding** (a `Needs Fixing` / `Requires Human Review` item, a thread asserting a real defect, or a step 2 CI failure) — step 10 routes on it.
 
-**LGTM with no blocking sections** still gets its non-blocking items: implement `Recommended Optional` per step 6, file `Create Follow-up Issue` items (fixed here only under scope rule 1). **Bare `LGTM`, no finding items, no open threads** — a `**Verification limitation:**` line is not a finding — report approved and stop, naming such lines; conflicts still get step 7.
+**LGTM with non-blocking items** still gets them. **Bare `LGTM`** — no finding items, no open threads, and after step 2 no CI failure this PR caused — report approved and stop, naming any `**Verification limitation:**` lines and any CI failure attributed elsewhere; a conflict still gets step 7.
 
 ### 2. Fetch failing CI checks
 
-One `gh pr checks` snapshot, never a wait or a poll; bucket handling, failing detail, and cancelled-check attribution per [fetch-recipes.md](fetch-recipes.md). Each `fail`-bucket check is one finding: **CI Failure — `<check name>`**.
+One `gh pr checks` snapshot; never wait or poll. Buckets, failing detail, and cancelled-check attribution per [fetch-recipes.md](fetch-recipes.md). Each `fail`-bucket check is one finding: **CI Failure — `<check name>`**.
 
 ### 3. Extract findings
 
-Parse everything into atomic findings — split compound feedback, merge duplicates across sources noting all — tagged: **Needs Fixing** (blocking; every CI Failure starts here), **Requires Human Review** (blocking; the reviewer couldn't decide), **Recommended Optional** (non-blocking), **Create Follow-up Issue** (track separately; any issue this run files gets a complete body per `github-issue-format`, including a `## Plain simple English` section under 55 words — never a stub).
-
-A `**Verification limitation:**` line is never a finding — skip it when classifying. Free-form feedback classifies into the same buckets by substance.
+Parse everything into atomic findings — split compound feedback, merge duplicates across sources noting all — tagged **Needs Fixing** (blocking; every CI Failure starts here), **Requires Human Review** (blocking; the reviewer could not decide), **Recommended Optional** (non-blocking), or **Create Follow-up Issue** (tracked separately; an issue this run files gets a complete body per `github-issue-format`, including a `## Plain simple English` section under 55 words — never a stub). Free-form feedback classifies by substance. A `**Verification limitation:**` line is never a finding — skip it.
 
 ### 4. Re-validate each finding
 
-For **every** finding, trace the claim to current code and assign a verdict with your own `file:line`: ✅ **Confirmed** (code matches → fix it, step 6); ❌ **Refuted** (the claim or its remedy doesn't hold → no change; record a code-grounded rebuttal); ⚠️ **Partial** (real but narrower/broader → fix the true part; note the correction); ❓ **Judgment** (a real tradeoff → derive and **implement** the best solution, below).
+For **every** finding, trace the claim to current code and assign a verdict with your own `file:line`: ✅ **Confirmed** (fix it, step 6); ❌ **Refuted** (the claim or its remedy does not hold, or the cited code already changed and the defect is gone → no change; record a code-grounded rebuttal); ⚠️ **Partial** (real but narrower or broader → fix the true part, note the correction); ❓ **Judgment** (a real tradeoff → derive and **implement** the best solution, below).
 
 A `### Needs Fixing` item's stated `**Reachability:**` precondition is part of its claim — trace it to current code. On a code-grounded refutation of the trigger, the blocking status is refuted while the defect may still stand: re-route the finding to `### Recommended Optional`, scope-test its remedy, and record it under `### Corrected scope (partial)` in the disposition. A finding never re-routes on a likelihood judgment of your own; with no stated precondition it is validated as written.
 
-Apply the validation-discipline list in [red-flags-and-mistakes.md](red-flags-and-mistakes.md): whole-body reads and negative proofs, a suggested fix verified as its own claim, the **safety carve-out** (money, data integrity, security, auto-protective mechanisms — fix or escalate even at low confidence, never silently drop without code proof), and CI-failure attribution (fix only failures this PR's diff caused).
+Apply the validation discipline in [red-flags-and-mistakes.md](red-flags-and-mistakes.md): whole-body reads, negative proofs, a suggested fix verified as its own claim, the **safety carve-out** (money, data integrity, security, auto-protective mechanisms: fix or escalate even at low confidence; a drop needs code proof), and CI-failure attribution (fix only failures this PR's diff caused).
 
 #### Scope: the second axis on every finding
 
-A verdict says whether a finding is real; scope says whether its remedy belongs in this PR. **The yardstick**: the issue(s) this PR closes (union of asks), else the PR body's stated scope. Classify each ✅/⚠️/❓ finding's **remedy** — except one the reviewer routed to `### Create Follow-up Issue`, which is **filed and never implemented**; Rule 1 is that exclusion's only exception (the disposition says so). Apply in order — first match decides; rule 1 outranks everything later:
+A verdict says whether a finding is real; scope says whether its remedy belongs in this PR. **The yardstick**: the issue(s) this PR closes (union of asks), else the PR body's stated scope. Classify each ✅/⚠️/❓ finding's **remedy** — except one the reviewer routed to `### Create Follow-up Issue`, which is **filed and never implemented**; Rule 1 is that exclusion's only exception (the disposition says so). Apply in order; the first match decides:
 
 1. **PR-caused — always in scope.** The defect lives in code this PR adds or changes, or this PR creates the hazard → implement it, however much mechanism the fix needs; no later rule or step may reclassify it.
-2. **New mechanism the yardstick never asked for — out of scope.** The remedy introduces a mechanism the PR lacks (a new persistent store, lifecycle scheme, cross-cutting invariant, retry path, a new subsystem) → file a follow-up issue, naming a deferred pre-existing hazard plainly.
-3. **Everything else — in scope**, including a pre-existing defect whose remedy needs no new mechanism → implement it (step 6).
+2. **New mechanism the yardstick never asked for — out of scope.** The remedy introduces a mechanism the PR lacks (a new persistent store, lifecycle scheme, cross-cutting invariant, retry path, or subsystem) → file a follow-up issue, naming a deferred pre-existing hazard plainly.
+3. **Everything else — in scope**, including a pre-existing defect whose remedy needs no new mechanism.
 
-**Remedy size never decides scope, in either direction**, and **a reviewer's `Recommended Optional` carries no authority to enlarge the PR** — same test, file the out-of-scope ones.
+**Remedy size never decides scope, in either direction**, and a reviewer's `Recommended Optional` carries no authority to enlarge the PR — same test, file the out-of-scope ones.
 
-**Growth check — once per invocation, before step 6.** Measure growth and cycle count per the Growth check section of [rereview-routing.md](rereview-routing.md) — base-excluded diff against the first push, and `pr_cycle_count` (never the loop's in-memory `review_count`). Past roughly 3x the first push, or at cycle 4+: state both numbers in the step 11 report and the disposition's `Growth check:` line, and re-run the scope test on every finding you were about to implement; sustained growth means the test is applied too loosely.
+**For every ❓ Judgment finding, do the analysis the reviewer could not and implement the result** — never hand the tradeoff back. Derive the absolute-best solution per the CLAUDE.md/AGENTS.md rule (a **Recommended proposed solution:** line is verified like any remedy); record the decision, `file:line` reasoning, and rejected alternatives in the disposition. In-scope `Recommended Optional` items get the same standard.
 
-**For every ❓ Judgment finding, do the analysis the reviewer couldn't and implement the result** — never hand the tradeoff back or pause. Derive the absolute-best solution per the global rule in CLAUDE.md/AGENTS.md (a **Recommended proposed solution:** line is verified like any remedy), and record the decision, `file:line` reasoning, and rejected alternatives in the disposition. In-scope `Recommended Optional` items get the same standard; the scope test runs first.
+**Growth check — once per invocation, before step 6.** Measure per the Growth check section of [rereview-routing.md](rereview-routing.md): base-excluded diff against the first push, and `pr_cycle_count` (never the loop's in-memory `review_count`). Past roughly 3x the first push, or at cycle 4+: state both numbers in the step 11 report and the disposition's `Growth check:` line, and re-run the scope test on every finding you were about to implement — sustained growth means the test is applied too loosely.
 
 ### 5. Delegate implementation?
 
-Steps 3–4 always run inline — validation never gets delegated. Steps 6–11 may go to a synchronous `general-purpose` subagent, inheriting the session model, only on a long session, never for an open-ended ❓ Judgment or safety carve-out finding; hand it the verdicts and remedies, its footers name its own model, and relay its report verbatim.
+Steps 3–4 always run inline — validation is never delegated. Steps 6–11 may go to one synchronous `general-purpose` subagent on the session model, only on a long session and never for an open ❓ Judgment or safety carve-out finding; hand it the verdicts and remedies, its footers name its own model, relay its report verbatim.
 
 ### 6. Implement the fixes
 
-Implement every in-scope ✅/⚠️/❓/`Recommended Optional` finding. Never implement ❌ Refuted or `Create Follow-up Issue` items — file the latter, rule 1 the only exception.
+Implement every in-scope ✅/⚠️/❓/`Recommended Optional` finding, each fix scoped to its finding, following existing conventions. Never implement a ❌ Refuted item.
 
-- File each out-of-scope finding per `github-issue-format`, carrying its number plus the basis (the scope rule applied, or the reviewer's routing) into the disposition. A finding you neither implement nor file is a finding you dropped. **Search before filing:** `gh issue list --search "<keywords>" --state all` — cite an existing issue instead of duplicating; when a human closed it, say so.
-- Follow existing conventions; keep each fix scoped to its finding. When implementation reveals an in-scope remedy needs a new mechanism, re-run the scope rules in order: rule 1 stays and the mechanism gets built here; a rule-3 finding moves to rule 2 — stop and file it.
-- After all fixes, **verify**: run the project's tests/build/lint and report failures honestly; an infeasible fix moves its finding to Refuted with the reason.
-- **A stale test follows the CLAUDE.md/AGENTS.md rule "The optimal solution comes first, and the tests follow it"** — edit one only as **Outdated**, **Wrong**, or **Obsolete**, naming that case's checkable ground first — a confirmed finding grounds a test its fix makes outdated; fixtures and snapshots included. **A test that breaks in another location is checked before it is edited.** The refute check runs first: a red test may show the finding was wrong — it moves to Refuted with no test edit. When the finding stands, decide: Outdated (the fix deliberately replaces the tested behavior), Obsolete (the behavior is deleted, or another test covers it — name the surviving test carrying every assertion), or Wrong (the test was never correct). A test that is none of the three means the fix broke real behavior — leave the test and fix the code; a test with no ground stays as it is — your own reading is never a ground — and never delete, skip, loosen, or narrow a test for a green tree. When the correct fix cannot pass an ungrounded test, do not commit: stop before step 8 and report the test, `file:line`, and the conflict (step 11). **Disclose every test edit** in the commit message and under `### Test edits` in the disposition: the test, its case, the ground, and what the replacement asserts (a removal gives the ground instead).
+- **File** each out-of-scope and reviewer-routed follow-up per `github-issue-format`, carrying its number and basis (the scope rule applied, or the reviewer's routing) into the disposition. A finding you neither implement nor file is a finding you dropped. **Search first:** `gh issue list --search "<keywords>" --state all` — cite an existing issue instead of duplicating; when a human closed it, say so.
+- When implementation shows an in-scope remedy needs a new mechanism, re-run the scope rules in order: rule 1 stays and the mechanism gets built here; a rule-3 finding moves to rule 2 — stop and file it.
+- **Verify** after all fixes: run the project's tests, build, and lint; report failures honestly. An infeasible fix moves its finding to Refuted with the reason. A failure pre-existing on the base branch never blocks the commit; name it in the report.
+- **A stale test follows the CLAUDE.md/AGENTS.md rule "The optimal solution comes first, and the tests follow it"**: edit a test, fixture, or snapshot only as **Outdated**, **Wrong**, or **Obsolete**, naming that case's checkable ground first — a confirmed finding grounds a test its fix makes outdated. The refute check runs first: a red test may show the finding was wrong, moving it to Refuted with no test edit. **A test that breaks in another location is checked before it is edited** — read it and decide: Outdated (the fix deliberately replaces the tested behavior), Wrong (never correct), or Obsolete (behavior deleted, or another test covers it — name the surviving test carrying every assertion). None of the three means the fix broke real behavior: leave the test and fix the code. Your own reading is never a ground; never delete, skip, loosen, or narrow a test for a green tree. When the correct fix cannot pass an ungrounded test, do not commit: stop before step 8 and report the test, its `file:line`, and the conflict. **Disclose every test edit** in the commit message and under `### Test edits` in the disposition: the test, its case, the ground, and what the replacement asserts (a removal gives the ground instead).
 
 ### 7. Resolve merge conflicts
 
-If the PR is `CONFLICTING`: `git fetch origin <baseRefName> && git merge origin/<baseRefName>` on the head branch — never rebase a pushed PR branch, never blanket `ours`/`theirs`; preserve the intent of both sides, re-deriving your fix on new base code where they overlap. An irreconcilable conflict in safety-class code → stop and surface to the user. Re-run verification after resolving; give the resolution its own line in the disposition and the report.
+If the PR is `CONFLICTING`: `git fetch origin <baseRefName> && git merge origin/<baseRefName>` on the head branch — never rebase a pushed PR branch, never blanket `ours`/`theirs`; preserve the intent of both sides, re-deriving your fix on new base code where they overlap. An irreconcilable conflict in safety-class code → stop and surface it to the user. Re-run verification; give the resolution its own line in the disposition and the report.
 
 ### 8. Commit and push
 
-Only after verification passes: `git status`; stage **each fix file by name** (never `git add -A`); `git commit -F <msg-file>`; `git push` to the tracked upstream (a fork's head is not on `origin`). Message: "Address review on #<N>: <summary>" plus the **Updated**-verb LLM Attribution Footer per the global CLAUDE.md/AGENTS.md rule, `Harness: Claude Code`.
+Only after step 6's verification: `git status`; stage **each fix file by name** (never `git add -A`; a step 7 merge commit stays as git created it); `git commit -F <msg-file>`; `git push` to the tracked upstream. Message: "Address review on #<N>: <summary>", every test edit disclosed, plus the **Updated**-verb LLM Attribution Footer per the global CLAUDE.md/AGENTS.md rule, `Harness: Claude Code`. Confirm the push landed: `gh pr view <N> --json headRefOid` must equal `git rev-parse HEAD`; on a mismatch stop, post nothing, and report it.
 
 ### 9. Post the disposition comment
 
-Post one comment stating what happened to each finding, per [disposition-comment.md](disposition-comment.md), read completely.
+One comment stating what happened to each finding, per [disposition-comment.md](disposition-comment.md), read completely — posted even when every finding was refuted; never silently no-op.
 
 ### 10. Trigger the re-review
 
-Post one trigger comment per [rereview-routing.md](rereview-routing.md), read completely. The step-down is keyed to the reviewer that actually ran cycle 1, never to a band; route by whether the addressed set contained **any blocking finding** (step 1), never by the newest verdict alone; the trigger is its **own** comment, never bundled into the disposition.
+One trigger comment per [rereview-routing.md](rereview-routing.md), read completely. The step-down is keyed to the reviewer that actually ran cycle 1; the band does not decide it. Route by whether the addressed set contained **any blocking finding** (step 1); the newest verdict alone does not decide it either. The trigger is its **own** comment; a trigger bundled into the disposition does not fire.
 
 ### 11. Report to the user
 
-Terse summary: reviews/threads acted on, per-disposition counts, commit SHA, verification result, and the re-review reviewer. Name every test edit with its case and ground. If step 6 stopped on an ungrounded test, say no commit or push exists and name the test, its `file:line`, what it asserts, and the conflict. Include growth-check numbers, unexpected dirty files left unstaged (step 8), `**Verification limitation:**` sources, and any unrecognized argument only when present. Flag resolved judgment calls for override — the work is done. Edge cases: the stop-condition table in [red-flags-and-mistakes.md](red-flags-and-mistakes.md).
+Terse summary: reviews and threads acted on, per-disposition counts, commit SHA, verification result, re-review reviewer, and every test edit with its case and ground. A step 6 stop on an ungrounded test says no commit or push exists and names the test, its `file:line`, what it asserts, and the conflict. Only when present: growth-check numbers, pre-existing verification failures, unexpected dirty files left unstaged, `**Verification limitation:**` sources, an ignored argument. Flag resolved judgment calls for override — the work is done.

--- a/skills/fix-pr-review/disposition-comment.md
+++ b/skills/fix-pr-review/disposition-comment.md
@@ -13,16 +13,19 @@ Growth check: diff <lines> lines vs <lines> at first push (<ratio>x); cycle <N>.
 1. **<finding title>** — <what changed> (`file:line`). <Scope rule 1 note when required — see below.>
 
 ### Corrected scope (partial)
-1. **<finding title>** — <what was real and fixed vs. what wasn't | blocking status refuted: the stated Reachability precondition <trigger>, refuted by <what the code does>; the defect <stands | does not stand>; re-routed to `### Recommended Optional`> (`file:line`).
+1. **<finding title>** — <what was real and fixed vs. what was not | blocking status refuted: the stated Reachability precondition <trigger>, refuted by <what the code does>; the defect <stands | does not stand>; re-routed to `### Recommended Optional`> (`file:line`).
 
 ### Not changed (refuted)
-1. **<finding title>** — <code-grounded reason the suggestion doesn't apply> (`file:line`).
+1. **<finding title>** — <code-grounded reason the suggestion does not apply> (`file:line`).
 
 ### Resolved judgment calls (was Requires Human Review)
 1. **<finding title>** — implemented <the best solution and why, `file:line`>. Alternatives rejected: <one line each>.
 
+### Resolved merge conflicts
+1. `<file>` — <how the two sides were reconciled>.
+
 ### Deferred to follow-up
-1. **<finding title>** — out of scope, basis <scope rule <N>: the mechanism the remedy needs and the yardstick that does not ask for it | reviewer-routed to `### Create Follow-up Issue`>; filed as #<issue>.
+1. **<finding title>** — out of scope, basis <scope rule 2: the mechanism the remedy needs and the yardstick that does not ask for it | reviewer-routed to `### Create Follow-up Issue`>; filed as #<issue>.
 
 ### Test edits
 1. **<test name>** (`file:line`) — <Outdated | Wrong | Obsolete>; ground: <the finding, issue, contract, or instruction that authorizes it>; now asserts <what the replacement asserts, or the ground alone for a removal, naming the surviving test for the redundancy case>.
@@ -32,13 +35,12 @@ Growth check: diff <lines> lines vs <lines> at first push (<ratio>x); cycle <N>.
 
 - **Copy `<finding title>` verbatim from the review comment** — the reviewer's bold one-sentence title, word for word. The next reviewer matches findings to these dispositions by claim; a reworded title brings a settled finding back.
 - Every **Not changed (refuted)** and **Corrected scope (partial)** item carries a code-grounded rebuttal with its `file:line` that stands on its own — what a later reviewer must answer before re-raising.
-- **A blocking finding whose stated `**Reachability:**` precondition the code refutes goes under `### Corrected scope (partial)`, and nowhere else** — `pr-review`'s prior-cycle rule settles findings only on the dispositions it names, so a re-route recorded elsewhere settles nothing. The item names the stated precondition, the `file:line` that refutes it, whether the defect still stands, and the section the finding moves to. When the re-routed remedy is fixed in this same push, it also gets its own **Fixed** item; this item records the routing change alone.
-- Omit any empty section. Keep each item one line with a `file:line` anchor.
+- **A blocking finding whose stated `**Reachability:**` precondition the code refutes goes under `### Corrected scope (partial)`, and nowhere else** — `pr-review`'s prior-cycle rule settles findings only on the dispositions it names. The item names the stated precondition, the `file:line` that refutes it, whether the defect still stands, and the section the finding moves to. A re-routed remedy fixed in this same push also gets its own **Fixed** item; this item records the routing change alone.
+- Omit any empty section. Keep each item one line with a `file:line` anchor. The `Growth check:` line appears only when step 4's growth check fired; it is the one place those numbers live.
 - **Every test edit appears under `### Test edits`** with its case, ground, and replacement assertion (a removal gives the ground instead); an edit missing from it reads as undisclosed.
-- The `Growth check:` line appears only when step 4's growth check fired; it is the one place those numbers live.
-- **Every Deferred to follow-up item names both its basis and the issue number.** The basis has exactly two admissible values: the fixer scope rule applied (rule 2, with the mechanism the remedy needs and the yardstick that does not ask for it), or the reviewer's own `### Create Follow-up Issue` routing, where step 4's exclusion filed the item without running one. Rule 1 never appears here — it keeps the finding in the PR, under **Fixed** with the rule-1 note. `pr-review` settles the finding on that pair as on a rebuttal; a deferral missing either half settles nothing, so the finding returns next cycle. An item matching an issue an earlier cycle filed cites that existing issue.
-- **A Fixed item that kept a finding in the PR against something that would have filed it carries a scope rule 1 note** — required exactly when the reviewer routed it to `### Create Follow-up Issue` and the exclusion-exception pulled it back, or when rule 2 would have filed it and rule 1 matched first. The note names rule 1 and states, from code, what this PR adds or changes that causes the defect (or the hazard it creates). Other Fixed items carry no note.
-- CI Failure findings slot into the same sections — fixed under **Fixed**, pre-existing/flaky under **Not changed (refuted)** with the base-branch or flake evidence in place of a code citation.
+- **Every Deferred to follow-up item names both its basis and the issue number.** The basis has exactly two admissible values: scope rule 2 (with the mechanism the remedy needs and the yardstick that does not ask for it), or the reviewer's own `### Create Follow-up Issue` routing, filed without running a scope rule. Rule 1 never appears here — it keeps the finding in the PR, under **Fixed** with the rule-1 note. `pr-review` settles the finding on that pair as on a rebuttal; a deferral missing either half settles nothing, so the finding returns next cycle. An item matching an issue an earlier cycle filed cites that existing issue.
+- **A Fixed item that kept a finding in the PR against something that would have filed it carries a scope rule 1 note** — exactly when the reviewer routed it to `### Create Follow-up Issue` and the exclusion-exception pulled it back, or when rule 2 would have filed it and rule 1 matched first. The note names rule 1 and states, from code, what this PR adds or changes that causes the defect (or the hazard it creates). Other Fixed items carry no note.
+- CI Failure findings slot into the same sections — fixed under **Fixed**, pre-existing or flaky under **Not changed (refuted)** with the base-branch or flake evidence in place of a code citation.
 
 ## Inline-thread replies
 
@@ -46,7 +48,7 @@ For findings from inline diff threads, also post a one-line reply in the thread 
 
 ## Posting
 
-`gh pr comment <N> --body-file <file>`, ending with the **Created**-verb footer (it's a new comment):
+`gh pr comment <N> --body-file <file>`, ending with the **Created**-verb footer (it is a new comment):
 
 ```
 ---

--- a/skills/fix-pr-review/fetch-recipes.md
+++ b/skills/fix-pr-review/fetch-recipes.md
@@ -5,26 +5,26 @@ Reference for SKILL.md steps 1–2: channel queries, collection rules, CI-check 
 ## Review-feedback channels (step 1)
 
 ```bash
-# PR reviews (formal review events) — state included so DISMISSED reviews can be skipped
+# Formal review events — state included so DISMISSED reviews can be skipped
 gh api repos/{owner}/{repo}/pulls/<N>/reviews --paginate --jq '.[] | {id, user: .user.login, state, submitted_at, body}'
-# Issue comments on the PR (where @claude review output usually lands)
+# Issue comments on the PR — where @claude review output usually lands
 gh api repos/{owner}/{repo}/issues/<N>/comments --paginate --jq '.[] | {author: .user.login, created_at, body}'
-# Inline diff threads WITH resolution state — REST can't report isResolved, so use GraphQL
+# Inline diff threads with resolution state — REST cannot report isResolved, so use GraphQL
 gh api graphql -F owner='{owner}' -F repo='{repo}' -F pr=<N> -f query='
   query($owner:String!,$repo:String!,$pr:Int!){ repository(owner:$owner,name:$repo){ pullRequest(number:$pr){
     reviewThreads(first:100){ pageInfo{hasNextPage endCursor} nodes{ isResolved isOutdated path line
       comments(first:50){ nodes{ databaseId author{login} createdAt body } } } } } } }'
 ```
 
-(If `hasNextPage` is true, paginate with `endCursor` — don't silently drop threads past 100.)
+When `hasNextPage` is true, paginate with `endCursor` — never drop threads past 100.
 
 ### Collection rules
 
 **Cutoff** = the timestamp of your most recent disposition comment on the PR (or the last commit you pushed addressing a review); no cutoff → everything since the PR opened. Collect:
 
-- Every formal review or review-formatted comment **newer than the cutoff** — one opening with an `LGTM` / `Needs Updates` verdict, carrying review sections like `### Needs Fixing`, or otherwise clearly review feedback. **If multiple reviews landed, address all of them**, not just the latest. Skip `DISMISSED` reviews.
-- Every **unresolved** inline thread (`isResolved: false`) **regardless of age** — resolution state, not timestamp, decides; `isOutdated` alone doesn't mean resolved. Exception: a thread whose last comment is your own disposition reply with no response since is awaiting the reviewer — skip it. Each thread is one finding.
-- Skip your own prior disposition comments and `@<bot> … review` trigger comments when collecting new work.
+- Every formal review or review-formatted comment **newer than the cutoff** — one opening with an `LGTM` / `Needs Updates` verdict, carrying sections like `### Needs Fixing`, or otherwise clearly review feedback. **When several landed, address all of them.** The latest alone is incomplete. Skip `DISMISSED` reviews.
+- Every **unresolved** inline thread (`isResolved: false`) **regardless of age** — resolution state decides and the timestamp does not; `isOutdated` alone does not mean resolved. Exception: a thread whose last comment is your own disposition reply with no response since is awaiting the reviewer — skip it. Each thread is one finding.
+- Skip your own prior disposition comments and `@<bot> … review` trigger comments.
 
 ## CI check snapshot (step 2)
 
@@ -34,12 +34,12 @@ gh pr checks <N> --json name,state,bucket,link,startedAt,completedAt
 
 `bucket` normalizes `state` into `pass`/`fail`/`pending`/`skipping`/`cancel`:
 
-- `pending` / `skipping` — **skip entirely.** A running check is the next pass's problem; don't retry, wait, or treat "not done yet" as a finding.
+- `pending` / `skipping` — **skip entirely.** A running check is the next pass's problem; never retry, wait, or treat "not done yet" as a finding.
 - `cancel` — see the attribution procedure below.
-- `fail` — pull just the failing detail, not the whole log:
+- `fail` — pull only the failing detail:
   - GitHub Actions: resolve the run ID from the check's `link`, then `gh run view <run-id> --log-failed`.
-  - External CI: `gh api` doesn't auto-fill `{sha}`, so get it first (`gh pr view <N> --json headRefOid --jq .headRefOid`), then `gh api repos/{owner}/{repo}/commits/<sha>/check-runs --jq '.check_runs[] | select(.conclusion=="failure") | {name, output}'`.
+  - External CI: `gh api` does not fill `{sha}`, so read it first (`gh pr view <N> --json headRefOid --jq .headRefOid`), then `gh api repos/{owner}/{repo}/commits/<sha>/check-runs --jq '.check_runs[] | select(.conclusion=="failure") | {name, output}'`.
 
 ### Attributing a `bucket: cancel` check
 
-Skip a cancelled check unless its run log shows a real upstream failure caused the cancel rather than a manual one. When it did, and this snapshot already has a `fail`-bucket entry for that upstream job, skip the cancelled check — the `fail` path covers it. Otherwise resolve the run ID from its `link`, `gh run view <run-id>` to find the failed job, pull its detail via the `fail` procedure, and cite that job's name. If no concrete failed job surfaces, never invent an upstream cause — record the finding against the cancelled check's own name with its run link and flag it for human review.
+Skip a cancelled check unless its run log shows a real upstream failure caused the cancel; a manual cancel is skipped. When it did and this snapshot already has a `fail`-bucket entry for that upstream job, skip it — the `fail` path covers it. Otherwise resolve the run ID from its `link`, find the failed job with `gh run view <run-id>`, pull its detail via the `fail` procedure, and cite that job's name. When no concrete failed job surfaces, never invent an upstream cause — record the finding against the cancelled check's own name with its run link and flag it for human review.

--- a/skills/fix-pr-review/red-flags-and-mistakes.md
+++ b/skills/fix-pr-review/red-flags-and-mistakes.md
@@ -1,30 +1,27 @@
-# Red Flags, Validation Discipline, and Common Mistakes
+# Validation discipline and red flags
 
-Reference for SKILL.md; step numbers refer to it.
+Reference for SKILL.md step 4.
 
-## Validation discipline (step 4)
+## Validation discipline
 
-- **Read the body, not just the cited line.** A name states intent; open the function and trace the conditional fully before agreeing.
+- **Read the whole body, beyond the cited line.** A name states intent; open the function and trace the conditional fully before agreeing.
 - **Prove negatives by reading the path.** "X is never validated / never freed / not awaited" — confirm the absence across *all* relevant paths; the behavior may be produced elsewhere.
-- **A suggested fix is its own claim.** Verify the *remedy* is correct for this codebase, and derive the right fix from first principles if the suggested one is suboptimal.
-- **Safety carve-out** — money, data integrity, security, auto-protective mechanisms: fix or escalate even at low confidence; never silently drop as Refuted without code proof it's a non-issue.
-- **CI Failures**: read the failing step's actual error, not just the job name. ✅ Confirmed if it traces to this PR's diff (reproduce the failing command locally where feasible). ❌ Refuted only with evidence — pre-existing on the base branch (check CI history or reproduce on base) or a one-off infra flake — don't patch around it; note it in the disposition and flag it to the user.
+- **A suggested fix is its own claim.** Verify the remedy is correct for this codebase; derive the right fix from first principles when the suggested one is suboptimal, and never blind-apply one that touches money, data, security, or auto-protective logic.
+- **Safety carve-out** — money, data integrity, security, auto-protective mechanisms: fix or escalate even at low confidence; never drop as Refuted without code proof it is a non-issue.
+- **CI Failures**: read the failing step's actual error; the job name alone is no evidence. ✅ Confirmed when it traces to this PR's diff (reproduce the failing command locally where feasible). ❌ Refuted only with evidence — pre-existing on the base branch (CI history, or reproduce on base) or a one-off infra flake; never patch around it, and flag it to the user.
+- **`Requires Human Review`**: verify the **Recommended proposed solution:** like any remedy, implement the chosen solution, and document the decision plus rejected alternatives. Never pause, punt, or guess blindly.
 
-## Red Flags — STOP
+## Red flags — STOP
 
 | Situation | Action |
 |-----------|--------|
-| Finding cites a line that no longer matches current code | Re-validate against current `file:line`; it may already be fixed — Refuted with the reason |
-| Suggested fix touches money/data/security/auto-protective logic | Never blind-apply; implement the safest correct design from first principles |
-| On the base branch or a divergent branch | Check out the PR head first; never commit review fixes to the base |
-| All findings refuted | Still post the disposition with the rebuttals and request re-review — never silently no-op |
-| `Requires Human Review` item | Verify the **Recommended proposed solution:** against the step 4 standard, implement the chosen solution, document decision + rejected alternatives. Never pause, punt, or guess blindly |
-| A failing test looks wrong and no checkable ground says so | Leave it and fix the code — your reading is not a ground. Check first whether the red test refutes the finding; if the correct fix still can't pass, stop before step 8 and report the test with its `file:line` |
-| PR `CONFLICTING` with the base | Resolve via step 7 (merge base into head, reconcile intent, re-verify) — never rebase a pushed branch or blanket `ours`/`theirs` |
-| Conflict sides irreconcilable in intent (esp. safety-class code) | Stop and surface to the user instead of guessing |
+| Finding cites a line that no longer matches current code | Re-validate against current `file:line`; an already-fixed defect is Refuted with the reason |
+| All findings refuted | Still post the disposition with the rebuttals and request the re-review — never silently no-op |
+| A failing test looks wrong and no checkable ground says so | Leave it and fix the code — your reading is not a ground; when the correct fix still cannot pass, stop before step 8 and report it |
+| Conflict sides irreconcilable in intent, especially safety-class code | Stop and surface it to the user instead of guessing |
 
-## Common Mistakes
+## Common mistakes
 
 - **Blind-implementing the review** — performative agreement ships regressions; validate first, every time.
-- **Delegating validation** — steps 3–4 always run inline; dispatch only steps 6–11, and never split one review across subagents.
+- **Delegating validation** — steps 3–4 always run inline; dispatch only steps 6–11, as one unit; one review never splits across several subagents.
 - **Addressing only the latest review when several landed** — every review newer than your last disposition and every unresolved thread gets addressed.

--- a/skills/fix-pr-review/rereview-routing.md
+++ b/skills/fix-pr-review/rereview-routing.md
@@ -1,37 +1,24 @@
 # Re-review routing (fix-pr-review step 10)
 
-The routing procedure for the re-review trigger. Read it whole before posting — a guessed phrase posts a trigger no Action answers.
+Read it whole before posting — a guessed phrase posts a trigger no Action answers.
 
-## 1. Pick the bot, then the model
+## 1. Pick the bot
 
-The re-review goes to the **current cycle's** review bot; the default is `@claude`. Use `@codex` only when this cycle selected Codex: the user said so, a caller argument named it, the invocation carried the literal `codex` argument, or this run started from an `@codex` comment. A `codex.yml` merely existing does **not** select Codex. Once a cycle has a bot, never switch mid-cycle.
+The re-review goes to the **current cycle's** bot; the default is `@claude`. Use `@codex` only when this cycle selected Codex: the user said so, a caller argument named it, the invocation carried the literal `codex` argument, or this run started from an `@codex` comment. A `codex.yml` merely existing does **not** select Codex. Never switch bots mid-cycle.
 
 ## 2. Route by blocking vs non-blocking
 
-Route by whether the addressed set contained **any blocking finding** (fix-pr-review step 1), never by the newest review's verdict alone — a later `LGTM` from one reviewer does not erase another's `Needs Updates`. Blocking = a `Needs Fixing` or `Requires Human Review` item from any review, an inline thread that validated as a real defect, or any CI Failure finding — **counted regardless of its verdict**, fixed or refuted. A refuted CI failure still counts on purpose: a wrong refutation is what the heavier re-review catches.
+Route by whether the addressed set contained **any blocking finding** (fix-pr-review step 1). The newest review's verdict alone does not decide it: a later `LGTM` from one reviewer does not erase another's `Needs Updates`. Blocking = a `Needs Fixing` or `Requires Human Review` item from any review, an inline thread that validated as a real defect, or any CI Failure finding — **counted regardless of its verdict**, fixed or refuted. A refuted CI failure still counts on purpose: a wrong refutation is what the heavier re-review catches.
 
-### Blocking — route on the reviewer that ran cycle 1
+**Non-blocking only** (optional improvements or follow-ups) → the cheap shorthand, `@claude sonnet review` on Claude or `@codex luna review` on Codex, in any band, consuming no rung.
 
-**The step-down is keyed to the reviewer that actually ran cycle 1** — the score band does not decide it. Identify cycle 1 first: take the **EARLIEST** `@<bot> … review` trigger comment on the PR (one whose entire body is the trigger line), **skipping every cheap non-blocking re-trigger** (`@claude sonnet review` on Claude, `@codex luna review` on Codex) — **unless the cheap phrase is what cycle 1 itself would have used**, in which case that earliest comment IS cycle 1. Two things make it cycle 1: the PR's band is the owner table's cheapest first-review row, or a stamped `PR review:` line in the linked issue names the cheap reviewer (`sonnet`/`haiku` on Claude, either mapped to `luna` on Codex), which posts that phrase as cycle 1 at any band. **Read the stamp before applying the skip** — a stamped cheap trigger is byte-identical to the non-blocking phrase, and skipping it would discard the genuine cycle 1. Never take a later trigger comment as cycle 1 — a step-down rung is itself a later trigger comment.
+**Blocking** → the step-down below, **keyed to the reviewer that actually ran cycle 1**; the score band never decides it.
 
-When skipping leaves no trigger comment at all, take the fallback table below. Otherwise: a cycle 1 on Fable or Opus — selected by the owner table's row for its band, or by a stamped `PR review:` line naming Fable or Opus at any score — takes the step-down ladder. A first review on the standard trigger or on Sonnet sits at or below the ladder floor and keeps its own trigger for every blocking re-review, whatever its band.
+### Identify cycle 1
 
-On a Claude cycle a stamped `haiku` posts `@claude sonnet review`: `claude.yml` resolves only `opus`, `sonnet` and `fable`, and an unresolved shorthand becomes the route keyword, routing a trusted-author PR to the write-capable fix-pr job.
+Take the **EARLIEST** `@<bot> … review` trigger comment on the PR (one whose entire body is the trigger line), **skipping every cheap non-blocking re-trigger** (`@claude sonnet review` on Claude, `@codex luna review` on Codex) — **unless that cheap phrase is what cycle 1 itself would have used**, in which case the earliest such comment IS cycle 1. Two things make it so: the PR's band is the owner table's cheapest first-review row, or a stamped `PR review:` line in the linked issue names the cheap reviewer (`sonnet`/`haiku` on Claude, either mapped to `luna` on Codex). **Read the stamp before applying the skip** — a stamped cheap trigger is byte-identical to the non-blocking phrase, and skipping it discards the genuine cycle 1. A step-down rung is itself a later trigger comment, so a later comment is never cycle 1.
 
-**On a Codex cycle apply the stamp rule in Codex's vocabulary.** Never post a `@claude` rung on a Codex cycle, and never discard the stamp back to the band: a stamped `sonnet`/`haiku` becomes `@codex luna review`, a stamped `opus`/`fable` the bare `@codex review`, each keeping a stamped `effort:<tier>`. Codex exposes one flagship and has no step-down ladder — its cycle-1 trigger repeats for every blocking re-review.
-
-**The fallback table applies ONLY when the PR carries no cycle-1 trigger comment** — none at all, or none left after the cheap non-blocking re-triggers are skipped. Once a genuine cycle-1 trigger comment exists, that comment decides. **This table carries no boundary numbers of its own**: its rows are the rows of the first-review table in `validate-issue` step 6, which owns every boundary — read the band there and take the matching row here. Read the score from the `[C<score>, …]` bracket in the PR title, then the `[C<score>]` prefix of the issue the PR closes; a stamped `PR review:` line is not a score source — it selects the reviewer directly.
-
-| Owner's first-review row | Claude fallback trigger | Codex fallback trigger |
-|---|---|---|
-| the sonnet row | `@claude sonnet review` | `@codex luna review` |
-| the standard-trigger row | `@claude review` | `@codex review` |
-| the opus row | `@claude opus review`, only when no `@claude opus review` comment already exists on the PR; `@claude review` otherwise | `@codex review` |
-| the fable row, or no score | as the opus row — a first review already ran by some other route, so never open a Fable cycle on a re-review | `@codex review` at every cycle |
-
-The two heavy rows are guarded because Fable and Opus each review one cycle only. On Codex, every row above the sonnet row collapses onto the bare trigger; only the sonnet row and the non-blocking re-review use `@codex luna review`.
-
-### After a Fable or an Opus first review — the step-down ladder (Claude cycles only)
+### The step-down ladder (Claude cycles)
 
 **Every reviewer above the standard trigger runs one blocking cycle only.** Each blocking re-review steps down one rung; the floor is `@claude review`, which repeats for every blocking cycle after it:
 
@@ -39,21 +26,34 @@ The two heavy rows are guarded because Fable and Opus each review one cycle only
 |---|---|---|
 | `@claude fable review effort:high` | `@claude opus review` | `@claude review` |
 | `@claude opus review` | `@claude review` | `@claude review` |
+| `@claude review` or `@claude sonnet review` | same trigger | same trigger |
 
-Neither the fable nor the opus trigger is ever repeated on a blocking re-review. The ladder **never steps down to sonnet**, however many cycles it takes; Sonnet sits below the floor and takes no rung — a sonnet cycle 1 repeats its own trigger, as does a cycle 1 already on `@claude review`. Decide the rung from the trigger comments after cycle 1: a prior `@claude opus review` after a fable cycle 1 means the next rung is `@claude review`. Ignore `@claude sonnet review` comments while counting rungs — a non-blocking re-trigger consumes no rung.
+Neither heavy trigger is ever repeated on a blocking re-review, whether the owner-table row or a stamped `PR review:` line selected it. The ladder **never steps down to sonnet**: Sonnet sits below the floor and takes no rung, so a Sonnet cycle 1 repeats its own trigger, as does a cycle 1 already on `@claude review`. Decide the rung from the trigger comments after cycle 1 — a prior `@claude opus review` after a fable cycle 1 means the next rung is `@claude review` — ignoring `@claude sonnet review` comments, which consume no rung. A stamped `haiku` posts `@claude sonnet review`: `claude.yml` resolves only `opus`, `sonnet`, and `fable`, and an unresolved shorthand becomes the route keyword.
 
-### Non-blocking only
+### Codex cycles
 
-A pass that addressed only optional improvements or follow-ups routes to the cheap shorthand — `@claude sonnet review` on Claude, `@codex luna review` on Codex — in any band, consuming no rung.
+Codex exposes one flagship and has no ladder — its cycle-1 trigger repeats for every blocking re-review. Never post a `@claude` rung on a Codex cycle, and never discard a stamp back to the band: a stamped `sonnet`/`haiku` becomes `@codex luna review`, a stamped `opus`/`fable` the bare `@codex review`, each keeping a stamped `effort:<tier>`.
+
+### Fallback table
+
+**The fallback table applies ONLY when the PR carries no cycle-1 trigger comment** — none at all, or none left after the cheap re-triggers are skipped. **It carries no boundary numbers of its own**: its rows are the rows of the first-review table in `validate-issue` step 6, which owns every boundary — read the band there and take the matching row here. Read the score from the `[C<score>, …]` bracket in the PR title, then the `[C<score>]` prefix of the issue the PR closes; a stamped `PR review:` line is not a score source — it selects the reviewer directly.
+
+| Owner's first-review row | Claude fallback trigger | Codex fallback trigger |
+|---|---|---|
+| the sonnet row | `@claude sonnet review` | `@codex luna review` |
+| the standard-trigger row | `@claude review` | `@codex review` |
+| the opus row, the fable row, or no score | `@claude opus review` only when no `@claude opus review` comment already exists on the PR; `@claude review` otherwise | `@codex review` |
+
+The heavy rows are guarded because Fable and Opus each review one cycle only, and a first review already ran by some other route — never open a Fable cycle on a re-review.
 
 ## 3. Post it as its own comment
 
-Post a **separate** comment (`gh pr comment <N> --body "@claude review"` etc.) — a trigger buried in a longer body does not fire, so never bundle it into the disposition comment. If the repo uses a different trigger phrase, match its `.github/workflows/claude.yml` / `codex.yml`. A trigger comment is a one-line mention, not authored content — no footer.
+Post a **separate** comment (`gh pr comment <N> --body "@claude review"` etc.) — a trigger buried in a longer body does not fire, so never bundle it into the disposition. If the repo uses a different trigger phrase, match its `.github/workflows/claude.yml` / `codex.yml`. A trigger comment is a one-line mention and carries no footer.
 
 ## Growth check
 
-For fix-pr-review step 4's growth check, all read from the PR itself so a resumed loop sees the same values:
+Inputs for fix-pr-review step 4's growth check, all read from the PR itself so a resumed loop sees the same values:
 
 - **`<first-push-sha>`** — from `gh pr view <N> --json commits`, the newest commit whose `committedDate` is at or before the cycle-1 trigger comment's timestamp; with no trigger comment, use the PR's `createdAt`. A first push of several commits resolves to the last of them.
 - **Measurement** — `git diff --stat $(git merge-base origin/<baseRefName> HEAD)..HEAD` against the same reading at `<first-push-sha>`. Never a plain `<first-push-sha>..HEAD` two-dot diff, which counts every base change since the branch point — including commits a step 7 merge brought in — as PR growth.
-- **`pr_cycle_count`** — the PR's `@<bot> … review` trigger comments read chronologically per the cycle-1 rule, skipping the cheap non-blocking re-triggers, plus one when review feedback predates every trigger comment. This is never the loop's in-memory `review_count`.
+- **`pr_cycle_count`** — the PR's `@<bot> … review` trigger comments read chronologically per the cycle-1 rule, skipping the cheap non-blocking re-triggers, plus one when review feedback predates every trigger comment. Never the loop's in-memory `review_count`.


### PR DESCRIPTION
## Summary

Rewrites the five `skills/fix-pr-review/` files in place. No new companion file, step numbering 0–11 unchanged (`fix-pr-review-loop`, `work-on-issue-loop`, and `docs/contract-inventory.md` reference steps by number).

| File | Before | After |
|---|---|---|
| `SKILL.md` | 11,991 | 11,743 |
| `disposition-comment.md` | 4,721 | 4,684 |
| `fetch-recipes.md` | 3,543 | 3,475 |
| `red-flags-and-mistakes.md` | 3,038 | 2,569 |
| `rereview-routing.md` | 7,497 | 6,417 |
| Total | 30,790 | 28,888 |

The core stays near its size because the contract tests pin its unique rules there (scope rules, Reachability re-route, broken-test cases, disposition rule) and the rewrite adds the behavior fixes below.

### Behavior improvements

- **Step 0** reads `headRefOid` and stops on `MERGED`/`CLOSED` before any checkout.
- **Bare LGTM** stops only after the step 2 CI snapshot shows no failure this PR caused. Before, the stop ran ahead of step 2, so a red check the PR's own diff caused was never fixed on an approved PR.
- **Step 6 verification**: a failure pre-existing on the base branch no longer blocks the commit; it is named in the report. Before, "only after verification passes" blocked every commit on an unrelated red test.
- **Step 8** confirms the push landed (`headRefOid` equals local `HEAD`) before any comment is posted, and keeps a step 7 merge commit as git created it.
- **Step 9** states that an all-refuted pass still posts the disposition.
- **Disposition template** gains the `### Resolved merge conflicts` section that step 7 already required.
- **Refuted verdict** names the already-fixed-defect case (a stale citation).

### Cuts

- `red-flags-and-mistakes.md` drops the table rows the core already states (base branch, `CONFLICTING`, `Requires Human Review`) and folds the safety blind-apply row into the validation list.
- `rereview-routing.md` folds the floor rows into the ladder table, merges the two guarded fallback rows, and removes repeated cycle-1 explanations.
- Duplicated Verification-limitation, follow-up-issue, and best-solution sentences now appear once in the core.
- Contrastive "X, not Y" phrasing replaced across all five files.

## Verification

`bun test`: 265 pass, 0 fail (includes `pr-review-contract`, `first-review-boundary-drift`, `issue-plain-simple-english-contract`, `contract-inventory`).

## Test edits

None.

## Plain simple English

The review-fix skill files are smaller and clearer. The skill now also fixes a failing check on an approved pull request, does not block on a test that was already red before the change, and confirms its push reached the pull request before it posts comments.

https://claude.ai/code/session_01Ce3zEKk7wVyRwNX7RYs56C

---
Created with LLM: Fable 5.1 | high | Harness: Claude Code
