### PR TITLE
refactor(validate-issue): tighten the baseline rule and shrink the skill [C64, Fable 5.1, high]

### DIFF
--- a/skills/validate-issue/SKILL.md
+++ b/skills/validate-issue/SKILL.md
@@ -5,15 +5,21 @@ description: Use when the user asks to validate, review, or check a GitHub issue
 
 # validate-issue
 
-Validate every current-behavior claim against code. Input: a full issue URL, `#N`, `N`, or `owner/repo#N` — with none, take the newest open issue and state the number.
+Validate every current-behavior claim against code. Input: a full issue URL, `#N`, `N`, or `owner/repo#N`; with none, take the newest open issue and state its number.
 
 ### 0. Default-branch baseline
 
-No worktree for validation or issue edits. Resolve `DEFAULT=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)`; `git fetch origin "$DEFAULT"`; `git rev-list --left-right --count "origin/$DEFAULT...HEAD"`. Read working-tree files only at `0 0`, or when `git diff --name-only HEAD "origin/$DEFAULT"` excludes every inspected path; otherwise `git show "origin/$DEFAULT":<path>`. State the baseline in the verdict.
+No worktree for validation or issue edits. Resolve `DEFAULT=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)`, run `git fetch origin "$DEFAULT"`, and state `git rev-parse --short "origin/$DEFAULT"` as the baseline in the verdict. Read a working-tree path only when it is tracked and `git diff --quiet "origin/$DEFAULT" -- <path>` exits 0; otherwise read `git show "origin/$DEFAULT":<path>`.
 
 ### 1. Fetch the issue and linked PRs
 
-Fetch body and comments with `gh issue view <N> --comments`; comments omit cross-referenced PRs, so also read the paginated issue timeline API for `cross-referenced` events with `.source.issue.pull_request` set. Verify merged fixes against current code, recommend closure or reuse, and list overlapping open work under Concerns.
+Run `gh issue view <N> --comments`, then list the cross-referenced PRs that comments omit (`owner/repo#N` input names the repo):
+
+```sh
+gh api --paginate repos/{owner}/{repo}/issues/<N>/timeline --jq '.[] | select(.event=="cross-referenced") | .source.issue | select(.pull_request) | "\(.number) \(.state)"'
+```
+
+Verify a merged fix against current code and recommend closure or reuse; list open overlapping PRs under Concerns.
 
 ### 2. Extract claims and assertions
 
