### PR TITLE
chore: remove remaining source comment [C5, Sonnet 5, high]

### DIFF
--- a/templates/claude-workflow/scripts/test_patch_claude_comment.py
+++ b/templates/claude-workflow/scripts/test_patch_claude_comment.py
@@ -56,10 +56,6 @@ COMMENTS_PAGE = [
 ]
 
 FAKE_GH = """#!/usr/bin/env bash
-# Fake gh for tests: a --paginate fetch prints the canned comments page; a
-# --method call (PATCH/POST) records its argv (one arg per line) and prints
-# nothing; a bare `gh api repos/.../issues/comments/<id>` GET (the
-# TARGET_COMMENT_ID path) prints the canned single comment.
 set -euo pipefail
 if printf '%s\\n' "$@" | grep -q -- '--paginate'; then
   cat "$GH_STUB_COMMENTS"


### PR DESCRIPTION
## Summary
- Removes the four-line explanatory comment block above `FAKE_GH` in the test fixture, the only non-shebang comment left in the repo's code files.
- Leaves the two required shebang lines (`install.sh`, `patch_claude_comment.sh`) in place; those are interpreter directives, not comments.

## Verification
- Ran the 13 existing tests in `test_patch_claude_comment.py` (unittest): all pass, unchanged behavior.

## Plain simple English
This change removes a text comment from a test file. It does not change what the code does. All tests still pass.

---
Created with LLM: Sonnet 5 | high | Harness: Claude Code
https://claude.ai/code/session_012k1PhjGg941skwPYdEJtTE