### PR TITLE
refactor(issueplan): clarify planning and build boundaries [C58, GPT-6, high]

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Issues carry a **complexity score** (`C0` to `C100`) in the title and a `fablepl
 | `github-issue-format` | Reference skill: the required issue format. Loaded before any issue is filed or edited. |
 | `work-on-issue` | Implements an issue in an isolated git worktree, builds to any posted plan (newest wins, deviations named in the PR), verifies, and opens a PR that closes the issue. An optional `targetBranch` replaces the default branch as worktree and PR base. |
 | `work-on-issue-loop` | Runs `work-on-issue`, triggers the first review, then delegates to `fix-pr-review-loop` until the PR gets an LGTM. |
-| `issueplan` | Plans and builds on the session's own model with no subagent. For an issue it posts the plan and asks whether to build. |
+| `issueplan` | Plans on the session's model without subagents. Supports planning only; explicit build authorization continues to a PR. A bare issue invocation asks after posting the plan. |
 
 ### PR review skills
 
@@ -157,3 +157,6 @@ The plugin auto-discovers `skills/` and the `/commit` command and auto-updates; 
 ## License
 
 MIT, see [LICENSE](./LICENSE).
+
+---
+Updated with LLM: GPT-6 | high | Harness: skill-creator

--- a/skills/issueplan/SKILL.md
+++ b/skills/issueplan/SKILL.md
@@ -1,80 +1,67 @@
 ---
 name: issueplan
 description: >-
-  Use when the user wants the current large language model to plan and build a task in the same session without a subagent. When an issue is referenced, it posts the plan and asks whether to build. Without an issue, it builds and opens a pull request after presenting the plan. Trigger on "/issueplan", "issueplan this", or "plan this issue in this session".
+  Plan a task or GitHub issue with the current session model, then build when authorized. Use for "/issueplan", "issueplan this", "issue-plan", or requests to plan an issue in this session. Supports planning only; uses no subagents.
 ---
 
 # issueplan
 
-The current session's large language model (LLM) plans and builds. Never call the Agent tool, Task tool, workflow delegation, or any subagent mechanism at any step.
+The current session's large language model (LLM) owns planning and implementation. Do not delegate or launch another coding agent. Follow the repository's Response Style, engineering, Git workflow, and attribution rules without duplicating them here.
 
-## Input
+## Determine the requested outcome
 
-A task description, with an optional GitHub issue:
+Accept a task description or an issue URL, `#<N>`, bare issue number, or `owner/repo#N`; also accept a target branch. Resolve an omitted task from clear session context. Ask only when the task or repository remains ambiguous.
 
-- Prose, such as "issueplan adding X to Y".
-- An issue reference: full URL, `#<N>`, bare `<N>`, or `owner/repo#N`. The plan is then also posted as an issue comment.
-- Ask what to plan only when the task is unclear. With no issue referenced, never invent one or post anywhere.
+- A planning-only request or planning-phase caller ends after the checked plan is delivered. It never starts implementation.
+- Explicit authorization to plan and build, including authorization already given in this session, continues through an open pull request (PR) without another approval question.
+- A bare `issueplan` invocation with an issue posts and presents the plan, then asks whether to build. With a task description and no issue, it presents the plan and builds by default.
 
-## Steps
+User limits on posting, implementation, or publishing override these defaults. Without an issue, do not create an issue or issue comment; the build may still open a PR. Planning-only use does not require a worktree.
 
-### 1. Resolve the GitHub issue (only if one is referenced)
+## 1. Establish the source of truth
 
-Fetch the issue before planning:
+Read the repository instructions and check its identity, current branch, commit, and working-tree status. For a referenced issue, fetch its title, full body, state, URL, update time, and comments with `gh issue view <issue> --json number,title,body,state,url,updatedAt,comments`. Use an explicit `--repo owner/repo` when needed and preserve that identity for later GitHub commands.
 
-```
-gh issue view <N> --json number,title,body,url
-```
+Confirm that the code checkout belongs to the issue's repository. Use the correct local clone when available; otherwise stop issue-based planning and report the missing repository. A failed issue fetch blocks issue-based planning. Never substitute a paraphrase or another issue.
 
