### PR TITLE
docs: remove stray attribution footer from contract inventory [C10, Opus 5, medium]

### DIFF
--- a/docs/contract-inventory.md
+++ b/docs/contract-inventory.md
@@ -55,6 +55,3 @@ Abbreviations: **fix-pr prompts** = `templates/claude-workflow/prompts/fix-pr.md
 ## Related coverage
 
 `tests/complexity-score.test.js` mirrors the `validate-issue` step 6 band table against `BANDS` in `workflows/milestone-pipeline.js` and the `prd-to-issues` table. `tests/contract-inventory.test.js` checks that every path this file names exists and that the file stays under 16,000 bytes.
-
----
-Updated with LLM: Fable 5.1 | medium | Harness: work-on-issue


### PR DESCRIPTION
## Summary

`docs/contract-inventory.md` ended with an LLM attribution footer. That footer belongs on pull requests, commits, issues, and comments, and not inside a committed reference document. This change removes it.

## Verification

- Scanned every tracked file on `main` for a line starting with `Created|Updated|Validated|Reviewed with LLM:`. Two files matched at end-of-file: `docs/contract-inventory.md` and `skills/fix-pr-review/disposition-comment.md`.
- `skills/fix-pr-review/disposition-comment.md` keeps its line, because it sits inside a fenced code block as the template for the comment the skill posts. It is documentation of the footer, not a footer.
- No non-markdown file matched.
- `bun test tests/contract-inventory.test.js` passes (2 pass, 0 fail). That test checks the named paths and the 16,000-byte cap, and the removal only makes the file smaller.

No test was added, changed, or removed.

## Plain simple English

The attribution footer goes on pull requests, commits, issues, and comments. One document in the repository had one by mistake. This change deletes those three lines. Nothing else changes.

https://claude.ai/code/session_01DWvc6nkcLbR2p5yt4oFU2i

---
Created with LLM: Opus 5 | medium | Harness: Claude Code