### PR TITLE
refactor(skills): shrink and tighten the fableplan and issueplan skills [C64, Fable 5.1, high]

### DIFF
--- a/skills/fableplan/SKILL.md
+++ b/skills/fableplan/SKILL.md
@@ -5,109 +5,97 @@ description: Use when the user wants a task planned by a Fable 5.1 planning suba
 
 # fableplan
 
-Delegate planning to a **Fable 5.1** Plan subagent, then build from its plan in the main agent. The main agent does the building — the subagent only plans.
+A **Fable 5.1** Plan subagent writes the plan. The main agent checks it, posts it, and builds from it. The subagent never builds.
 
 ## Input
 
-The user provides a task description, and optionally a GitHub issue:
-- A task in prose ("fableplan adding X to Y").
-- A GitHub issue reference — full URL, `#<N>`, bare `<N>`, or `owner/repo#N`. When present, the plan is also posted as an issue comment.
-- If neither is obvious, ask the user what to plan before dispatching.
+A task description, with an optional GitHub issue:
+
+- Prose, such as "fableplan adding X to Y".
+- An issue reference: full URL, `#<N>`, bare `<N>`, or `owner/repo#N`. The plan is then also posted as an issue comment.
+- Ask what to plan only when the task is unclear. With no issue referenced, never invent one or post anywhere.
 
 ## Steps
 
 ### 1. Resolve the GitHub issue (only if one is referenced)
 
-If the user named an issue, fetch it so the subagent plans against the real requirements, not a paraphrase:
+Fetch the issue so the subagent plans against the real requirements:
 
 ```
 gh issue view <N> --json number,title,body,url
 ```
 
-For the `owner/repo#N` form (or a full URL to another repo), add `-R owner/repo` — a bare `gh issue view <N>` only resolves against the current repo.
+Add `-R owner/repo` for another repository. Stop and tell the user if the command fails. Never plan from a paraphrase of an issue you could not fetch.
 
-If the command fails (wrong number, no auth, no repo), stop and tell the user — never proceed by planning against your paraphrase of an issue you couldn't fetch.
-
-Record the issue number and URL — you'll need them in step 4. If no issue is referenced, skip this and step 4's posting.
-
-Also note any legacy **Plan effort** line on the fetched body — step 2 always dispatches at `high`; any stamped tier that is not `high` is clamped and reported in step 5. When no issue is referenced, step 2 still dispatches at `high`.
+Record the number and URL for step 4. Note any legacy **Plan effort** line on the body: planning always runs at `high`, and step 5 reports a stamped tier that differs.
 
 ### 2. Dispatch the Fable 5.1 Plan subagent
 
-Do not re-plan the task yourself first — the subagent owns the plan. **Load the `fable-dispatch` skill before dispatching**: it owns the dispatch path and the dispatch-hygiene rules in its section 7 (read-only prompt, snapshot/diff, retry once then report). Dispatch per its ladder; on the Agent-tool path, call the Agent tool with:
+Do not plan the task yourself first. **Load the `fable-dispatch` skill before dispatching.** It owns the dispatch ladder, the CLI shim, result parsing, attribution (section 6), and the dispatch-hygiene rules every caller follows (section 7: read-only prompt, snapshot and diff, retry once then report). On the Agent-tool path, call the Agent tool with:
 
 - `subagent_type`: `Plan`