-Add `-R owner/repo` for another repository. Stop and tell the user if the command fails. Never plan from a paraphrase of an issue you could not fetch.
+Read acceptance criteria, maintainer corrections, prior plans, and any Execution block. A current-session request selects this session's model and effort; retain the block's scope, dependency, and target constraints. Do not dispatch a stamped model through another harness. Report any routing conflict that the user's request does not resolve before implementation.
 
-Record the number, URL, title, and full body for steps 2 and 4. Read any `## Execution` block as a task constraint. Planning still runs on the current session model and effort.
+## 2. Write and check the plan
 
-### 2. Produce the plan in the current session
+Trace the requested behavior through the relevant code, callers, and tests with read-only inspection. Distinguish existing mechanisms from proposed additions. Correct false assumptions yourself when the intended outcome remains clear; ask only for a missing product decision or a scope change that requires the user.
 
-Inspect the repository with read-only commands. Read its instruction files and the code that controls the requested behavior.
+Write a plan sized to the task:
 
-Produce a concrete, ordered plan: files to create or modify, the approach, build sequence, correctness and safety risks, edge cases, and verification. Number the implementation steps (`1.`, `2.`, …) and end each step with a **verify point**: the observable check that proves the step is done (a command, a passing test, a file state).
+- State the intended behavior and scope, tied to the acceptance criteria.
+- Identify the affected files and approach, including dependencies and material correctness or safety risks.
+- Number the implementation steps (`1.`, `2.`, ...) and end each with a **verify point**: an observable check of the intended behavior or result.
+- Cover relevant regression cases and required project checks. Separate proposed checks from checks already run, and identify any blocker to verification.
 
-Plan the absolute-best solution. Cost, time, token use, and code volume never narrow the option space. Only correctness and safety override "best".
+Check the plan against the code before delivery: existing paths and symbols must be real, proposed additions must be labeled, and verification commands must match the project's tools. Every acceptance criterion needs an implementation step and a check, or an explicit unresolved dependency. Do not present a blocked plan as ready to build.
 
-Write the plan in clean Markdown, fit to act on directly and to post verbatim as an issue comment. Save it to a scratchpad file at once. It must survive context summarization during a long build, and step 4 posts from it.
+Save the checked plan in a scratchpad file outside the working tree. Include the task or issue URL, inspected commit, target branch, unresolved decisions, and implementation authorization so the work can resume after context summarization.
 
-### 3. Check the plan against the code
+## 3. Preserve and present the plan
 
-Verify each load-bearing claim: the files, symbols, commands, and conventions the plan names exist. Fix small errors yourself, note them, and update the scratchpad file. If the plan depends on a missing mechanism or a major false assumption, stop and ask the user whether to revise the task or the plan.
+For an issue, unless the user limits posting, post the checked plan before implementation. Use `## Implementation plan (current session)` as the heading so `work-on-issue` can find it. Apply the repository's attribution footer; absent a repository format, use a final `---` line followed by `Created with LLM: <current session model> | <current session effort> | Harness: issueplan`. Use observed model and effort values or the repository's explicit fallback; report unknown values instead of inventing them.
 
-### 4. Post the plan to the GitHub issue (only if one was resolved in step 1)
+Post from the saved body with `gh issue comment <issue> --body-file <plan-file>`, using the resolved repository. Record the returned comment URL. After an uncertain posting result, inspect the issue comments before retrying to avoid duplicate plans. If required posting fails, preserve the local plan and report the blocker before building.
 
-Post the checked plan before building, so it is preserved whatever happens to the build. Build the body from the scratchpad file: a heading line `## Implementation plan (current session)`, the plan, then the repository's required attribution footer. Use this form when the repository has no stronger rule:
+Give the user the plan's main decisions and a link to its full text, using the comment URL or local scratchpad path. Follow the requested outcome above: stop for planning only, continue when authorized, or ask the one remaining build question. Keep the saved plan for a later continuation.
 
