### PR TITLE
docs(#276): bring prd-to-issues up to date and shrink it [C6, Fable 5.1, low]

### DIFF
--- a/skills/prd-to-issues/SKILL.md
+++ b/skills/prd-to-issues/SKILL.md
@@ -5,33 +5,31 @@ description: Use when the user wants a finished PRD broken into GitHub milestone
 
 # prd-to-issues
 
-Break a refined PRD into milestones and fully-specified GitHub issues that cold agents can implement one at a time. Every issue must be self-sufficient: an agent holding only the issue body and the PRD can build it correctly.
+Break a refined PRD into milestones and fully specified GitHub issues that cold agents implement one at a time. An agent holding only the issue body and the PRD must be able to build it correctly.
 
-**Load the `github-issue-format` skill before filing anything — mandatory.**
+**Load the `github-issue-format` skill before filing anything (mandatory).**
 
 ## Steps
 
 ### 1. Plan the breakdown (present before filing)
 
-- Derive **milestones** from dependency structure, not feature themes. Typical shape: `v0 — Foundation & core <surface>` (scaffold, schema, auth, core domain flows, payments happy path), `v1 — Lifecycle & delivery` (jobs, schedulers, notifications, end-of-life), `v2 — <second surface> parity`, `v3 — Post-MVP`.
-- Aim for **15–25 issues** total; each independently implementable and PR-sized.
-- Identify the **dependency spine** (issues everything else needs, built serially) vs **parallel waves** (dependency-free islands). For each planned issue, record its direct hard prerequisites separately from ordering-only predecessors. Name the risk concentrators — usually the schema and the money/pricing module.
-- Show the user the plan (titles, milestones, order) in chat before filing. Adjust on feedback.
+- Derive **milestones** from dependency structure, never from feature themes. Typical shape: `v0` foundation and core surface (scaffold, schema, auth, core flows, payments happy path), `v1` lifecycle and delivery (jobs, schedulers, notifications), `v2` second-surface parity, `v3` post-MVP.
+- Aim for **15–25 issues**, each independently implementable and PR-sized.
+- Separate the **dependency spine** (built serially) from **parallel waves**. For each issue record its direct hard prerequisites apart from ordering-only predecessors. Name the risk concentrators, usually the schema and the money module.
+- Show the plan (titles, milestones, order) in chat before filing and adjust on feedback.
 
 ### 2. Create milestones
 
-`gh api repos/<owner>/<repo>/milestones -f title='...' -f description='...'` — one per phase, descriptions listing the member issues' themes.
+`gh api repos/<owner>/<repo>/milestones -f title='...' -f description='...'`, one per phase, the description listing the member issues' themes.
 
 ### 3. Write the issues
 
-Per `github-issue-format`: `[C<score>]` plain-language title, complexity rationale first line, then **Problem** (with PRD § references), **Goal**, **Approach**, **Acceptance criteria**, **`## Plain simple English`** (mandatory, under 55 words, ASD-STE100), attribution footer. The step 4 Execution block is appended between that last section and the footer.
+Per `github-issue-format`: `[C<score>]` plain-language title, complexity rationale first line, then **Problem** (with PRD § references), **Goal**, **Approach**, **Acceptance criteria**, **`## Plain simple English`** (mandatory, under 55 words, ASD-STE100), the step 4 Execution block, then the attribution footer.
 
-Issue-quality rules learned the hard way:
-
-- Cite PRD section numbers everywhere — they're the cold agent's index.
-- Acceptance criteria are testable behaviors, including the negative ones ("no endpoint can return a signed URL for sealed media, for any role").
-- Money, privacy, and irreversible-deletion issues get their invariants stated as acceptance criteria, not prose.
-- Pure logic (pricing engines) gets the PRD's worked examples embedded as required test cases.
+- Cite PRD section numbers everywhere; they are the cold agent's index.
+- Acceptance criteria are testable behaviors, including negative ones ("no endpoint can return a signed URL for sealed media, for any role").
+- Money, privacy, and irreversible-deletion invariants go in the acceptance criteria.
+- Pure logic (pricing engines) embeds the PRD's worked examples as required test cases.
 - File via one batch script (heredoc bodies, `gh issue create --milestone`), sequentially so numbering is stable.
 
 ### 4. Stamp Execution blocks
@@ -43,21 +41,20 @@ Append to every issue body, before the footer:
 - **Depends on:** #<n>[, #<n>…] | none
 - **Runs after:** #<n>[, #<n>…] | none
 - **Build model:** <Fable 5.1 | Opus 5 | ... | <Name> (Codex CLI[, <model-id>]) | <Name> (Cursor CLI[, <model-id>])>
-- **Effort:** <low (Fable-only, discretionary — below the formula floor) | medium (Fable-only) | high | xhigh | max (Codex CLI-only)>
-- **fableplan first:** <Yes — Fable 5.1 plans, plan posted to this issue, builder implements against it | No>
+- **Effort:** <low (Fable-only, discretionary, below the formula floor) | medium (Fable-only) | high | xhigh | max (Codex CLI-only)>
+- **fableplan first:** <Yes (Fable 5.1 plans, plan posted to this issue, builder implements against it) | No>
 - **PR review:** standard `@claude` review trigger
-- **Validate effort:** <low | medium | high | xhigh>   (optional — omit to use the band default)
-- **Plan effort:** <low | medium | high>   (optional — omit to plan at high; only read when fableplan first is Yes)
+- **Validate effort:** <low | medium | high | xhigh>   (optional; omit for the band default)
+- **Plan effort:** <low | medium | high>   (optional; omit to plan at high; read only when fableplan first is Yes)
 ```
 
-Ordering-field rules:
+Ordering fields, stamped from the approved spine/wave graph once final numbers are known:
 
-- Stamp both fields from the approved spine/wave graph after final issue numbers are known. Record direct predecessor edges only, use comma-separated issue numbers, and write `none` when there is no edge of that kind.
-- **Depends on** means the issue needs the predecessor's code or product result to be correct; for example, an API issue that requires a schema introduced by another issue.
-- **Runs after** means the issues must not overlap but the later issue does not need the earlier issue's code; for example, two otherwise-independent issues editing the same package.
-- A same-package exclusion is `Runs after`, not `Depends on`. If an edge is genuinely hard, record it only in `Depends on`; never list one predecessor in both fields.
+- Record direct predecessor edges only, comma-separated; write `none` when there is no edge of that kind.
+- **Depends on**: the issue needs the predecessor's code or product result (an API issue that needs another issue's schema).
+- **Runs after**: the issues must not overlap but the later one needs none of the earlier one's code (two independent issues editing the same package). A same-package exclusion is always `Runs after`. Never list one predecessor in both fields.
 
-Assignment — **derive from the complexity score band**. Load the canonical formula and band table from `validate-issue` step 6, score each issue there, then stamp Execution from that band:
+Routing fields derive from the complexity score band. Score each issue with the `validate-issue` step 6 formula and stamp from that band:
 
 | Band | Score band | Build model | fableplan first | Effort |
 |---|---|---|---|---|
@@ -68,28 +65,24 @@ Assignment — **derive from the complexity score band**. Load the canonical for
 | 4 | 71–80 | Opus 5 | **Yes** | xhigh |
 | 5 | 81–99 | Opus 5 | **Yes** | xhigh |
 
-**Never stamp Fable 5.1 as the Build model** — no band defaults to a Fable build, and this skill never assigns one; a Fable build exists only when the user explicitly directs it on a specific issue.
-
-**Never stamp an external CLI harness as the Build model** — no band defaults to a Codex CLI or Cursor CLI build, and this skill never assigns one. A CLI build exists only when the user directs it on a specific issue; `execution-plan-review` writes the form `<Name> (Codex CLI)` or `<Name> (Cursor CLI)`, with an optional model id after a comma inside the parenthetical, and the `cli-dispatch` skill owns how the pipeline reaches that CLI.
-
-Axes already encode the old parallel heuristics (money/security → high Risk; design-heavy → high Uncertainty; mechanical grind → high Scope/Volume at Capability 0). Do **not** override the band with a separate signal table unless a safety carve-out is explicit in the PRD and Risk was under-scored — then raise Risk and re-score, don't bypass the formula.
-
-- **fableplan first: Yes** means score ≥ 71 (bands 4–5): a Fable 5.1 plan is posted before the build; the builder is Opus 5 at xhigh in both plan bands. Never below 71.
-- **Validate model is derived from the score and never stamped**: the `validate-issue` step 6 band table owns the Validate mapping, and a missing `[C..]` prefix is unknown, not small, so it routes as band 5. Never add a `Validate model:` line — nothing reads it. **Validate effort defaults to the band value and is stampable per issue** through the optional `Validate effort:` line; this skill omits the line at filing time so the band default applies, and `execution-plan-review` adds it when the user wants a different tier. A stamped tier on a Fable validate (bands 4–5) runs as stamped, `xhigh` included; a stamped `low` or `medium` on an Opus validate (bands 0–3) is raised to `high`, because those tiers are Fable-only.
-- **Plan effort** (the fableplan stage): defaults to **high** and is stampable per issue through the optional `Plan effort:` line, read only when `fableplan first` is Yes. This skill omits the line at filing time; `execution-plan-review` adds it when the user wants the plan at `low` or `medium`. The planner is always Fable 5.1; a stamped `xhigh` runs at `xhigh`, since the stamp is the user's explicit choice (the LLM Attribution Footer section of CLAUDE.md owns this rule).
-- Effort floor is **medium** — never low, and medium is Fable-only: **Opus/Sonnet builds run at high or xhigh, never medium or low.** Fable builds may drop one tier further to **low**, a discretionary Fable-only tier below the formula's own floor, for a band-5 issue (score 81+) judged lighter than its Volume warrants. **Fable 5.1 defaults to high on every stage (build, plan, validate, review, or fix); never assign it xhigh unless the user asks for it, and the LLM Attribution Footer section of CLAUDE.md owns this rule.** When unsure between two tiers, take the higher (best-solution rule) — on Fable, stay at high unless the user asked for xhigh.
-- PR review: the pipeline derives the first-review trigger from the score on the first-review scale, which is coarser than the build bands above and is owned by the `validate-issue` step 6 first-review table — load that table for the rows and triggers; this file states no first-review boundary of its own. Every reviewer above the standard trigger is first-review-only, and each blocking re-review steps down one rung: a fable cycle 1 posts `@claude opus review effort:high` then `@claude review`, and an opus cycle 1 posts `@claude review` for every blocking re-review. Both ladders stop at `@claude review` rather than dropping to sonnet. Stamp an explicit `@claude <model> review effort:<tier>` line only to override that default, and only with a model the Action admits — `sonnet`, `opus` or `fable`. `claude.yml` resolves no other shorthand, and it reads an unresolved one as the route keyword, which sends the "review" to its write-capable fix-pr job. Stamp `sonnet` where you mean the cheapest reviewer; never stamp `haiku`.
-- Scores filed before the band-encoding change are **not comparable** — re-score if routing matters.
+- **Never stamp Fable 5.1 as the Build model.** No band defaults to a Fable build; one exists only when the user directs it on a specific issue.
+- **Never stamp an external CLI harness as the Build model.** `execution-plan-review` writes `<Name> (Codex CLI)` or `<Name> (Cursor CLI)` (optional model id after a comma) on the user's instruction, and `cli-dispatch` owns how the pipeline reaches that CLI.
+- The axes already encode the old heuristics (money/security raises Risk; design-heavy raises Uncertainty; mechanical grind raises Scope/Volume at Capability 0). Never override the band with a separate signal table; if the PRD states a safety carve-out and Risk was under-scored, raise Risk and re-score.
+- **fableplan first: Yes** means score 71 or higher (bands 4–5). Never below 71.
+- **Validate model** is derived from the score by the `validate-issue` step 6 band table and is never stamped; a missing `[C..]` prefix routes as band 5. **Validate effort** and **Plan effort** default to the band value and `high`; this skill omits both lines at filing time, and `execution-plan-review` adds them and owns the clamp rules (an Opus validate stamped `low` or `medium` runs at `high`).
+- Effort floor is **medium** and medium is Fable-only: Opus and Sonnet builds run at high or xhigh. A Fable build may drop to **low** only on a band-5 issue judged lighter than its Volume warrants. Fable 5.1 defaults to high on every stage and runs at xhigh only when the user asks for it or stamps it (the LLM Attribution Footer section of CLAUDE.md owns this rule). When unsure between two tiers, take the higher.
+- **PR review**: the pipeline derives the first-review trigger from the `validate-issue` step 6 first-review table; this file states no boundary of its own. `skills/fix-pr-review/rereview-routing.md` owns the blocking re-review step-down ladder and the shorthand `claude.yml` resolves (`sonnet`, `opus`, `fable`; never stamp `haiku`). Stamp an explicit `@claude <model> review effort:<tier>` line only to override the default.
+- Scores filed before the band-encoding change are not comparable; re-score if routing matters.
 
 ### 5. Report
 
-A compact table: issue number, `C`, title. Note the spine/waves ordering and which issues concentrate risk.
+A compact table: issue number, `C`, title. Note the spine/wave ordering and which issues concentrate risk.
 
 ## Failure modes
 
 | Situation | Do this |
 |---|---|
-| An issue can't be specced without a decision the PRD doesn't make | Stop; run `prd-questions` for it first — never file a stub |
-| Two issues want to touch the same module in the same wave | In the later issue's `Runs after`, list the earlier issue, or merge them if they are not independently implementable |
-| A milestone exceeds ~12 issues | Split it; workflow waves get unwieldy past that |
-| Tempted to skip Execution blocks "for now" | Don't — cold agents need them; that's the point |
+| An issue cannot be specced without a decision the PRD does not make | Stop; run `prd-questions` for it first. Never file a stub |
+| Two issues touch the same module in the same wave | List the earlier issue in the later issue's `Runs after`, or merge them if they are not independently implementable |
+| A milestone exceeds about 12 issues | Split it; workflow waves get unwieldy past that |
+| Tempted to skip Execution blocks "for now" | Never; cold agents need them |


### PR DESCRIPTION
Closes #276

## Summary
- `skills/prd-to-issues/SKILL.md` goes from 9830 bytes to 7202 bytes (`wc -c`, measured before and after; the issue quoted 9758 from an earlier main).
- Removed text that restates rules owned by other files: the validate-effort clamp (`execution-plan-review`), the blocking re-review ladder and `claude.yml` shorthand resolution (`fix-pr-review/rereview-routing.md`), and the first-review scale (`validate-issue` step 6). Each now links to its owner.
- Updated the Fable 5.1 effort claim to match CLAUDE.md: Fable runs at xhigh when the user asks for it or stamps it.
- Compressed prose to single-line rules; the Execution block template, band table, and every field a test checks are unchanged.

## Verification
- `bun test`: 314 pass, 0 fail.
- No test edited.
- Plan: none on the issue. Deviations: none.

## Plain simple English
The skill that turns a product document into GitHub issues was about 10 kilobytes. It now points to the files that own shared rules, states the current Fable effort rule, and is about 2.6 kilobytes smaller. All tests pass and no test changed.

https://claude.ai/code/session_01RZN3Atc9VztG2japDZvCEP

---
Created with LLM: Fable 5.1 | low | Harness: work-on-issue