-- `model`: `fable` (this is the whole point of the skill — the plan must come from Fable 5.1)
-- `run_in_background`: `false` — every later step depends on the plan, so wait for it synchronously instead of doing other work first
-- `effort`: always `high`. Pass it explicitly rather than omitting it — an omitted parameter leaves the subagent on the session's own tier, which the footer cannot name honestly and which may be below `high`. **Not every harness's Agent tool accepts `effort`.** Before passing it, check the Agent tool's own parameter schema in this harness: if it exposes no `effort` property, don't construct the argument — dispatch without it and note that the tier could not be honored. If the schema check is inconclusive and the call fails input validation on the parameter, re-dispatch once without `effort` rather than treating it as the step-2 failure below; a plan at session effort beats no plan. Either way this is a degradation, not an error — never abort the step over it, and report it to the user in step 5. This degradation is Agent-tool-only: on `fable-dispatch`'s CLI-shim path, `--effort high` carries the tier directly.
+- `model`: `fable`. This forces Fable 5.1 whatever the main agent's model.
+- `run_in_background`: `false`. Every later step needs the plan, so wait for it.
+- `effort`: `high`, passed explicitly, when the Agent tool's schema exposes an `effort` property. When it does not, dispatch without it. When the schema check is inconclusive and the call fails input validation on that parameter, re-dispatch once without it. Dispatching without `effort` is a degradation to report in step 5, never a step failure. On the CLI-shim path, `--effort high` carries the tier directly.
 - `description`: `Plan <short task name>`
-- `prompt`: Hand the subagent everything it needs to plan independently — the full task description, the issue title/body if one was fetched, the working directory, and any constraints the user stated. Tell it explicitly:
-  - Produce a concrete, ordered implementation plan (files to create/modify, the approach, build sequence, risks/edge cases, and how to verify).
-  - Number the implementation steps (`1.`, `2.`, …) and end each step with a **verify point** — the observable check that proves the step is done (a command to run, a test that passes, a file state to confirm). Builders mirror these numbered steps into their progress tracker during long builds, so a step without a number or a verify point loses its anchor.
-  - Plan the absolute-best solution the task calls for, evaluated as if cost, effort, time, token spend, and code volume were unlimited — they are not factors and must never narrow the option space. The only constraints that override "best" are correctness and safety.
-  - Return the plan as its final message in clean Markdown suitable to (a) act on directly and (b) post verbatim as a GitHub issue comment.
-  - It is planning only — state the read-only rule explicitly in the prompt per `fable-dispatch` section 7.
+- `prompt`: everything the subagent needs to plan on its own: the full task, the issue title and body when fetched, the working directory, and the user's constraints. Instruct it to:
+  - Produce a concrete, ordered plan: files to create or modify, the approach, build sequence, risks and edge cases, and verification.
+  - Number the implementation steps (`1.`, `2.`, …) and end each step with a **verify point**: the observable check that proves the step is done (a command, a passing test, a file state). Builders mirror these steps into their task tracker, so a step without a number or verify point loses its anchor.
+  - Plan the absolute-best solution. Cost, effort, time, token spend, and code volume never narrow the option space. Only correctness and safety override "best".
+  - Return the plan as its final message in clean Markdown, fit to act on directly and to post verbatim as an issue comment.
+  - Make no file edits and no commits, including through Bash (the read-only rule of `fable-dispatch` section 7).
 
-The Plan subagent's final message is returned to you as the tool result; it is not shown to the user.
+When the tool result (the plan) arrives:
 
-When the result arrives:
-- Save the plan verbatim to a scratchpad file immediately, so it survives context summarization during a long build and step 4 can post it exactly as produced.
-- **Record the model and effort the subagent actually ran at** — the model is `Fable 5.1` unless the `fable-dispatch` fallback ladder substituted another, and the effort is `high` unless the harness accepted no `effort` at all. Only in that last case does the recorded value become a convention rather than an observation — then record `high` and **do not try to name the session's own tier**, which an agent cannot observe. Also record *whether* the tier was honored — step 5 tells the user when a legacy stamped tier that is not `high` was clamped. Step 4's footer names these recorded values, so resolve them now rather than assuming the run took effect.
+- Save the plan verbatim to a scratchpad file at once. It must survive context summarization during a long build, and step 4 posts from it.
+- Run the snapshot diff from `fable-dispatch` section 7.
+- **Record the model and effort that actually ran.** The model is `Fable 5.1` unless the fallback ladder substituted another. The effort is `high` unless the harness accepted no `effort` parameter. In that case record `high` as the requested tier, note that the tier was not honored, and do not guess the session's own tier. Step 4's footer and step 5's report use these values.
 
 ### 3. Sanity-check the plan against the code
 