-```
+## 4. Build and deliver
+
+Load [work-on-issue](../work-on-issue/SKILL.md) for the shared build procedures below. Apply those procedures in this session; do not invoke its issue-selection fallback or a delegated workflow.
+
+On a resumed run, identify the task's existing worktree and PR first so the duplicate check can recognize its own branch. Before building, refresh issue state and comments and apply `work-on-issue` step 0 for issue-state, duplicate-PR, and plan-selection rules. Use the saved plan when no posted plan exists. For tasks without an issue, skip issue-specific commands and gates.
+
+If no Git repository is available, preserve the plan and report that implementation needs one. Otherwise, create or reuse the isolated worktree per `work-on-issue` step 1. Resolve the target from user and repository instructions, otherwise the repository default branch. Use `<agent-prefix>/issueplan/<short-task-name>` for a new branch. This skill supplies no `baseRefs`; new work starts from the fetched target branch. The PR uses that same target. Confirm a reused worktree belongs to this task and target; preserve its existing work.
+
+Recheck affected code against the saved plan after entering the worktree, especially when the base or issue changed. Before writing any code, apply `work-on-issue` step 2 for plan deviations and mirroring numbered steps into the task tracker, including its scratchpad fallback and overridden-step rules. Update the saved plan and record material changes; ask again only when a change exceeds existing authorization.
+
+Apply its implementation, verification, commit, push, and PR procedures in steps 3 through 6, within user limits. For tasks without an issue, omit issue references and closing keywords. Preserve the plan and deviations in the PR body; include locally saved plan text only when publishing it is permitted.
+
+Report the PR URL, verification result, and any remaining blocker. If stopped, include the saved plan and worktree paths needed to resume. Retain worktrees with unfinished or unpushed work; clean up completed work only when repository rules permit. This skill ends at delivery; merging or an automated review loop needs separate authorization.
+
 ---
-Created with LLM: <current session model> | <current session effort> | Harness: issueplan
-```
-
-Fill the model and effort from the current session. Never guess a value the session cannot observe; when the repository gives no fallback, tell the user the limitation before posting.
-
-```
-gh issue comment <N> --body-file <tmpfile>
-```
-
-Add `-R owner/repo` for another repository. Follow the repository's comment conventions (for example no bare `#N` list numbering). Give the user the comment URL.
-
-### 5. Present the plan
-
-Show the checked plan, with the comment URL when step 4 posted it. State any attribution limitation or repository constraint that affects the plan.
-
-### 6. Ask whether to continue building (only if an issue was referenced)
-
-The plan is safely posted, so do not assume an immediate build. Ask (for example via `AskUserQuestion`) whether to build now or stop. On stop, end the skill; the user can resume later with `work-on-issue`. With no issue, there is nothing posted to fall back to, so skip the question and build.
-
-### 7. Set up an isolated git worktree
-
-Never build in the user's current checkout. If the directory is not a git repository, tell the user and ask how to proceed. Create the worktree and branch per `work-on-issue` step 1 ("Create the isolated worktree on a verified base"). Deltas: the name is `<agent-prefix>/issueplan/<short-task-name>`, and there is no `baseRefs` input, so the base is the fetched `origin/<target>`: the `targetBranch` the user named, else the default branch. The PR opens against that same target.
-
-### 8. Build
-
-Build per the plan in the worktree with the current session LLM. Before writing any code, mirror the plan's numbered steps into the task tracker per `work-on-issue` step 2 (its "Mirror the plan's steps into the task tracker" paragraph). That paragraph owns the mirroring rule, both fallbacks, and the disposition of a step an override cancels. Confirm with the user first only when the plan exposes a product decision or an unsafe ambiguity.
-
-Follow the repository's test, commit, push, and pull request rules. Record every plan deviation in the pull request body. Remove the worktree once it is no longer needed and repository rules permit.
+Updated with LLM: GPT-6 | high | Harness: skill-creator


### PR DESCRIPTION
## Summary

Rework issueplan to honor planning-only requests and existing build authorization. Remove repeated guidance and use shared build procedures. Add repository checks, issue comments, safe posting retries, and resume checks; update the README entry.

## Verification

- Bun: 319 tests passed.
- Python workflow suites: 91 and 55 tests passed.
- Final focused contract checks, skill validation, and diff checks passed.
- Manual decision-path review; no live issueplan run or test edits.

## Plain simple English

The skill now separates planning from building and keeps prior approval. It checks the issue and code before work starts and preserves the information needed to resume.

---
Updated with LLM: GPT-6 | high | Harness: Claude Code
