### PR TITLE
refactor(#208): trim fableplan under the 8,000-byte cap [C37, Fable 5.1, medium]

### DIFF
--- a/skills/fableplan/SKILL.md
+++ b/skills/fableplan/SKILL.md
@@ -57,7 +57,7 @@ Verify the plan's load-bearing claims against the codebase: the files it modifie
 
 ### 4. Post the plan to the GitHub issue (only if one was resolved in step 1)
 
-Post the checked plan before building, so it survives whatever happens to the build. Never update the comment afterwards. Build the body from the scratchpad file: a heading line `## Implementation plan (Fable 5.1)`, the plan, then the attribution footer:
+Post the checked plan before building. Never update the comment afterwards. Build the body from the scratchpad file: a heading line `## Implementation plan (Fable 5.1)`, the plan, then the attribution footer:
 
 ```
 ---


### PR DESCRIPTION
## Summary

- PR 236 did the fableplan shrink but landed at 8,011 bytes. Issue 208 requires 8,000 or under.
- Removed one redundant clause in step 4 ("so it survives whatever happens to the build"). The file is now 7,965 bytes.
- Step numbers, the wrapper-mode section, and every pointer are unchanged.

Closes #208

## Verification

- `wc -c skills/fableplan/SKILL.md`: 7,965.
- `bun test`: 265 pass, 0 fail. No test edits.

## Plain simple English

The plan skill file was 11 bytes over the size limit set in the issue. This change removes one extra clause so the file meets the limit. Nothing else changes.

---
Updated with LLM: Fable 5.1 | medium | Harness: Claude Code

https://claude.ai/code/session_01GjPS82DeMp9KLgoAzWurRw