-Before posting or presenting it, verify the plan's load-bearing claims against the actual codebase: the files it says to modify exist, the functions/symbols it references are real, and it doesn't contradict repo conventions (CLAUDE.md). Fix small inaccuracies yourself and note them; if the plan is structurally wrong (built on a file or mechanism that doesn't exist), do NOT automatically re-dispatch the Plan subagent — stop and tell the user what's failing, and let them decide whether to re-plan with Fable 5.1, adjust the task, or proceed anyway. If you fixed small inaccuracies, update the scratchpad file from step 2 so it reflects the corrected plan before step 4 posts it.
+Verify the plan's load-bearing claims against the codebase: the files it modifies exist, the symbols it names are real, and it follows repository conventions (CLAUDE.md). Fix small inaccuracies yourself, note them, and update the scratchpad file. If the plan is structurally wrong (built on a file or mechanism that does not exist), do not re-dispatch on your own. Stop, tell the user what fails, and let them decide: re-plan with Fable 5.1, adjust the task, or proceed anyway.
 
 ### 4. Post the plan to the GitHub issue (only if one was resolved in step 1)
 
-Now that the plan has passed the sanity-check, save it to the issue as a comment before building, so the vetted plan is preserved on the issue regardless of how the build goes. This comment is not updated after the build.
-
-```
-gh issue comment <N> --body-file <tmpfile>
-```
-
-Add `-R owner/repo` when the issue lives in another repo (as in step 1). Use the scratchpad file from step 2 (with any step-3 corrections) as the body-file base — it avoids shell-escaping problems with Markdown. Prefix the comment so its origin is clear with a heading line `## Implementation plan (Fable 5.1)` above the plan body, and end the body with the standard metadata footer:
+Post the checked plan before building, so it survives whatever happens to the build. Never update the comment afterwards. Build the body from the scratchpad file: a heading line `## Implementation plan (Fable 5.1)`, the plan, then the attribution footer:
 
 ```
 ---
 Created with LLM: <model that actually ran> | <effort that actually ran> | Harness: <harness> | fableplan
 ```
 
-Fill the model and effort fields from the values recorded at the end of step 2 — **never a constant**. `<harness>` names the harness actually running the session (`Claude Code`, `Cursor`, `Codex`, …), per `fable-dispatch` section 6. Normally that is `Fable 5.1 | high`. It falls back to the substituted model name when the `fable-dispatch` fallback ladder fired. Never invent a tier the run cannot account for. A footer claiming a tier the run did not use is a false attribution, the same defect the milestone-pipeline plan footer fixes.
+Fill the model and effort from step 2's recorded values, never a constant. `<harness>` names the harness running the session per `fable-dispatch` section 6. A footer that names a model or tier the run did not use is a false attribution.
 
-After posting, give the user the comment URL `gh` returns. Follow the repo's CLAUDE.md conventions for comment formatting if any apply (e.g. avoid `#N` auto-links in list items). If no issue is referenced, skip this step.
+```
+gh issue comment <N> --body-file <tmpfile>
+```
+
+Add `-R owner/repo` for another repository. Follow the repository's comment conventions (for example no bare `#N` list numbering). Give the user the comment URL.
 
 ### 5. Relay the plan to the user
 
-Present the vetted plan to the user (the main agent).
-
-**If step 2 recorded that the harness could not honor `high`, say so here in one line.** **If the issue carried a legacy stamped Plan effort that is not `high`, say it was clamped to `high`.** When neither applies, stay silent.
+Present the checked plan. Say in one line if step 2 could not honor `high`, or if the issue's legacy Plan effort stamp differed from `high` and was clamped. Otherwise say nothing about tiers.
 
 ### 6. Ask whether to continue building (only if an issue was referenced)
 
-The plan is now safely posted to the issue regardless of what happens next — don't assume the user wants an immediate build. Ask (e.g. via `AskUserQuestion`) whether to continue building this now or stop here. If they stop, end the skill; they can resume later with `work-on-issue` on the same issue. If no issue was referenced in step 1, there's nothing posted to fall back to, so skip the question and proceed straight to building.
+The plan is safely posted, so do not assume an immediate build. Ask (for example via `AskUserQuestion`) whether to build now or stop. On stop, end the skill; the user can resume later with `work-on-issue`. With no issue, there is nothing posted to fall back to, so skip the question and build.
 
 ### 7. Set up an isolated git worktree
 
-Before making any code changes, move the build into its own git worktree so it never touches the user's current workspace. If the directory isn't a git repository, tell the user and ask how to proceed rather than building in place. Create the worktree and branch per `work-on-issue` step 1 ("Create the isolated worktree on a verified base"): it owns the fetch-first rule, the base verification, the reset rule for a brand-new worktree, and the `-C` anchoring. Deltas for this skill: the name is `<agent-prefix>/fableplan/<short-task-name>` (e.g. `cc/fableplan/<short-task-name>`), and there is no `baseRefs` input — the base is always the fetched `origin/<default-branch>`.
+Never build in the user's current checkout. If the directory is not a git repository, tell the user and ask how to proceed. Create the worktree and branch per `work-on-issue` step 1 ("Create the isolated worktree on a verified base"). Deltas: the name is `<agent-prefix>/fableplan/<short-task-name>` (for example `cc/fableplan/<short-task-name>`), and there is no `baseRefs` input, so the base is always the fetched `origin/<default-branch>`.
 
-Do all of step 8's building inside that worktree. When the build is done, follow the repo's usual conventions for merging or opening a PR from the branch, and remove the worktree once it's no longer needed (`git worktree remove <path>`).
+Build inside that worktree. When done, open a PR per the repository's conventions, and remove the worktree once it is no longer needed (`git worktree remove <path>`).
 
 ### 8. Build
 
-In the worktree from step 7, the main agent builds the task per the plan. **Before writing any code, mirror the plan's numbered steps into the task tracker per `work-on-issue` step 2 ("Mirror the plan's steps into the task tracker")** — it owns the mirroring rule, the two fallbacks (a plan with no numbers or verify points, a harness with no tracker), and the disposition for a step an override cancels. Confirm with the user first only if the plan reveals ambiguity or a decision the user must make; otherwise proceed.
+The main agent builds per the plan. Before writing any code, mirror the plan's numbered steps into the task tracker per `work-on-issue` step 2 (its "Mirror the plan's steps into the task tracker" paragraph). That paragraph owns the mirroring rule, both fallbacks, and the disposition of a step an override cancels. Confirm with the user first only when the plan exposes an ambiguity or a decision that is theirs to make.
 
 ## Planning-phase-only invocation
 
 Wrapper skills (the validate chains, `fableplan-loop`, `fableplan-work-on-issue`) invoke this skill for planning only. In that mode:
 
-- Run **steps 1 through 5 only**: fetch the issue, dispatch the Fable 5.1 Plan subagent, sanity-check the plan against the code, post the vetted plan as an issue comment, and relay it.
-- **Do NOT execute steps 7–8** (worktree + build), and do not act on step 6's build question. The caller owns implementation; a build here would duplicate the caller's implement chain in the wrong worktree location.
-- When the caller supplies a harness suffix, use it in place of `fableplan` in step 4's posted-comment attribution footer, so the comment records the actual entry point.
-- Keep the vetted plan's scratchpad file; the caller passes it to its implementation or report stage.
-- If the step-3 sanity-check finds the plan structurally wrong, or the dispatch fails after the `fable-dispatch` section 7 retry, stop and report to the caller. Never post a broken plan, and never plan the task yourself in fableplan's place.
+- Run **steps 1 through 5 only**. Do not act on step 6's build question, and do not execute steps 7 and 8. The caller owns implementation.
+- Use the caller's harness suffix in place of `fableplan` in step 4's footer, so the comment records the actual entry point.
+- Keep the scratchpad file. The caller passes it to its implementation or report stage.
+- On a structurally wrong plan, or a dispatch that fails after the `fable-dispatch` section 7 retry, stop and report to the caller. Never post a broken plan, and never plan the task yourself in fableplan's place.
 
-## Notes
-
-- The Plan subagent runs on Fable 5.1 regardless of the main agent's model — `model: fable` on the Agent call forces it.
-- If the user did not reference an issue, never invent one or post anywhere — just plan and build.

--- a/skills/issueplan/SKILL.md
+++ b/skills/issueplan/SKILL.md
@@ -6,21 +6,19 @@ description: >-
 
 # issueplan
 
-Plan with the current large language model (LLM) in the current session. Keep planning and building in this session.
-
-Do not create or use a subagent during this workflow. The current agent owns every step.
+The current session's large language model (LLM) plans and builds. Never call the Agent tool, Task tool, workflow delegation, or any subagent mechanism at any step.
 
 ## Input
 
-Accept a task description and an optional GitHub issue:
+A task description, with an optional GitHub issue:
 
-- Accept prose, such as "issueplan adding X to Y."
-- Accept a full issue URL, `#<N>`, bare `<N>`, or `owner/repo#N`.
-- Ask what to plan only when the task is unclear.
+- Prose, such as "issueplan adding X to Y".
+- An issue reference: full URL, `#<N>`, bare `<N>`, or `owner/repo#N`. The plan is then also posted as an issue comment.
+- Ask what to plan only when the task is unclear. With no issue referenced, never invent one or post anywhere.
 
 ## Steps
 
-### 1. Resolve the GitHub issue when one is referenced
+### 1. Resolve the GitHub issue (only if one is referenced)
 
 Fetch the issue before planning:
 
@@ -28,110 +26,55 @@ Fetch the issue before planning:
 gh issue view <N> --json number,title,body,url
 ```
 
-Add `-R owner/repo` for another repository. A bare command resolves against the current repository.
+Add `-R owner/repo` for another repository. Stop and tell the user if the command fails. Never plan from a paraphrase of an issue you could not fetch.
 
-Stop if the command fails. Do not plan from a paraphrase when the referenced issue is unavailable.
-
-Record the issue number, URL, title, and full body. Skip issue posting in step 4 when the user gave no issue.
-
-Read any `## Execution` block as a task constraint. Keep the current session model and effort for planning.
+Record the number, URL, title, and full body for steps 2 and 4. Read any `## Execution` block as a task constraint. Planning still runs on the current session model and effort.
 
 ### 2. Produce the plan in the current session
 
-Do not call the Agent tool, Task tool, workflow delegation, or any subagent mechanism.
-
 Inspect the repository with read-only commands. Read its instruction files and the code that controls the requested behavior.
 
-Produce a concrete, ordered implementation plan. Include:
+Produce a concrete, ordered plan: files to create or modify, the approach, build sequence, correctness and safety risks, edge cases, and verification. Number the implementation steps (`1.`, `2.`, …) and end each step with a **verify point**: the observable check that proves the step is done (a command, a passing test, a file state).
 
-- Files to create or modify.
-- The implementation approach and build sequence.
-- Correctness risks, safety risks, and edge cases.
-- Tests and other verification.
+Plan the absolute-best solution. Cost, time, token use, and code volume never narrow the option space. Only correctness and safety override "best".
 
-Number the implementation steps (`1.`, `2.`, …). End each step with a verify point: the observable check that proves the step is done (a command to run, a test that passes, a file state to confirm). Builders mirror these steps into their progress tracker during long builds.
-
-Select the best solution for correctness and safety. Ignore cost, time, token use, and code volume during solution selection.
-
-Keep the plan in clean Markdown. Make it suitable for direct use and for a GitHub issue comment.
-
-Save the plan to a temporary scratchpad immediately. Preserve its exact text for step 4 and the later build.
-
-Use the current session model and effort in attribution. Use a repository-defined fallback only when its instructions require one.
-
-Never infer unavailable attribution values. State the limitation before posting when repository instructions provide no fallback.
+Write the plan in clean Markdown, fit to act on directly and to post verbatim as an issue comment. Save it to a scratchpad file at once. It must survive context summarization during a long build, and step 4 posts from it.
 
 ### 3. Check the plan against the code
 
-Verify each load-bearing claim against the repository. Confirm that named files, symbols, commands, and conventions exist.
+Verify each load-bearing claim: the files, symbols, commands, and conventions the plan names exist. Fix small errors yourself, note them, and update the scratchpad file. If the plan depends on a missing mechanism or a major false assumption, stop and ask the user whether to revise the task or the plan.
 
-Correct small errors and update the scratchpad. Tell the user what changed.
+### 4. Post the plan to the GitHub issue (only if one was resolved in step 1)
 
-Stop when the plan depends on a missing mechanism or a major false assumption. Ask the user whether to revise the task or plan.
-
-### 4. Post the plan when an issue was resolved
-
-Add this heading before the checked plan:
-
-```
-## Implementation plan (current session)
-```
-
-End the comment with the repository's required attribution footer. Use this form when the repository has no stronger rule:
+Post the checked plan before building, so it is preserved whatever happens to the build. Build the body from the scratchpad file: a heading line `## Implementation plan (current session)`, the plan, then the repository's required attribution footer. Use this form when the repository has no stronger rule:
 
 ```
 ---
 Created with LLM: <current session model> | <current session effort> | Harness: issueplan
 ```
 
-Post the prepared file:
+Fill the model and effort from the current session. Never guess a value the session cannot observe; when the repository gives no fallback, tell the user the limitation before posting.
 
 ```
 gh issue comment <N> --body-file <tmpfile>
 ```
 
-Add `-R owner/repo` for another repository. Give the returned comment URL to the user.
-
-Skip this step when the user gave no issue. Do not create or select an issue on the user's behalf.
+Add `-R owner/repo` for another repository. Follow the repository's comment conventions (for example no bare `#N` list numbering). Give the user the comment URL.
 
 ### 5. Present the plan
 
-Show the checked plan to the user. Include the issue comment URL when step 4 posted it.
+Show the checked plan, with the comment URL when step 4 posted it. State any attribution limitation or repository constraint that affects the plan.
 
-State any attribution limitation or repository constraint that affects the plan.
+### 6. Ask whether to continue building (only if an issue was referenced)
 
-### 6. Confirm issue builds or continue prose tasks
+The plan is safely posted, so do not assume an immediate build. Ask (for example via `AskUserQuestion`) whether to build now or stop. On stop, end the skill; the user can resume later with `work-on-issue`. With no issue, there is nothing posted to fall back to, so skip the question and build.
 
-Ask whether to continue building or stop after the posted plan. Use the harness question tool when one is available.
+### 7. Set up an isolated git worktree
 
-End the workflow when the user stops. They can resume later with `work-on-issue`.
+Never build in the user's current checkout. If the directory is not a git repository, tell the user and ask how to proceed. Create the worktree and branch per `work-on-issue` step 1 ("Create the isolated worktree on a verified base"). Deltas: the name is `<agent-prefix>/issueplan/<short-task-name>`, and there is no `baseRefs` input, so the base is always the fetched `origin/<default-branch>`.
 
-For a task with no issue, continue directly into worktree creation, implementation, and pull request creation after presenting the checked plan.
+### 8. Build
 
-Ask first only when the plan exposes a required product decision or unsafe ambiguity.
+Build per the plan in the worktree with the current session LLM. Before writing any code, mirror the plan's numbered steps into the task tracker per `work-on-issue` step 2 (its "Mirror the plan's steps into the task tracker" paragraph). That paragraph owns the mirroring rule, both fallbacks, and the disposition of a step an override cancels. Confirm with the user first only when the plan exposes a product decision or an unsafe ambiguity.
 
-### 7. Create an isolated git worktree
-
-Keep all changes out of the user's current checkout. Stop and ask how to proceed when the directory is not a git repository.
-
-Create the worktree and branch per `work-on-issue` step 1, "Create the isolated worktree on a verified base". Use the name `<agent-prefix>/issueplan/<short-task-name>`. Supply no `baseRefs`; the base is the fetched `origin/<default-branch>`.
-
-Verify the working directory before every later write.
-
-### 8. Build from the plan
-
-Implement the checked plan in the worktree with the current session LLM. Do not delegate implementation to a subagent.
-
-Before you write any code, copy the plan's numbered steps into the task tracker per `work-on-issue` step 2, "Mirror the plan's steps into the task tracker". That step owns the rule, the two fallbacks, and what to do with a step that an override cancels.
-
-Follow repository test, commit, push, and pull request rules. Record any plan deviation in the pull request.
-
-Remove the worktree only after repository rules permit removal.
-
-## Rules
-
-- Keep the same session and current LLM for planning and building.
-- Use no subagent at any point.
-- Post only to an issue the user referenced.
-- Preserve the checked plan for the build.
-- Follow repository instructions for attribution and git workflow.
+Follow the repository's test, commit, push, and pull request rules. Record every plan deviation in the pull request body. Remove the worktree once it is no longer needed and repository rules permit.


### PR DESCRIPTION
## Summary

- `skills/fableplan/SKILL.md`: 11,725 → 8,011 bytes. `skills/issueplan/SKILL.md`: 5,788 → 5,165 bytes.
- Step numbers 1 through 8 are unchanged. The wrapper skills (`fableplan-loop`, `fableplan-work-on-issue`, the validate chains) cite steps 1–5, 6, and 7–8 by number and the "Planning-phase-only invocation" section by name; all of those anchors stay.
- fableplan cites `fable-dispatch` sections 6 (attribution) and 7 (read-only prompt, snapshot and diff, retry once) in place of restating them. The effort-parameter paragraph keeps the same rules in fewer words: pass `effort: high` when the schema exposes it, re-dispatch once without it on input-validation failure, report the degradation in step 5.
- Both skills cited `work-on-issue` step 2 as if its heading were "Mirror the plan's steps into the task tracker". That step's heading is "Understand the issue and the code"; the mirror rule is a paragraph inside it. The citations now name the paragraph.
- issueplan drops the trailing Rules section that repeated the body, removes duplicated attribution sentences, aligns steps 6 and 7 with fableplan, and moves the ask-first rule into the build step.
- Banned rhetoric removed from both skill bodies (stacked-contrast phrasings such as "a degradation, not an error").

## Verification

- `wc -c` on the committed files: 8,011 and 5,165 bytes.
- `bun test`: 265 pass, 0 fail. The `plan-steps-contract` and `fable-dispatch-contract` tests pin the numbered-step and verify-point instructions, the `## Implementation plan (` heading, the "Before writing any code … `work-on-issue` step 2" pointer, the `model: fable` line, the `fable-dispatch` reference, and the absence of a hardcoded `Harness: Claude Code` footer. All hold.
- No test edits.

## Plain simple English

The two planning skills were long and repeated rules that other skills own. This change removes the repeated text, fixes a wrong reference to a step heading, and keeps every step number and rule that other skills depend on. All tests pass without changes.

---
Created with LLM: Fable 5.1 | high | Harness: Claude Code

https://claude.ai/code/session_01GSRyudyeZNwuYhBaWsd2TM
