### PR TITLE
fix(installer): skip already-symlinked skills and workflows [C33, Sonnet 5, high]

### DIFF
--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, renameSync, rmSync } from 'node:fs';
+import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, readlinkSync, renameSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -33,8 +33,16 @@ const agentsDir = join(claudeDir, 'agents');
 const workflowsDir = join(claudeDir, 'workflows');
 
 mkdirSync(skillsDir, { recursive: true });
+const linkedSkills = [];
 for (const name of skills) {
-	cpSync(join(skillsSrc, name), join(skillsDir, name), { recursive: true });
+	const src = join(skillsSrc, name);
+	const dest = join(skillsDir, name);
+	const destStat = lstatSync(dest, { throwIfNoEntry: false });
+	if (destStat?.isSymbolicLink() && resolve(dirname(dest), readlinkSync(dest)) === src) {
+		linkedSkills.push(name);
+		continue;
+	}
+	cpSync(src, dest, { recursive: true });
 }
 
 const retiredSkills = ['pr-review-format'].filter((name) => !skills.includes(name));
@@ -65,17 +73,30 @@ for (const name of removedAgents) {
 const workflows = existsSync(workflowsSrc)
 	? readdirSync(workflowsSrc).filter((name) => name.endsWith('.js')).sort()
 	: [];
+const linkedWorkflows = [];
 if (workflows.length > 0) {
 	mkdirSync(workflowsDir, { recursive: true });
 	for (const name of workflows) {
-		cpSync(join(workflowsSrc, name), join(workflowsDir, name));
+		const src = join(workflowsSrc, name);
+		const dest = join(workflowsDir, name);
+		const destStat = lstatSync(dest, { throwIfNoEntry: false });
+		if (destStat?.isSymbolicLink() && resolve(dirname(dest), readlinkSync(dest)) === src) {
+			linkedWorkflows.push(name);
+			continue;
+		}
+		cpSync(src, dest);
 	}
 }
 
+const copiedSkills = skills.filter((name) => !linkedSkills.includes(name));
 const scope = project ? 'this project' : 'your personal skills';
-console.log(`rk-skills installed ${skills.length} skills into ${scope}:`);
+console.log(`rk-skills installed ${copiedSkills.length} skills into ${scope}:`);
 console.log(`  ${skillsDir}`);
-console.log(`  ${skills.join(', ')}`);
+console.log(`  ${copiedSkills.join(', ') || '(none)'}`);
+if (linkedSkills.length > 0) {
+	console.log(`\nLeft ${linkedSkills.length} skills as-is (already symlinked to this checkout):`);
+	console.log(`  ${linkedSkills.join(', ')}`);
+}
 if (removedSkills.length > 0) {
 	console.log(`\nRemoved ${removedSkills.length} renamed skill symlinks from:`);
 	console.log(`  ${skillsDir}`);
@@ -94,9 +115,14 @@ if (removedAgents.length > 0) {
 	console.log(`  ${agentsDir}`);
 	console.log(`  ${removedAgents.map((n) => n.replace(/\.md$/, '')).join(', ')}`);
 }
-if (workflows.length > 0) {
-	console.log(`\nAlso installed ${workflows.length} workflow scripts into:`);
+const copiedWorkflows = workflows.filter((name) => !linkedWorkflows.includes(name));
+if (copiedWorkflows.length > 0) {
+	console.log(`\nAlso installed ${copiedWorkflows.length} workflow scripts into:`);
 	console.log(`  ${workflowsDir}`);
-	console.log(`  ${workflows.map((n) => n.replace(/\.js$/, '')).join(', ')}`);
+	console.log(`  ${copiedWorkflows.map((n) => n.replace(/\.js$/, '')).join(', ')}`);
+}
+if (linkedWorkflows.length > 0) {
+	console.log(`\nLeft ${linkedWorkflows.length} workflows as-is (already symlinked to this checkout):`);
+	console.log(`  ${linkedWorkflows.map((n) => n.replace(/\.js$/, '')).join(', ')}`);
 }
 console.log('\nRestart Claude Code (or start a new session), then invoke any skill by name, e.g.\n  /fableplan <task to plan>');

--- a/tests/install.test.js
+++ b/tests/install.test.js
@@ -204,6 +204,23 @@ describe('install.sh Codex links', () => {
   })
 })
 
+describe('bin/install.mjs symlinked source', () => {
+  test('skips a skill already symlinked to its own source instead of crashing', () => {
+    const project = makeTempDir('rk-skills-selflink-')
+    mkdirSync(join(project, '.claude/skills'), { recursive: true })
+    const skill = shippedSkills[0]
+    symlinkSync(join(repoRoot, 'skills', skill), join(project, '.claude/skills', skill))
+
+    const run = runMjs(project)
+
+    expect(run.exitCode, run.stderr.toString()).toBe(0)
+    const target = join(project, '.claude/skills', skill)
+    expect(lstatSync(target).isSymbolicLink()).toBe(true)
+    expect(readlinkSync(target)).toBe(join(repoRoot, 'skills', skill))
+    expect(run.stdout.toString()).toContain('already symlinked to this checkout')
+  })
+})
+
 describe('retired skill cleanup', () => {
   test('bin/install.mjs retires a leftover retired skill from the destination', () => {
     for (const asSymlink of [false, true]) {


### PR DESCRIPTION
## Summary

- `bin/install.mjs` crashed with `ERR_FS_CP_EINVAL` / `ERR_FS_CP_DIR_TO_NON_DIR` whenever a target under `~/.claude/skills` or `~/.claude/workflows` was already a symlink pointing at the matching source in this checkout (the standing dev setup for live-editing skills).
- The installer now detects a target already symlinked to its exact source and leaves it in place instead of copying, reporting it under a new "Left N skills/workflows as-is (already symlinked to this checkout)" line.
- The top summary line ("installed N skills") now counts only skills actually copied, so it no longer claims to install skills it skipped.

## Verification

- Added `bin/install.mjs symlinked source` test in `tests/install.test.js`, seeding a self-referencing symlink and asserting the installer exits 0 and leaves it untouched. Confirmed this test fails against the pre-fix script (same crash) and passes with the fix.
- `bun test`: 312 pass, 0 fail.
- Manually ran `node bin/install.mjs` against the real `~/.claude` (which has ~37 skills and 1 workflow symlinked to this repo): completed cleanly, correctly reported 0 copied / 37 skills and 1 workflow left as-is.

## Plain simple English

The install script failed when a skill link already pointed back to this project folder. This is normal for a developer setup. The script now sees this case and skips the copy, so it no longer crashes and gives an accurate summary.

---
Created with LLM: Sonnet 5 | high | Harness: Claude Code