### PR TITLE
refactor(#206): trim sync-docs under the 8,000-byte cap [C37, Fable 5.1, high]

### DIFF
--- a/skills/sync-docs/SKILL.md
+++ b/skills/sync-docs/SKILL.md
@@ -5,23 +5,15 @@ description: Use when the user asks to sync, update, or refresh CLAUDE.md, AGENT
 
 # sync-docs
 
-Keep CLAUDE.md, AGENTS.md, SKILL.md, and README.md accurate after new commits land. Finds the last docs-sync point, classifies every commit since then, and writes targeted updates — no rewrite, no drift. Syncing is bidirectional: as well as adding what's new, **remove or correct anything the current codebase now contradicts** — stale paths, renamed symbols, removed fields, dead defaults. A doc that lies is worse than one that's merely incomplete.
+Keep CLAUDE.md, AGENTS.md, SKILL.md, and README.md accurate after new commits land: find the last docs-sync point, classify every commit since then, and write targeted edits. Syncing is bidirectional: add what is new, and **remove or correct anything the current codebase contradicts** (stale paths, renamed symbols, removed fields, dead defaults). A doc that lies is worse than one that is incomplete.
 
-Adapt to the repo you're in. The doc set below is the common shape, not a requirement — a repo may have only a README, or add its own docs. Edit the files that exist; never create a new top-level doc (AGENTS.md, CHANGELOG.md, SKILL.md) as part of a sync — if one seems warranted, surface it to the user instead.
+Adapt to the repo. Edit the docs that exist; never create a new top-level doc (AGENTS.md, CHANGELOG.md, SKILL.md) during a sync. If one seems warranted, surface it to the user.
 
-Audience split:
-- **CLAUDE.md** — agent-facing dense reference (architecture, symbol/file names, `file:line` cues). Describes **current behavior**; not a history log.
-- **AGENTS.md** *(only if the repo already has one — check `ls -l AGENTS.md` first)* — the counterpart agent doc for other tools (e.g. Codex). A repo keeps it in one of two shapes. As a symlink to CLAUDE.md it holds no content of its own, so it needs no edit. As a real file it carries the same body content (architecture, commands, conventions) with a tool-specific intro line, so every CLAUDE.md body edit gets mirrored into it — see step 5.
-- **SKILL.md** *(only if the repo has one)* — operator-facing imperative guide (config knobs, setup prompts, CLI flows).
-- **README.md** — public/newcomer-facing (setup, supported features, headline config). Lowest churn — update only when public surface changes.
-- **CHANGELOG.md** *(only if the repo already has one — check `ls CHANGELOG.md` first)* — per-issue/PR history, rationale, and migration archaeology. When present it is the home for the "why" and resolved-migration detail, so CLAUDE.md stays lean. Never create one as part of a sync.
+Audiences: **CLAUDE.md** is the dense agent reference (architecture, symbol and file names, `file:line` cues) and describes current behavior, never history. **AGENTS.md** is the counterpart for other agent tools (step 5). **SKILL.md** is operator-facing and imperative (config keys, setup, CLI flows); symbol and field names stay out of its tables. **README.md** is the newcomer entry point and changes only when the public surface changes. **CHANGELOG.md**, when present, holds per-issue rationale and migration history so CLAUDE.md stays lean.
 
 ## Preconditions
 
-```bash
-git log --oneline -5        # confirm you're on the right branch
-git status                  # must be clean before editing docs
-```
+`git log --oneline -5` to confirm the branch; `git status` must be clean.
 
 ## Steps
 
@@ -31,147 +23,67 @@ git status                  # must be clean before editing docs
 git log --oneline | grep -m1 "docs:.*sync\|docs:.*CLAUDE\|docs:.*SKILL\|sync docs"
 ```
 
-Note the SHA. If none found, ask the user for the last-known-good tag or SHA (or fall back to the initial commit for a first sync).
+If none is found, ask the user for the last-known-good tag or SHA, or use the initial commit for a first sync.
 
-### 2. Get commits since last sync
+### 2. Get commits since the baseline
 
-```bash
-git log <last-sync-sha>..HEAD --oneline
-```
-
-Exclude pure CI / workflow / chore commits (`.github/`, `scripts/`, version bumps) unless they affect agent- or operator-facing behavior.
+`git log <last-sync-sha>..HEAD --oneline`. Exclude pure CI, workflow, and chore commits unless they change agent- or operator-facing behavior.
 
 ### 3. Classify each commit
 
 | Category | Docs target | Action |
 |----------|-------------|--------|
-| New config field / flag / setting | CLAUDE.md config reference; SKILL.md settings table (if present); README.md **only if** it's a top-level/public-facing knob | Add field description + notes |
-| Changed default behavior | CLAUDE.md patterns section; SKILL.md (if present); README.md **only if** a documented default/example now contradicts the code | Update description; note old vs new |
-| New pluggable unit (plugin, command, integration, platform, strategy, theme, provider…) | CLAUDE.md structure + SKILL.md catalog (if present) + README.md feature list | Add entry to each doc that enumerates the set |
-| Bug fix (behavior change) | CLAUDE.md patterns (if pattern-level) | Update the relevant bullet |
-| New CLI command / flag | SKILL.md commands (if present); README.md Getting Started **only if** it's part of the setup/operator flow | Add usage |
-| Setup / install flow change | README.md Getting Started + SKILL.md (if operator-facing) | Update the relevant block |
-| Internal refactor / test | Skip (no docs change needed) | — |
-| New release milestone | Project memory/notes file **if one exists** (see step 9) | Append version entry |
-| Per-issue/PR history, rationale, or migration archaeology (*if CHANGELOG.md exists*) | CHANGELOG.md | Add a keyed entry there, not into CLAUDE.md; CLAUDE.md gets only the terse current-state invariant |
-| Existing doc claim contradicted by current code (stale path, renamed symbol, removed field, changed default) | Whichever doc carries the claim | Correct or delete the stale statement |
+| New config field / flag | CLAUDE.md config; SKILL.md settings table; README.md only for a public top-level knob | Add field description |
+| Changed default behavior | CLAUDE.md patterns; SKILL.md; README.md only if a documented example now contradicts the code | Update; note old vs new |
+| New pluggable unit (plugin, command, integration, provider, theme) | Every doc that enumerates the set | Add one entry per doc |
+| Bug fix (behavior change) | CLAUDE.md patterns, if pattern-level | Update the bullet |
+| New CLI command / flag | SKILL.md commands; README.md Getting Started only if part of setup | Add usage |
+| Setup / install flow change | README.md Getting Started; SKILL.md if operator-facing | Update the block |
+| Internal refactor / test | Skip | — |
+| Release milestone | Project notes file, if one exists (step 9) | Append version entry |
+| Rationale or migration history (CHANGELOG.md exists) | CHANGELOG.md | Keyed entry there; CLAUDE.md keeps only the current invariant |
+| Doc claim contradicted by code | Whichever doc carries the claim | Correct or delete it |
 
-### 4. Audit existing docs against the codebase and prune outdated content
+### 4. Audit existing docs against the code
 
-Commit-driven updates catch what changed; they miss docs that silently went stale. Before writing new content, spot-check the existing docs against the actual code:
+Commit-driven edits miss docs that went stale on their own. For each doc section near an in-scope commit, verify the surrounding claims: file paths exist, symbol names match, defaults and versions are current, CLI flags accept the documented args. Delete or correct what the code contradicts. Stay scoped to the in-scope areas; if the docs look broadly drifted, flag it instead of rewriting. When unsure, grep the code first; never remove a claim you haven't verified is wrong.
 
-- For each doc section in the area of an in-scope commit, verify the surrounding claims still hold — file paths exist, symbol names match, defaults and version numbers are current, CLI flags still accept the documented args.
-- Delete or correct any statement the codebase contradicts: removed fields, renamed symbols, dead file paths, stale defaults, deprecated flows, examples that no longer run.
-- Removing wrong content is as important as adding new content — treat a prune as a first-class edit, not an afterthought.
-- Stay scoped: audit the areas related to the in-scope commits, not the entire doc. If the docs look broadly drifted beyond that scope, flag it to the user rather than silently doing a full rewrite.
-- When unsure whether something is outdated, grep the code to confirm before deleting — never remove a claim you haven't verified is wrong.
-- **Cross-check "current/live/active/default" claims against the deciding variable, not the doc's own prior text.** Any doc that names which version/mode/config is currently in effect (a build script's target, a feature-flag default, an active-environment pointer) can go stale silently — the doc reads as self-consistent even after the underlying switch moved. Find the actual switch (grep for the assignment — `MAIN=`, `ACTIVE_*`, a default-branch config key, etc.) and confirm it still matches what the doc claims.
-- **Diff enumerable generated listings against the filesystem.** When an in-scope commit touches a directory holding a versioned or pluggable set of items (plugins, commands, integrations, themes, providers), list the actual directory entries (`ls`, `find`) and compare against every place that's supposed to enumerate them (index/chooser pages, catalog tables, README lists). A missing or orphaned entry is a silent drift the commit diff alone won't surface, because the commit that broke it may be several syncs back.
-- **Check promotion/demotion parity.** If the codebase has a "promote item to active, retire the previous one" pattern (a new default version, a new production config, a newly-active integration), verify that state encoding "this is the active one" — self-referencing URLs, indexing/discoverability directives, feature flags, config defaults — was flipped on BOTH the newly-promoted item and the newly-demoted item. A promotion is a two-sided edit; half-applied swaps (new item correct, old item still claiming to be active) are a common source of live bugs, not just doc drift, and won't show up in a diff of the promoting commit alone. If you find this pattern is real but undocumented as an explicit invariant, add a short rule for it to the project's own docs (e.g. CLAUDE.md patterns) so future promotions don't repeat the same half-applied swap.
+- **Check "current/active/default" claims against the deciding switch** (a build script's target, a feature-flag default, an active-environment key), never against the doc's own prior text.
+- **Diff enumerated listings against the filesystem.** When a commit touches a directory of pluggable items, `ls` it and compare with every catalog, index, and README list that enumerates it.
+- **Check promotion parity.** When an item is promoted to active and another is retired, confirm the "this is active" state (self-referencing URLs, indexing directives, flags, defaults) flipped on both. If this invariant is real but undocumented, add a short rule to the project's docs.
 
-### 5. Edit CLAUDE.md
+### 5. Edit CLAUDE.md, then mirror into AGENTS.md
 
-- Stay surgical: edit only the sections that changed.
-- Add new fields to the appropriate config or patterns section.
-- Keep bullets concise — CLAUDE.md is dense reference, not narrative.
-- Update any config/schema version constant the project maintains if a migration bumped it.
-- If a new opt-in field was added and the repo has a SKILL.md, add it to the relevant operator table there (see step 6).
-- **Mirror into AGENTS.md if it exists.** Run `ls -l AGENTS.md` and branch on what it is.
-  - **A symlink to CLAUDE.md** (this repo's shape): skip it. The CLAUDE.md edits you just made are already the AGENTS.md content. Never open AGENTS.md for writing here — the write resolves through the link and edits CLAUDE.md, so a tool-specific intro line would land in the canonical file.
-  - **A real file**: apply every body edit you just made to CLAUDE.md to AGENTS.md verbatim (architecture, commands, conventions, schema — same content). The only thing that differs is the intro/header line, which stays tool-specific — do not overwrite it with CLAUDE.md's Claude-facing line. Also audit AGENTS.md for the same staleness patterns as step 4: it drifts silently because commit-driven edits target CLAUDE.md by name.
-  - **Absent**: skip it — never create one during a sync.
+Edit only the sections that changed; keep bullets terse and one behavioral change per bullet. Update any schema or config version constant a migration bumped. Translate PR descriptions into imperative phrases; never paste them. Then run `ls -l AGENTS.md`:
+
+- **Symlink to CLAUDE.md**: skip it. Never open it for writing; the write resolves to CLAUDE.md and a tool-specific intro would land in the canonical file.
+- **Real file**: apply every CLAUDE.md body edit to it verbatim, keep its own intro line, and audit it for the step 4 staleness patterns.
+- **Absent**: skip it.
 
 ### 6. Edit SKILL.md (only if the repo has one)
 
-Keep SKILL.md operator-facing and imperative; avoid code internals. Common targets, depending on what the repo's SKILL.md documents:
-- **Settings / configuration table** — add new global or per-unit keys.
-- **Post-update / upgrade reference** — add the change as a default, opt-in, or auto-migration row so operators get prompted on upgrade.
-- **Commands / reconfiguration section** — if a CLI surface or reload scope changed.
-- **Operator safety controls** — if guard/circuit-breaker/limit behavior changed.
+Add new keys to the settings table and the upgrade or post-update reference so operators get prompted; update commands, reload scope, and safety-control sections when those surfaces change.
 
-### 7. Edit README.md (only if public surface changed)
+### 7. Edit README.md (only if the public surface changed)
 
-README is the entry point for newcomers and the public face of the project. Default to **no edit** — only touch when one of these is true:
-
-- **New supported feature/platform/integration** → add to the relevant feature or catalog section.
-- **New public-facing unit** (plugin, command, provider, theme) → add to the list that enumerates them, one line each, matching the existing format.
-- **New top-level CLI subcommand** that users run by hand → add to the appropriate Getting Started block or a dedicated section.
-- **Setup / install / build flow change** → update the relevant setup block.
-- **Public-facing config knob change** that contradicts a documented example → update the affected config sub-block only.
-
-Skip README for: bug fixes, internal refactors, parameter tweaks, symbol renames, schema migrations (those go in SKILL.md if present), and cosmetic changes.
-
-When editing:
-- Keep the tone tutorial-clean — no `file:line` cues, no code internals, no PR numbers in body text (PR numbers only in changelog-style sections that already use them).
-- Don't grow lists into prose — each item gets one line / one bullet matching the existing format.
-- If a section already has version/PR references, follow the same convention; otherwise omit them.
+Default to no edit. Touch it only for a new supported feature or integration, a new public unit in an enumerated list, a new top-level CLI subcommand, a setup or install change, or a public config example the code now contradicts. Skip bug fixes, refactors, renames, and migrations. Keep the tutorial tone: no `file:line` cues, code internals, or PR numbers in body text; one line per list item in the existing format. New public units are the README edit most often missed, so always check its enumerated lists.
 
 ### 8. Check CLAUDE.md size and condense if oversized
 
-Claude Code warns when CLAUDE.md exceeds 40k chars ("Large CLAUDE.md will impact performance"). Run after step 5:
+Run `wc -c CLAUDE.md`. Above **35000** bytes, condense in place to under **30000** before finishing. Never split it into multiple files; agents auto-load only the root CLAUDE.md.
 
-```bash
-wc -c CLAUDE.md
-```
+Keep symbol and file names, field lists, enum values, defaults, version numbers, non-obvious gotchas, concurrency and ordering rules, and live behavior. Drop "why" prose where the rule alone is actionable, shipped-migration narrative, resolved-incident stories, duplicate statements, and examples that restate a terse rule. If a CHANGELOG.md exists, move history there keyed by issue or PR instead of deleting it. Never trim the Environment, Setup, Build & Deploy, or Testing blocks, lookup tables of IDs, paths, or prefixes, concurrency-hazard rules, or a format convention the repo defines.
 
-If the byte count exceeds **35000**, condense in-place before finishing the sync. Target: bring the file back under 30000 chars (leaves headroom for the next sync). Do NOT split into multiple files — agents only auto-load the root CLAUDE.md.
+Re-run `wc -c` and report old and new byte counts. If the file is still over 40000 bytes, list the largest sections and ask the user which to cut.
 
-**If a CHANGELOG.md exists, relocate rather than delete.** Before dropping completed-migration prose, resolved-incident narrative, or per-issue "why" detail (passes 2 and 5 below), move it into CHANGELOG.md keyed by issue/PR instead of discarding it — the history stays available without loading into agent context every turn. Only outright-delete history when the repo has no CHANGELOG.md to receive it. Never create a CHANGELOG.md solely to offload bytes during a sync; if CLAUDE.md is oversized and no CHANGELOG.md exists, surface that to the user as an option rather than introducing the file unilaterally.
+### 9. Update the project notes file if one exists
 
-**Condensation rules — preserve agent-critical signal, drop narrative:**
-
-| Keep | Trim / drop |
-|------|-------------|
-| Symbol / file names and `file:line` cues | Prose explaining *why* a pattern exists when the rule alone is actionable |
-| Field-name lists, enum values, default values, version numbers (thresholds, timeouts, schema versions) | Historical migration notes once the migration has shipped and stabilized (>2 versions old) |
-| Non-obvious gotchas, race conditions, lock order, ordering constraints | Restated information that's already in another bullet |
-| Active "new X requires Y" instructions | Examples that duplicate a rule already stated tersely |
-| Currently-live behavior | Deprecated behavior, legacy field aliases that no caller uses |
-
-**Mechanical passes — apply in order, stop when under target:**
-
-1. **Collapse duplicated phrasing** — same fact stated twice in different bullets → merge into one bullet.
-2. **Drop completed-migration prose** — if a migration is ≥2 versions behind the current schema/config version AND the legacy field is no longer read, delete the migration narrative; keep the field rename only if code still references the old name.
-3. **Compress example-laden bullets** — `e.g.` lists with 3+ items → keep the first 1–2 + `…` if the pattern is obvious.
-4. **Inline single-line sub-bullets** — `- foo:\n  - bar` where bar is one short clause → `- foo: bar`.
-5. **Remove resolved-incident narrative** — "fixed because X happened in prod" becomes "X — see <symbol>" or is dropped if the rule stands on its own.
-6. **Shorten reference-table cells** — multi-clause descriptions → one clause + symbol name; agents resolve details from code.
-
-**Forbidden — never trim these even if oversized:**
-- The `## Environment`, `## Setup`, `## Build & Deploy`, `## Testing` blocks (operator-load-bearing).
-- Lookup tables — lists of IDs, type names, prefixes, file paths (losing one row corrupts dispatch).
-- Concurrency-hazard rules (state-locking, lock-order, skip-reason/live-exec guards).
-- Any PR/commit footer or format convention the repo's own CLAUDE.md defines.
-
-After condensing, re-run `wc -c CLAUDE.md` and report old → new byte counts. If still over 40k after all six passes, surface to the user with a list of the largest sections and ask which to cut further — don't unilaterally remove load-bearing content.
-
-### 9. Update the project memory/notes file if one exists
-
-Some repos keep a running notes or memory file (e.g. `MEMORY.md`, `NOTES.md`, `docs/CHANGELOG`-style log) with a Releases section. If one exists **and** the in-scope commits include a version tag or release PR, append:
-
-```
-- **vX.Y.Z** — YYYY-MM-DD: <one-line summary> (PRs #N, #M)
-```
-
-Only append if such a file already exists — never create one during a sync.
+If the repo keeps a notes or memory file with a Releases section and the in-scope commits include a version tag or release PR, append `- **vX.Y.Z** — YYYY-MM-DD: <summary> (PRs #N, #M)`.
 
 ## Red Flags — STOP
 
 | Situation | Action |
 |-----------|--------|
-| `git status` is dirty before you start | Stash or commit pending work first |
-| Commit touches multiple unrelated areas | Split classification carefully; don't conflate |
-| A field was *removed* | Delete the row/bullet — don't leave stale docs |
-| Behavior reversal (bug was fixed back to original) | Note the revert explicitly, don't just silently restore |
-| A sync seems to warrant a brand-new top-level doc (AGENTS.md, CHANGELOG.md, SKILL.md) | Surface it to the user — never create one as part of a sync |
-
-## Common Mistakes
-
-- **Over-documenting internals** — CLAUDE.md is for agent-relevant patterns; SKILL.md is for operators. Symbol/field names belong in CLAUDE.md, not SKILL.md operator tables.
-- **Under-documenting opt-in fields** — when the repo has a SKILL.md, every new opt-in field needs a row in its settings table and its upgrade reference so operators get prompted on upgrade.
-- **Copying PR descriptions verbatim** — translate to concise imperative phrases the reader can act on.
-- **Bundling multiple unrelated changes into one bullet** — one bullet per behavioral change.
-- **Treating README like CLAUDE.md** — don't dump code internals, symbol names, or PR-by-PR changelog entries into README. If a change doesn't affect what a newcomer needs to install/run/configure, it doesn't belong there.
-- **Forgetting README on new public units** — new features/plugins/integrations are the highest-signal README updates and the easiest to miss because CLAUDE.md and SKILL.md updates feel "complete." Always check the enumerated lists.
-- **Trusting a doc's own history instead of re-deriving current state from code** — a "currently active" claim is only correct as of when it was written. Always re-check it against the actual deciding switch (config default, build-script variable, feature flag) rather than assuming a prior sync got it right.
-- **Creating a new top-level doc during a sync** — AGENTS.md, CHANGELOG.md, and SKILL.md are only edited when they already exist; introducing one is a user decision, not a sync side effect.
+| Commit touches multiple unrelated areas | Classify each area separately |
+| A field was removed | Delete the row or bullet |
+| Behavior reversal (fix reverted to original) | Note the revert explicitly |


### PR DESCRIPTION
Closes #206

## Summary

- `skills/sync-docs/SKILL.md` goes from 16,851 bytes to 7,327 bytes.
- Kept: baseline detection, the classify table (one line per category), the prune-against-code checks (deciding-switch, enumerated listings, promotion parity), AGENTS.md mirroring by shape, the CLAUDE.md byte cap (35,000 trip, 30,000 target, 40,000 escalation), and the ban on creating AGENTS.md, CHANGELOG.md, or SKILL.md during a sync.
- The six-pass condensation playbook is replaced by one paragraph that lists what to keep, what to drop, where history relocates when a CHANGELOG.md exists, and what is never trimmed.
- Red Flags rows and Common Mistakes bullets that repeated a step are removed. The two unique rules from Common Mistakes (translate PR descriptions into imperative phrases; check README enumerated lists for new public units) moved into steps 5 and 7. Each remaining rule now appears once.

## Verification

- `wc -c skills/sync-docs/SKILL.md` reports 7,327.
- `bun test`: 265 pass, 0 fail.
- Test edits: none. `tests/sync-docs-release-contract.test.js` passes unchanged.
- Plan: none on the issue. Deviations: none.

## Plain simple English

The docs-sync skill was twice the size it needed to be. It taught a long condensation procedure and then repeated its own warnings. This change keeps every unique step and the size limit, and removes the repeated text. The skill is now under the 8,000-byte target and the tests still pass.

---
Created with LLM: Fable 5.1 | high | Harness: Claude Code

https://claude.ai/code/session_01BGE5gfXK27J9jce4PM2aSK