@@ -21,42 +27,42 @@ List each current-behavior claim (causes, citations, sets, negatives, benefit pr
 
 ### 3. Verify claims
 
-Trace each scenario through its conditions and config; when code contradicts prose, trust the code. Verify independently even for the repo owner, recent code, or runtime state machines. Apply every triggered depth rule:
+Trace each scenario through its conditions and config. When code contradicts prose, trust the code. Verify independently even for the repo owner, recent code, or runtime state machines. Apply every triggered depth rule:
 
-1. Named wrapper/helper: read its body and delegated or short-circuit paths.
+1. Named wrapper or helper: read its body and delegated or short-circuit paths.
 2. Set claim: find real call sites, establish membership, diff the claimed set.
-3. Benefit claim: prove the broken baseline still exists (code, comments, history).
-4. Conjunction/negative: split atomic assertions; prove absence on all paths.
+3. Benefit claim: prove the broken baseline exists in code, comments, or history.
+4. Conjunction or negative: split atomic assertions; prove absence on all paths.
 5. Negative over a window: trace the event-to-boundary dispatch and every producer.
 6. Superlative, method-over-set, or cited baseline: establish population, tool coverage, source history.
-7. Aggregate/dedupe/prorate/shared state: verify partition boundary and key against the scope.
-8. Missing/undocumented/unhandled surface: read surrounding content, find stale copy, diff deliverables.
+7. Aggregate, dedupe, prorate, or shared state: verify the partition boundary and key against the scope.
+8. Missing, undocumented, or unhandled surface: read surrounding content, find stale copy, diff deliverables.
 
 Evidence outranks every verdict; reconcile it across bullets and paired findings.
 
 ### 4. Mark claims
 
-Mark ✅ Verified, ❌ Refuted (name the real symbol), ⚠️ Conditional (name the config), or ❓ Unverified; cite `file:line` and retain every unresolved claim.
+Mark ✅ Verified, ❌ Refuted (name the real symbol), ⚠️ Conditional (name the config), or ❓ Unverified. Cite `file:line` and retain every unresolved claim.
 
 ### 5. Assess the proposal
 
-Lead Proposal with a ≤55-word ASD-STE100 Goal stating the outcome; a refuted premise can make the proposal unnecessary.
+Lead Proposal with a ≤55-word ASD-STE100 Goal stating the outcome. A refuted premise can make the proposal unnecessary.
 
 #### 5a. Architecture
 
-For every non-trivial proposal from step 2, read [architecture.md](architecture.md) completely; apply it after claim tracing.
+For every proposal step 2 flagged, read [architecture.md](architecture.md) completely and apply it after claim tracing.
 
 #### 5b. Self-consistency
 
-Whenever 5a runs, read [proposal-consistency.md](proposal-consistency.md) completely; apply it to the issue text.
+Whenever 5a runs, read [proposal-consistency.md](proposal-consistency.md) completely and apply it to the issue text.
 
 #### 5c. General checks
 
-Run `git log --since=7.days` on touched paths; check locking, migrations, reloads, idempotency, failure blast radius, parallel live/offline/admin paths, dual implementations, and recent-work regression. Material findings go under Concerns with `file:line`; any safety, recent-work, or parity defect requires an update.
+Run `git log --since=7.days` on touched paths. Check locking, migrations, reloads, idempotency, failure blast radius, parallel live/offline/admin paths, dual implementations, and recent-work regression. Material findings go under Concerns with `file:line`; any safety, recent-work, or parity defect requires an update.
 
 ### 6. Score complexity
 
-Read [complexity-scoring.md](complexity-scoring.md) completely on every validation; derive axes from the traced edits and tests. The canonical formula is:
+Read [complexity-scoring.md](complexity-scoring.md) completely; grade axes from the traced edit list. The canonical formula is:
 
 1. Capability maps `max(Risk, Uncertainty)` as `0–1 → 0`, `2 → 1`, `3 → 2`, `4 → 3`. If **Coupling ≥ 3**, use at least Capability 2.
 2. Volume is `(Scope + Coupling + Verification) × 2`.
@@ -71,7 +77,7 @@ Read [complexity-scoring.md](complexity-scoring.md) completely on every validati
 | 4 | 71–80 | Fable 5.1 · medium | **Yes** | Opus 5 · high |
 | 5 | 81–99 | Fable 5.1 · high | **Yes** | Opus 5 · xhigh |
 
-The fableplan signal is yes when the score is 71 or higher. The **first review** escalates on a coarser scale; rows start on band edges above.
+fableplan is yes when the score is 71 or higher. The **first review** uses the coarser table below; each row starts on a band edge.
 
 | Score | First review | Claude | Codex |
 |---|---|---|---|
@@ -80,17 +86,17 @@ The fableplan signal is yes when the score is 71 or higher. The **first review**
 | 71–80 | Opus 5 · high | `@claude opus review` | `@codex review` |
 | 81–99, or no score | Fable 5.1 · high | `@claude fable review effort:high` | `@codex review` |
 
-Blocking re-reviews step down one rung at a time, keyed to the reviewer that actually ran cycle 1, never to the score band (`skills/fix-pr-review/rereview-routing.md`).
+Blocking re-reviews step down one rung per cycle, keyed to the reviewer that actually ran cycle 1 (`skills/fix-pr-review/rereview-routing.md`).
 
 ### 7. Scope disposition
 
-A high score alone is acceptable; Split and Umbrella must pass three gates:
+A high score alone is acceptable. Split and Umbrella need all three gates:
 
-1. Each part can ship, pass tests, and deliver value in its own PR.
-2. Fold parts below C41 into the parent; at least two remaining parts must each score C41 or higher, and any folded part forces Umbrella. With fewer than two, keep one issue, emit `OK — restructure as in-body checklist`, and require an update when the body lacks it.
-3. The combined diff is roughly above 500 changed lines, parts route to different bands, or a part has money, data-integrity, or security risk.
+1. Each part ships, passes tests, and delivers value in its own PR.
+2. Fold each part below C41 into the parent; at least two parts of C41 or higher remain. A folded part forces Umbrella. With fewer than two, keep one issue, emit `OK — restructure as in-body checklist`, and require an update when the body lacks that checklist.
+3. The combined diff is roughly above 500 changed lines, parts route to different bands, or a part carries money, data-integrity, or security risk.
 
-Keep one issue when any gate fails or one root cause needs one diff. **Split** = independent parts, none folded; **Umbrella** = coordinated or folded parts; **Narrow** always available — cut to the core, move extras to a Future note. Every child needs its own scored title, problem, and acceptance criteria; scope and update decisions stay independent.
+Keep one issue when a gate fails or one root cause needs one diff. **Split** = independent parts, none folded. **Umbrella** = coordinated or folded parts. **Narrow** is always available: keep the core, move extras to a Future note. Each child needs its own scored title, problem, and acceptance criteria. Scope and update decisions stay independent.
 
 ### 8. Output the verdict
 
@@ -114,9 +120,9 @@ Scope:  # only for a disposition
 <next-step line>
 ```
 
-Yes for a material ❌/⚠️ claim, architecture/consistency gap, material concern, missing scope, or required restructure; No only when accurate, feasible, consistent, and complete.
+Yes for a material ❌/⚠️ claim, architecture or consistency gap, material concern, missing scope, or required restructure; No only when accurate, feasible, consistent, and complete.
 
-**Next-step line.** Post the first matching string verbatim; with fableplan no, drop that option and its connective (case 3: `or` moves before `"update issue"`):
+**Next-step line.** Post the first matching string verbatim. With fableplan no, drop that option and its connective; in case 3 the `or` moves before `"update issue"`:
 
 1. Split/umbrella scope: `→ Recommend "split issue" to restructure; or "update issue" to edit, "work on issue" to build as-is, "fableplan" to plan first.`
 2. Update is Yes: `→ Recommend "update issue" to apply the edits above; or "work on issue" to build as-is, "fableplan" to plan first.`
@@ -132,4 +138,4 @@ Invoke `fableplan` with the issue number; honor an explicit request even at sign
 
 ### 11. Handle "update issue"
 
-Read [issue-editing.md](issue-editing.md) completely; apply its verified title/body procedure from the checkout, no worktree.
+Read [issue-editing.md](issue-editing.md) completely and apply it from the checkout, with no worktree.

--- a/skills/validate-issue/architecture.md
+++ b/skills/validate-issue/architecture.md
@@ -1,7 +1,5 @@
 # Architecture procedure
 
-Read this file completely when the main skill links it from Architecture.
-
 ## Runtime topology
 
 Trace the hot path from its entrypoint. Identify processes, threads, containers, or requests; who spawns or dispatches them; and each lifetime. Cite the spawn or dispatch site.
@@ -23,7 +21,7 @@ For each shared or authoritative state item, require or derive:
 | Consumer contract | Inject, pull, subscribe, or explicit recompute fallback |
 | Failure policy | Miss, stale value, timeout, and error behavior |
 
-Mark the design ⚠️ when any required answer is absent and supply the code-grounded answer when possible.
+Mark the design ⚠️ when a required answer is absent, and supply the code-grounded answer when possible.
 
 ## Isolation boundaries
 
@@ -42,7 +40,7 @@ Treat every proposed site list as a set claim. Search each affected field or sym
 
 Read the complete load/apply sequence around each proposed edit. Check for an earlier normalization that pre-empts an unset guard and for a later copy/apply site that the issue omitted. An unnamed required site makes architecture ⚠️ or ❌.
 
-For aggregates or shared state, also confirm the enclosing partition boundary and key match the scope that feeds the facility.
+For aggregates or shared state, also confirm that the enclosing partition boundary and key match the scope that feeds the facility.
 
 ## Verdict
 

--- a/skills/validate-issue/complexity-scoring.md
+++ b/skills/validate-issue/complexity-scoring.md
@@ -1,6 +1,6 @@
 # Complexity scoring procedure
 
-Read this file completely on every validation. The canonical formula and routing table live only in the main skill.
+The canonical formula and both routing tables live only in the main skill.
 
 ## Build the edit list first
 
@@ -18,7 +18,7 @@ If architecture or consistency remains ⚠️ or ❌, raise Uncertainty and repo
 | Uncertainty | Fully specified | Mechanism known; shape needs discovery | Open design judgment |
 | Verification | Pure helper unit test | Several units and fixtures | Integration, parity, subprocess, or difficult state |
 
-Judgment-heavy work must raise Uncertainty or Coupling. Grade from the traced surface, then apply the step-6 formula.
+Judgment-heavy work raises Uncertainty or Coupling. Grade from the traced surface, then apply the step-6 formula.
 
 #### Golden examples (consistency checklist)
 
@@ -34,13 +34,8 @@ Judgment-heavy work must raise Uncertainty or Coupling. Grade from the traced su
 
 ## Routing details
 
-- Fable 5.1 has a high-effort ceiling and never runs at xhigh.
-- Fable is never the default builder. A Fable build requires explicit user direction.
-- Derive the first-review trigger and model from the main skill's first-review table, which owns every first-review boundary. Its scale is coarser than the band table's: each first-review row groups whole bands rather than cutting across them, and it is still a separate table, but each row must start on a band edge above, so a band change that moves an edge this table uses moves this table with it, while a band split that only adds a new edge leaves it unchanged.
-- Every reviewer above the standard trigger runs one blocking cycle only — however the main skill's first-review table or a stamped `PR review:` line selected it, at any score. Each blocking re-review steps down one rung: Fable to Opus, then to the standard reviewer, where the ladder stops; Opus to the standard reviewer for every blocking re-review. The step-down keys to the reviewer that ran cycle 1. The score band does not decide it. Neither heavy reviewer repeats, and the ladder never steps down to Sonnet.
-- In subagent mode, bands with the standard trigger inherit the session reviewer. Sonnet takes the main skill's cheapest first-review row, and it is also the cheaper non-blocking re-review in every band; it sits below the ladder floor and takes no rung.
-- A missing score routes as the highest band because its complexity is unknown. Missing means no `[C<score>]` prefix at all; a literal `[C0]` is a real score and routes on the lowest rows. Unknown holds for every stage — validate, build and review alike — so an issue with no prefix keeps the top band on all three even after the validator returns a low score.
-
-When validation produces a higher score band than the issue title, revalidate once on the higher route and replace all stale routing stamps. Never lower routing from a validator rescore, at any stage and with no carve-out: the rescore raises validate, build and review routing and never weakens one of them. Safety carve-outs for money, data integrity, security, and auto-protective logic always force the capable path when Risk was under-scored.
-
-Derive the `fableplan` signal, planner, builder, and effort from the main skill's band table.
+- Fable 5.1 never runs at xhigh; high is its ceiling. Fable is never the default builder, and a Fable build requires explicit user direction.
+- The main skill's band table owns the `fableplan` signal, planner, builder, and effort. Its first-review table owns every first-review boundary; each row starts on a band edge, so a moved band edge moves that table, and a new edge alone leaves it unchanged.
+- Re-review step-down is owned by `skills/fix-pr-review/rereview-routing.md`. In subagent mode the standard-trigger rows inherit the session reviewer, and Sonnet serves the cheapest first-review row plus every non-blocking re-review; it takes no rung on the ladder.
+- A missing score routes as the highest band at every stage: validate, build, and review. Missing means no `[C<score>]` prefix at all; a literal `[C0]` is a real score and routes on the lowest rows. An issue with no prefix keeps the top band on all three stages even after the validator returns a low score.
+- When validation produces a higher band than the issue title, revalidate once on the higher route and replace all stale routing stamps. Never lower routing from a validator rescore at any stage: the rescore raises validate, build, and review routing and weakens none of them. The safety carve-out for money, data integrity, security, and auto-protective logic forces the capable path when Risk was under-scored.

--- a/skills/validate-issue/issue-editing.md
+++ b/skills/validate-issue/issue-editing.md
@@ -1,6 +1,6 @@
 # Issue editing procedure
 
-Read this file completely when the user replies `update issue`. Run from the current checkout without a worktree. Load `github-issue-format` before editing.
+Run from the current checkout without a worktree. Load `github-issue-format` before editing.
 
 ## Verify the rewrite
 
@@ -8,7 +8,7 @@ Every verb, value, lifetime, owner, and proposed fix in the corrected text is a 
 
 ## Perform the final consistency pass
 
-Before every `gh issue edit`, read the complete assembled body. List each value or distinction repeated across sections and confirm every occurrence agrees. This pass is mandatory after edits across two or more sections or turns.
+Before every `gh issue edit`, read the complete assembled body. List each value or distinction repeated across sections and confirm that every occurrence agrees. This pass is mandatory after edits across two or more sections or turns.
 
 ## Edit the title
 
@@ -16,7 +16,7 @@ Change the title when it names the wrong behavior, component, root cause, scope,
 
 ## Edit the body
 
-Apply all validated corrections with `gh issue edit <N> --body-file <file>`. Keep the body complete. Keep the `## Plain simple English` section per `github-issue-format`: add it when the body has none, and rewrite it when the corrected Problem no longer matches it. Keep it under 55 words in ASD-STE100, after the acceptance criteria and before any Execution block. This backfill happens only on issues you already edit. Do not sweep other open issues. Preserve prior attribution lines and append the current line after one final `---` separator:
+Apply all validated corrections with `gh issue edit <N> --body-file <file>` and keep the body complete. Keep the `## Plain simple English` section per `github-issue-format`: add it when the body has none, and rewrite it when the corrected Problem no longer matches it. Keep it under 55 words in ASD-STE100, after the acceptance criteria and before any Execution block. This backfill applies only to issues you already edit; do not sweep other open issues. Preserve prior attribution lines and append the current line after one final `---` separator:
 
 ```text
 ---
@@ -25,8 +25,8 @@ Validated with LLM: <prior model> | <effort> | Harness: <harness>
 Validated with LLM: <current model> | <effort> | Harness: <harness>
 ```
 
-This edit is the output of a validation pass, so the appended verb is always `Validated`. Prior `Created` and `Updated` lines stay exactly as written. Collapse exact duplicates only. When no footer exists, append the current `Validated` line. Use the model, effort, and harness that actually produced the edit. In continuous integration, use the GitHub Action identifier from the system prompt; its absence means the session is interactive. Use the specific interactive tool, such as Claude Code, Cursor, or Codex. A repository footer rule overrides this default.
+The appended verb is always `Validated`, because this edit is the output of a validation pass. Prior `Created` and `Updated` lines stay exactly as written. Collapse exact duplicates only. When no footer exists, append the current `Validated` line. Use the model, effort, and harness that actually produced the edit: in continuous integration, the GitHub Action identifier from the system prompt; otherwise the interactive tool, such as Claude Code, Cursor, or Codex. A repository footer rule overrides this default.
 
 ## Verify the saved issue
 
-Read the issue back from GitHub. Confirm title, first complexity line, corrected sections, and final footer. Remove temporary body files and confirm local status contains no new artifact.
+Read the issue back from GitHub. Confirm the title, first complexity line, corrected sections, and final footer. Remove temporary body files and confirm that local status contains no new artifact.

--- a/skills/validate-issue/proposal-consistency.md
+++ b/skills/validate-issue/proposal-consistency.md
@@ -1,6 +1,6 @@
 # Proposal self-consistency procedure
 
-Read this file completely when the main skill links it from Self-consistency. Apply it after claim tracing and alongside Architecture.
+Apply this after claim tracing and alongside Architecture.
 
 ## Lifetime and population
 


### PR DESCRIPTION
## Summary

- Step 0 baseline: replaced the `0 0` ahead/behind check with a per-path `git diff --quiet origin/<default> -- <path>` test. The old rule read working-tree files whenever HEAD matched `origin/<default>`, so uncommitted local edits could be traced as the baseline. The new rule falls back to `git show` for any path that differs from the baseline.
- Step 1: added the exact paginated timeline command that lists cross-referenced PRs with their state (verified against issue 209 on this repo).
- Step 6: formula and both routing tables unchanged; the re-review sentence now points at `fix-pr-review/rereview-routing.md` and keeps the cycle-1 keying the contract tests require.
- `complexity-scoring.md`: the Routing details section no longer restates the step-down ladder; it keeps the Fable ceiling, missing-score rule, never-lower rescore rule, and subagent-mode reviewer inheritance.
- Removed the "read this file completely" preambles from companions (the core already says it) and tightened wording throughout. Step numbers and the 5a/5b/5c labels are unchanged, so every cross-reference from the loop skills still resolves.

## Sizes

| File | Before | After |
|---|---|---|
| SKILL.md | 7,989 | 7,996 |
| architecture.md | 3,015 | 2,944 |
| complexity-scoring.md | 4,393 | 3,440 |
| issue-editing.md | 2,645 | 2,550 |
| proposal-consistency.md | 1,978 | 1,902 |
| total | 20,020 | 18,832 |

The core stays under the 8,000-byte cap from issue 209 while carrying the new timeline command.

## Verification

- `bun test`: 265 pass, 0 fail.
- No test file was edited.

## Plain simple English

The validate skill now checks each file against the main branch before it reads it, so local uncommitted edits cannot be mistaken for the real code. It also gives the exact command to find linked pull requests. The helper files are shorter and repeat less.

---
Updated with LLM: Fable 5.1 | high | Harness: Claude Code

https://claude.ai/code/session_01NGVhz5L9HSDvETCFLvTW9T
