### PR TITLE
refactor(prd-to-issues): make backlog filing complete and verified [C64, GPT-6, high]

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ flowchart LR
 | `new-app-pipeline` | The orchestrator: stops at every stage boundary for review and re-enters mid-pipeline when artifacts exist. |
 | `app-prd` | Turns an idea dump into a section-numbered `PRD.md` landed via worktree and PR. |
 | `prd-questions` | Sweeps the PRD for open questions, asks them in batched multiple-choice form, and folds each answer into the owning section. |
-| `prd-to-issues` | Maps PRD requirements to dependency-ordered milestones and complete scored issues, with resumable filing and an `## Execution` block (`Depends on`, `Runs after`, build model, effort, fableplan, review trigger). |
+| `prd-to-issues` | Maps PRD requirements to dependency-ordered milestones and complete scored issues, with verified dependencies and an `## Execution` block (`Depends on`, `Runs after`, build model, effort, fableplan, review trigger). |
 | `execution-plan-review` | Renders the execution table from the issues, takes revisions ("11 should be medium", "build 275 with luna on codex at max"), rejects cycles, and writes changes back. |
 | `milestoneplan` | Read-only: renders a milestone's plan as one table, one row per issue. Missing fields show as *missing*. |
 | `milestone-workflow` | Builds dependency tracks, presents the run plan for approval, then runs `milestone-pipeline`: validate, plan, build, review loops, in-session merges, and the release. An optional `targetBranch` points every stage at that branch. |

--- a/README.md
+++ b/README.md
@@ -157,6 +157,3 @@ The plugin auto-discovers `skills/` and the `/commit` command and auto-updates; 
 ## License
 
 MIT, see [LICENSE](./LICENSE).
-
----
-Updated with LLM: GPT-6 | high | Harness: Codex

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ flowchart LR
 | `new-app-pipeline` | The orchestrator: stops at every stage boundary for review and re-enters mid-pipeline when artifacts exist. |
 | `app-prd` | Turns an idea dump into a section-numbered `PRD.md` landed via worktree and PR. |
 | `prd-questions` | Sweeps the PRD for open questions, asks them in batched multiple-choice form, and folds each answer into the owning section. |
-| `prd-to-issues` | Breaks the PRD into dependency-ordered milestones and 15 to 25 scored issues, each with an `## Execution` block (`Depends on`, `Runs after`, build model, effort, fableplan, review trigger). |
+| `prd-to-issues` | Maps PRD requirements to dependency-ordered milestones and complete scored issues, with resumable filing and an `## Execution` block (`Depends on`, `Runs after`, build model, effort, fableplan, review trigger). |
 | `execution-plan-review` | Renders the execution table from the issues, takes revisions ("11 should be medium", "build 275 with luna on codex at max"), rejects cycles, and writes changes back. |
 | `milestoneplan` | Read-only: renders a milestone's plan as one table, one row per issue. Missing fields show as *missing*. |
 | `milestone-workflow` | Builds dependency tracks, presents the run plan for approval, then runs `milestone-pipeline`: validate, plan, build, review loops, in-session merges, and the release. An optional `targetBranch` points every stage at that branch. |
@@ -157,3 +157,6 @@ The plugin auto-discovers `skills/` and the `/commit` command and auto-updates; 
 ## License
 
 MIT, see [LICENSE](./LICENSE).
+
+---
+Updated with LLM: GPT-6 | high | Harness: Codex

--- a/skills/execution-plan-review/SKILL.md
+++ b/skills/execution-plan-review/SKILL.md
@@ -21,7 +21,7 @@ Cell rules:
 - **Plan effort** defaults to `high` on `fableplan first: Yes` issues; a stamped line shows as `<tier> (stamped)`. On a `No` issue show `—` only when no line is stamped; any stamped line, `high` included, shows as `<tier> (inert — no plan stage runs)`, because the milestone pipeline logs it on every run and the source-of-truth table must not mask it.
 - An absent ordering field shows as `missing`, never `none`, so legacy prose inference is not silently discarded.
 
-Follow with 2–3 sentences on the pattern (dominant bands, which issues plan first at score ≥ 71, the review trigger) for a sanity check against the `prd-to-issues` / `validate-issue` band table.
+Follow with 2–3 sentences on the pattern (dominant bands, which issues plan first at score ≥ 71, the review trigger) for a sanity check against the `validate-issue` step 6 band table.
 
 ### 2. Take revisions
 
@@ -62,3 +62,6 @@ Re-render the final table once after all revisions land, and say it is what the 
 | Revision names a plan model | Only the effort is stampable; the fableplan stage is Fable 5.1 by definition. Drop the model part, keep the effort part, say so |
 | Revision names a plan effort | Write the `Plan effort:` line with `low`, `medium`, `high`, or `xhigh`. A revision to `high` removes the line, since high is the default |
 | Edits collide with concurrent issue edits | Re-fetch, re-apply only your delta |
+
+---
+Updated with LLM: GPT-6 | high | Harness: Codex

--- a/skills/execution-plan-review/SKILL.md
+++ b/skills/execution-plan-review/SKILL.md
@@ -62,6 +62,3 @@ Re-render the final table once after all revisions land, and say it is what the 
 | Revision names a plan model | Only the effort is stampable; the fableplan stage is Fable 5.1 by definition. Drop the model part, keep the effort part, say so |
 | Revision names a plan effort | Write the `Plan effort:` line with `low`, `medium`, `high`, or `xhigh`. A revision to `high` removes the line, since high is the default |
 | Edits collide with concurrent issue edits | Re-fetch, re-apply only your delta |
-
----
-Updated with LLM: GPT-6 | high | Harness: Codex

--- a/skills/new-app-pipeline/SKILL.md
+++ b/skills/new-app-pipeline/SKILL.md
@@ -14,7 +14,7 @@ The end-to-end process for starting a new app: capture the idea as a PRD, refine
 | 1 | Idea → PRD | `app-prd` | `PRD.md` on a PR | User iterates on the draft, in bursts |
 | 2 | Resolve questions | `prd-questions` | Updated PRD, empty Open Questions | User answered every batch |
 | 3 | Merge the PRD PR | — | PRD on main | Explicit user go |
-| 4 | Issues + milestones | `prd-to-issues` | Milestones, 15–25 issues with Execution blocks | User reviews the breakdown table |
+| 4 | Issues + milestones | `prd-to-issues` | Milestones, complete scoped issues with Execution blocks | User reviews the breakdown table |
 | 5 | Execution plan | `execution-plan-review` | Revised Execution blocks | User settles the final table |
 | 6 | Show the plan | `milestoneplan` | Single per-issue plan table (complexity, dependencies, models, efforts, fableplan, first review) | User reviews the table (recommended, not required) |
 | 7 | Run a milestone | `milestone-workflow` | Workflow run → PRs → LGTMs | User approves the run plan (mandatory) |
@@ -33,3 +33,6 @@ The end-to-end process for starting a new app: capture the idea as a PRD, refine
 If the artifacts already exist (a PRD in the repo, issues filed), enter at the first stage whose artifact is missing or stale — never redo a finished stage. Verify by looking at the repo and issues, not by asking.
 
 Entering at a milestone that already has Execution blocks is the common case; run `milestoneplan` first to see what state those blocks are actually in before assuming stage 5 is finished.
+
+---
+Updated with LLM: GPT-6 | high | Harness: Codex

--- a/skills/new-app-pipeline/SKILL.md
+++ b/skills/new-app-pipeline/SKILL.md
@@ -33,6 +33,3 @@ The end-to-end process for starting a new app: capture the idea as a PRD, refine
 If the artifacts already exist (a PRD in the repo, issues filed), enter at the first stage whose artifact is missing or stale — never redo a finished stage. Verify by looking at the repo and issues, not by asking.
 
 Entering at a milestone that already has Execution blocks is the common case; run `milestoneplan` first to see what state those blocks are actually in before assuming stage 5 is finished.
-
----
-Updated with LLM: GPT-6 | high | Harness: Codex

--- a/skills/prd-to-issues/SKILL.md
+++ b/skills/prd-to-issues/SKILL.md
@@ -19,7 +19,7 @@ Use a stable PRD link and its verified section heading or identifier in each iss
 
 ## 2. Map requirements and dependencies
 
-Keep a local filing record with the source revision, release scope, requirement-to-issue map, complete draft bodies, graph, intended create/reuse/update actions, and returned GitHub identifiers. Save it outside the tracked source unless the user requests a committed plan; make its location available for resumption.
+Hold the requirement-to-issue map, the complete draft bodies, the dependency graph, and the intended create/reuse/update action for each issue while you work.
 
 - Map every in-scope requirement to a draft key, an existing issue, or verified implementation. Record exclusions and deferred requirements with their reason. Give shared invariants an owning issue and identify the consumers that must enforce them.
 - Size issues around a coherent result that can be implemented and verified in one pull request (PR) after its prerequisites. Set no fixed issue count or milestone size. Keep inseparable changes together; use the scope-disposition criteria in `validate-issue` step 7 when splitting a large candidate.
@@ -50,7 +50,7 @@ The standard PR review line leaves first-review routing to the pipeline and the 
 
 Omit **Validate effort:** and **Plan effort:** at initial filing unless explicitly requested; the owners supply the defaults. Never stamp a validate model. Never stamp Fable 5.1 as the Build model without a specific user instruction. Never stamp an external CLI harness as the Build model without a specific user instruction. Command-line interface (CLI) overrides use `<Name> (Codex CLI[, <model-id>])` or `<Name> (Cursor CLI[, <model-id>])`.
 
-For user-directed model, effort, planner, or review overrides, read [execution-plan-review](../execution-plan-review/SKILL.md) and apply its validation and clamp rules to the draft. Preserve valid overrides when resuming. Do not execute the referenced build or review workflow.
+For user-directed model, effort, planner, or review overrides, read [execution-plan-review](../execution-plan-review/SKILL.md) and apply its validation and clamp rules to the draft. Preserve valid overrides. Do not execute the referenced build or review workflow.
 
 ## 4. Review the complete filing plan
 
@@ -62,17 +62,17 @@ Honor existing authorization to file. If the user requested review first or has 
 
 Recheck GitHub for concurrent changes before writes. Reuse matching milestones; create only missing ones with their completion outcome in the description. Use an explicit target repository on every GitHub operation. Pass issue bodies as data through `gh issue create --body-file` or a structured tool argument; never interpolate PRD text into executable shell code.
 
-Create issues sequentially in topological order across both edge types. Resolve each predecessor key to its verified GitHub number before creating the successor, so every new issue has its complete body and final Execution block at creation. Use the identifiers returned by GitHub; never predict numbering. Read back each created issue and persist its identity in the filing record before proceeding.
+Create issues sequentially in topological order across both edge types. Resolve each predecessor key to its verified GitHub number before creating the successor, so every new issue has its complete body and final Execution block at creation. Use the identifiers returned by GitHub; never predict numbering. Read back each created issue and confirm its number before proceeding.
 
 For approved updates to existing issues, re-fetch the body and apply only the intended changes, preserving unrelated content and valid overrides. Revalidate the combined graph after any concurrent change. Do not close, reopen, delete, or move existing work merely to make the backlog fit.
 
-If a create or update fails or returns an uncertain result, stop dependent writes and reconcile remote state before retrying. After an uncertain create, match the source reference, title, body, and milestone against GitHub and the filing record. Resume from verified results; never rerun the whole batch blindly or delete successful work as rollback. If the result remains ambiguous, report the blocker and request resolution.
+If a create or update fails or returns an uncertain result, stop dependent writes. After an uncertain create, search GitHub for the source reference, title, and milestone before retrying, so the same issue is not filed twice. Never rerun the whole batch blindly, and never close or delete successful work as rollback. Report what was filed, what remains, and the blocker.
 
 Read back the full filed set, including reused issues and milestones. Check saved titles, bodies, source references, milestone assignments, scores, routing fields, and actual dependency targets against the plan; rerun the combined graph and coverage checks. Resolve mismatches before reporting completion. Cross-milestone prerequisites remain explicit; [milestone-workflow run planning](../milestone-workflow/run-plan.md) owns their execution treatment.
 
 ## 6. Report the result
 
-Return links to the milestones and created or updated issues, a compact score/title table or linked filing record, and any unresolved or deferred scope. Distinguish reused and already implemented work from new filings. Report partial completion and the next required decision when blocked. Do not claim the backlog is ready until the saved bodies and graph pass verification.
+Return links to the milestones and created or updated issues, a compact score/title table, and any unresolved or deferred scope. Distinguish reused and already implemented work from new filings. Report partial completion and the next required decision when blocked. Do not claim the backlog is ready until the saved bodies and graph pass verification.
 
 ---
 Updated with LLM: GPT-6 | high | Harness: Codex

--- a/skills/prd-to-issues/SKILL.md
+++ b/skills/prd-to-issues/SKILL.md
@@ -1,88 +1,78 @@
 ---
 name: prd-to-issues
-description: Use when the user wants a finished PRD broken into GitHub milestones and issues — "file the issues from the PRD", "/prd-to-issues", "break this into GitHub issues". Derives dependency-ordered milestones, files complete complexity-scored issues (github-issue-format), and stamps each with an Execution block (typed predecessors, build model, effort, fableplan, review trigger). Stage 4 of the new-app-pipeline.
+description: Turn a finished Product Requirements Document (PRD) into GitHub milestones and complete, scored issues with typed dependencies and Execution blocks. Use for "file the issues from the PRD", "/prd-to-issues", or "break this into GitHub issues". Stage 4 of the new-app-pipeline.
 ---
 
 # prd-to-issues
 
-Break a refined PRD into milestones and fully specified GitHub issues that cold agents implement one at a time. An agent holding only the issue body and the PRD must be able to build it correctly.
+Produce a complete, dependency-ordered backlog that an agent can implement from each issue and its cited PRD. The deliverable ends at verified GitHub issues; implementation and workflow dispatch require their own instruction.
 
-**Load the `github-issue-format` skill before filing anything (mandatory).**
+Follow the target repository's CLAUDE.md/AGENTS.md Response Style and attribution rules. Read [github-issue-format](../github-issue-format/SKILL.md) before composing issue bodies. Read [validate-issue step 6](../validate-issue/SKILL.md#6-score-complexity) and its [complexity-scoring reference](../validate-issue/complexity-scoring.md) for scoring and routing; those sources own the formula, grades, and band tables. Use those sections without starting the validation workflow.
 
-## Steps
+## 1. Establish the source and existing work
 
-### 1. Plan the breakdown (present before filing)
+Identify the target repository, PRD revision, and requested release scope from the request and repository state. Read the full PRD, relevant repository instructions, implementation, and tests. Distinguish implemented behavior from planned work; an empty repository needs proposed implementation boundaries, clearly marked as proposed.
 
-- Derive **milestones** from dependency structure, never from feature themes. Typical shape: `v0` foundation and core surface (scaffold, schema, auth, core flows, payments happy path), `v1` lifecycle and delivery (jobs, schedulers, notifications), `v2` second-surface parity, `v3` post-MVP.
-- Aim for **15–25 issues**, each independently implementable and PR-sized.
-- Separate the **dependency spine** (built serially) from **parallel waves**. For each issue record its direct hard prerequisites apart from ordering-only predecessors. Name the risk concentrators, usually the schema and the money module.
-- Show the plan (titles, milestones, order) in chat before filing and adjust on feedback.
+Fetch all relevant open and closed issues and milestones, with pagination. Compare bodies, acceptance criteria, and implementation evidence before reusing an issue; a matching title or closed state alone does not prove coverage. Preserve existing work and deliberate execution overrides. Resolve an ambiguous repository or conflicting source revision before any write.
 
-### 2. Create milestones
+Use a stable PRD link and its verified section heading or identifier in each issue. Prefer a commit-pinned source when available. If the source is local or uncommitted, identify its revision in the drafts and establish a durable source accessible to future agents before filing. Do not invent section numbers or publish source material outside the user's authorized destination.
 
-`gh api repos/<owner>/<repo>/milestones -f title='...' -f description='...'`, one per phase, the description listing the member issues' themes.
+## 2. Map requirements and dependencies
 
-### 3. Write the issues
+Keep a local filing record with the source revision, release scope, requirement-to-issue map, complete draft bodies, graph, intended create/reuse/update actions, and returned GitHub identifiers. Save it outside the tracked source unless the user requests a committed plan; make its location available for resumption.
 
-Per `github-issue-format`: `[C<score>]` plain-language title, complexity rationale first line, then **Problem** (with PRD § references), **Goal**, **Approach**, **Acceptance criteria**, **`## Plain simple English`** (mandatory, under 55 words, ASD-STE100), the step 4 Execution block, then the attribution footer.
+- Map every in-scope requirement to a draft key, an existing issue, or verified implementation. Record exclusions and deferred requirements with their reason. Give shared invariants an owning issue and identify the consumers that must enforce them.
+- Size issues around a coherent result that can be implemented and verified in one pull request (PR) after its prerequisites. Set no fixed issue count or milestone size. Keep inseparable changes together; use the scope-disposition criteria in `validate-issue` step 7 when splitting a large candidate.
+- Derive milestones from prerequisite order and a verifiable completion outcome. Reuse suitable milestones and keep the user's release names and boundaries unless a conflict requires a decision. Do not move deferred roadmap features into the requested release.
+- Assign stable local keys while drafting. **Depends on** records direct prerequisites whose code or product result the successor requires. **Runs after** records a direct ordering constraint when no result is required, such as independent changes to the same package that must not overlap. Shared location alone is insufficient; identify the actual conflict. When the successor needs the result, use Depends on.
+- Preserve edge types and their reasons. Reject missing references, self-references, duplicate edges, a predecessor in both fields, and cycles across the combined graph. Recursively inspect referenced existing issues, including those outside the milestone. Milestone order must permit every prerequisite to finish before its successor; milestone membership alone supplies no edge. Identify serial prerequisites, concurrent work, and safety-critical issues.
 
-- Cite PRD section numbers everywhere; they are the cold agent's index.
-- Acceptance criteria are testable behaviors, including negative ones ("no endpoint can return a signed URL for sealed media, for any role").
-- Money, privacy, and irreversible-deletion invariants go in the acceptance criteria.
-- Pure logic (pricing engines) embeds the PRD's worked examples as required test cases.
-- File via one batch script (heredoc bodies, `gh issue create --milestone`), sequentially so numbering is stable.
+If a missing product decision prevents a complete specification, hold that issue and its affected successors. Use [prd-questions](../prd-questions/SKILL.md) only for the blocking decision and the affected source sections; do not start a whole-roadmap sweep. Continue independent drafts and file complete independent issues within existing scope authorization, unless the user required the whole backlog to be settled first. Record the held requirements and report partial completion; never file a stub or treat the subset as full coverage.
 
-### 4. Stamp Execution blocks
+## 3. Draft complete issues and execution metadata
 
-Append to every issue body, before the footer:
+Use `github-issue-format` for the title, rationale, body order, mandatory `## Plain simple English` section, and footer. Embed the issue's relevant requirements and acceptance criteria so that the PRD supplies context without becoming a substitute for the specification.
 
-```
-## Execution
-- **Depends on:** #<n>[, #<n>…] | none
-- **Runs after:** #<n>[, #<n>…] | none
-- **Build model:** <Fable 5.1 | Opus 5 | ... | <Name> (Codex CLI[, <model-id>]) | <Name> (Cursor CLI[, <model-id>])>
-- **Effort:** <low (Fable-only, discretionary, below the formula floor) | medium (Fable-only) | high | xhigh | max (Codex CLI-only)>
-- **fableplan first:** <Yes (Fable 5.1 plans, plan posted to this issue, builder implements against it) | No>
+State the result, scope boundaries, implementation contracts, prerequisite outputs, and verification method. Include applicable failure paths and money, privacy, authorization, data-integrity, and irreversible-deletion invariants. Carry the PRD's worked examples into acceptance tests, checking their inputs and expected results against the stated rules. Resolve contradictions before filing; do not silently choose a rule.
+
+Grade all five complexity axes from the proposed edit list and the proof required. Distinguish proposed sites from inspected sites, and record the evidence for each grade. Recompute the title score, rationale, and execution defaults together after scope changes.
+
+Append exactly one Execution block before the footer. Use these field names with concrete values; local keys are permitted only in unpublished drafts:
+
+- **Depends on:** comma-separated actual issue references, or `none`
+- **Runs after:** comma-separated actual issue references, or `none`
+- **Build model:** the score band's Build model
+- **Effort:** the score band's Build effort
+- **fableplan first:** the score band's `Yes` or `No`
 - **PR review:** standard `@claude` review trigger
-- **Validate effort:** <low | medium | high | xhigh>   (optional; omit for the band default)
-- **Plan effort:** <low | medium | high>   (optional; omit to plan at high; read only when fableplan first is Yes)
-```
 
-Ordering fields, stamped from the approved spine/wave graph once final numbers are known:
+The standard PR review line leaves first-review routing to the pipeline and the `validate-issue` step 6 first-review table. Do not copy review boundaries or re-review rules here.
 
-- Record direct predecessor edges only, comma-separated; write `none` when there is no edge of that kind.
-- **Depends on**: the issue needs the predecessor's code or product result (an API issue that needs another issue's schema).
-- **Runs after**: the issues must not overlap but the later one needs none of the earlier one's code (two independent issues editing the same package). A same-package exclusion is always `Runs after`. Never list one predecessor in both fields.
+Omit **Validate effort:** and **Plan effort:** at initial filing unless explicitly requested; the owners supply the defaults. Never stamp a validate model. Never stamp Fable 5.1 as the Build model without a specific user instruction. Never stamp an external CLI harness as the Build model without a specific user instruction. Command-line interface (CLI) overrides use `<Name> (Codex CLI[, <model-id>])` or `<Name> (Cursor CLI[, <model-id>])`.
 
-Routing fields derive from the complexity score band. Score each issue with the `validate-issue` step 6 formula and stamp from that band:
+For user-directed model, effort, planner, or review overrides, read [execution-plan-review](../execution-plan-review/SKILL.md) and apply its validation and clamp rules to the draft. Preserve valid overrides when resuming. Do not execute the referenced build or review workflow.
 
-| Band | Score band | Build model | fableplan first | Effort |
-|---|---|---|---|---|
-| 0 | 0–9 | Sonnet 5 (or the repo's cheap/fast builder) | No | high |
-| 1 | 10–20 | Sonnet 5 (or the repo's cheap/fast builder) | No | xhigh |
-| 2 | 21–49 | Opus 5 | No | high |
-| 3 | 50–70 | Opus 5 | No | xhigh |
-| 4 | 71–80 | Opus 5 | **Yes** | xhigh |
-| 5 | 81–99 | Opus 5 | **Yes** | xhigh |
+## 4. Review the complete filing plan
 
-- **Never stamp Fable 5.1 as the Build model.** No band defaults to a Fable build; one exists only when the user directs it on a specific issue.
-- **Never stamp an external CLI harness as the Build model.** `execution-plan-review` writes `<Name> (Codex CLI)` or `<Name> (Cursor CLI)` (optional model id after a comma) on the user's instruction, and `cli-dispatch` owns how the pipeline reaches that CLI.
-- The axes already encode the old heuristics (money/security raises Risk; design-heavy raises Uncertainty; mechanical grind raises Scope/Volume at Capability 0). Never override the band with a separate signal table; if the PRD states a safety carve-out and Risk was under-scored, raise Risk and re-score.
-- **fableplan first: Yes** means score 71 or higher (bands 4–5). Never below 71.
-- **Validate model** is derived from the score by the `validate-issue` step 6 band table and is never stamped; a missing `[C..]` prefix routes as band 5. **Validate effort** and **Plan effort** default to the band value and `high`; this skill omits both lines at filing time, and `execution-plan-review` adds them and owns the clamp rules (an Opus validate stamped `low` or `medium` runs at `high`).
-- Effort floor is **medium** and medium is Fable-only: Opus and Sonnet builds run at high or xhigh. A Fable build may drop to **low** only on a band-5 issue judged lighter than its Volume warrants. Fable 5.1 defaults to high on every stage and runs at xhigh only when the user asks for it or stamps it (the LLM Attribution Footer section of CLAUDE.md owns this rule). When unsure between two tiers, take the higher.
-- **PR review**: the pipeline derives the first-review trigger from the `validate-issue` step 6 first-review table; this file states no boundary of its own. `skills/fix-pr-review/rereview-routing.md` owns the blocking re-review step-down ladder and the shorthand `claude.yml` resolves (`sonnet`, `opus`, `fable`; never stamp `haiku`). Stamp an explicit `@claude <model> review effort:<tier>` line only to override the default.
-- Scores filed before the band-encoding change are not comparable; re-score if routing matters.
+Before writing to GitHub, make the complete drafts and coverage map available with a compact table of draft key, title, milestone, score, typed predecessors, and create/reuse/update action. Check that each in-scope requirement is covered, every criterion is verifiable, the combined graph is acyclic, routing matches scores or explicit overrides, and each milestone has a completion outcome.
 
-### 5. Report
+Honor existing authorization to file. If the user requested review first or has not authorized filing, stop at this concrete plan and ask for the required approval. Do not ask again when the session already authorizes the proposed scope. When invoked through `new-app-pipeline`, preserve its stage checkpoints. A material scope or dependency change after approval needs reconciliation before filing.
 
-A compact table: issue number, `C`, title. Note the spine/wave ordering and which issues concentrate risk.
+## 5. File in dependency order and verify
 
-## Failure modes
+Recheck GitHub for concurrent changes before writes. Reuse matching milestones; create only missing ones with their completion outcome in the description. Use an explicit target repository on every GitHub operation. Pass issue bodies as data through `gh issue create --body-file` or a structured tool argument; never interpolate PRD text into executable shell code.
 
-| Situation | Do this |
-|---|---|
-| An issue cannot be specced without a decision the PRD does not make | Stop; run `prd-questions` for it first. Never file a stub |
-| Two issues touch the same module in the same wave | List the earlier issue in the later issue's `Runs after`, or merge them if they are not independently implementable |
-| A milestone exceeds about 12 issues | Split it; workflow waves get unwieldy past that |
-| Tempted to skip Execution blocks "for now" | Never; cold agents need them |
+Create issues sequentially in topological order across both edge types. Resolve each predecessor key to its verified GitHub number before creating the successor, so every new issue has its complete body and final Execution block at creation. Use the identifiers returned by GitHub; never predict numbering. Read back each created issue and persist its identity in the filing record before proceeding.
+
+For approved updates to existing issues, re-fetch the body and apply only the intended changes, preserving unrelated content and valid overrides. Revalidate the combined graph after any concurrent change. Do not close, reopen, delete, or move existing work merely to make the backlog fit.
+
+If a create or update fails or returns an uncertain result, stop dependent writes and reconcile remote state before retrying. After an uncertain create, match the source reference, title, body, and milestone against GitHub and the filing record. Resume from verified results; never rerun the whole batch blindly or delete successful work as rollback. If the result remains ambiguous, report the blocker and request resolution.
+
+Read back the full filed set, including reused issues and milestones. Check saved titles, bodies, source references, milestone assignments, scores, routing fields, and actual dependency targets against the plan; rerun the combined graph and coverage checks. Resolve mismatches before reporting completion. Cross-milestone prerequisites remain explicit; [milestone-workflow run planning](../milestone-workflow/run-plan.md) owns their execution treatment.
+
+## 6. Report the result
+
+Return links to the milestones and created or updated issues, a compact score/title table or linked filing record, and any unresolved or deferred scope. Distinguish reused and already implemented work from new filings. Report partial completion and the next required decision when blocked. Do not claim the backlog is ready until the saved bodies and graph pass verification.
+
+---
+Updated with LLM: GPT-6 | high | Harness: Codex

--- a/skills/prd-to-issues/SKILL.md
+++ b/skills/prd-to-issues/SKILL.md
@@ -5,71 +5,62 @@ description: Turn a finished Product Requirements Document (PRD) into GitHub mil
 
 # prd-to-issues
 
-Produce a complete, dependency-ordered backlog that an agent can implement from each issue and its cited PRD. The deliverable ends at verified GitHub issues; implementation and workflow dispatch require their own instruction.
+Produce a complete, dependency-ordered backlog an agent can implement from each issue plus its cited PRD. The deliverable ends at verified GitHub issues; building and dispatch need their own instruction.
 
-Follow the target repository's CLAUDE.md/AGENTS.md Response Style and attribution rules. Read [github-issue-format](../github-issue-format/SKILL.md) before composing issue bodies. Read [validate-issue step 6](../validate-issue/SKILL.md#6-score-complexity) and its [complexity-scoring reference](../validate-issue/complexity-scoring.md) for scoring and routing; those sources own the formula, grades, and band tables. Use those sections without starting the validation workflow.
+Follow the target repo's CLAUDE.md/AGENTS.md Response Style and attribution rules. Read [github-issue-format](../github-issue-format/SKILL.md) before composing bodies. Read [validate-issue step 6](../validate-issue/SKILL.md#6-score-complexity) and its [complexity-scoring reference](../validate-issue/complexity-scoring.md) for scoring and routing; they own the formula and band tables. Do not start the validation workflow.
 
 ## 1. Establish the source and existing work
 
-Identify the target repository, PRD revision, and requested release scope from the request and repository state. Read the full PRD, relevant repository instructions, implementation, and tests. Distinguish implemented behavior from planned work; an empty repository needs proposed implementation boundaries, clearly marked as proposed.
-
-Fetch all relevant open and closed issues and milestones, with pagination. Compare bodies, acceptance criteria, and implementation evidence before reusing an issue; a matching title or closed state alone does not prove coverage. Preserve existing work and deliberate execution overrides. Resolve an ambiguous repository or conflicting source revision before any write.
-
-Use a stable PRD link and its verified section heading or identifier in each issue. Prefer a commit-pinned source when available. If the source is local or uncommitted, identify its revision in the drafts and establish a durable source accessible to future agents before filing. Do not invent section numbers or publish source material outside the user's authorized destination.
+- Identify the target repo, PRD revision, and release scope. Read the full PRD, repo instructions, code, and tests; separate implemented from planned work. In an empty repo, mark proposed boundaries as proposed.
+- Fetch all open and closed issues and milestones, with pagination. Reuse an issue only after comparing body, acceptance criteria, and implementation evidence; a matching title or closed state proves nothing. Preserve existing work and deliberate execution overrides.
+- Cite a stable PRD link with its verified section heading; prefer a commit-pinned source. A local or uncommitted source gets a durable, accessible home before filing. Never invent section numbers or publish source material outside the authorized destination.
+- Resolve an ambiguous repo or conflicting source revision before any write.
 
 ## 2. Map requirements and dependencies
 
-Hold the requirement-to-issue map, the complete draft bodies, the dependency graph, and the intended create/reuse/update action for each issue while you work.
+Hold the requirement-to-issue map, draft bodies, dependency graph, and each issue's create/reuse/update action while you work.
 
-- Map every in-scope requirement to a draft key, an existing issue, or verified implementation. Record exclusions and deferred requirements with their reason. Give shared invariants an owning issue and identify the consumers that must enforce them.
-- Size issues around a coherent result that can be implemented and verified in one pull request (PR) after its prerequisites. Set no fixed issue count or milestone size. Keep inseparable changes together; use the scope-disposition criteria in `validate-issue` step 7 when splitting a large candidate.
-- Derive milestones from prerequisite order and a verifiable completion outcome. Reuse suitable milestones and keep the user's release names and boundaries unless a conflict requires a decision. Do not move deferred roadmap features into the requested release.
-- Assign stable local keys while drafting. **Depends on** records direct prerequisites whose code or product result the successor requires. **Runs after** records a direct ordering constraint when no result is required, such as independent changes to the same package that must not overlap. Shared location alone is insufficient; identify the actual conflict. When the successor needs the result, use Depends on.
-- Preserve edge types and their reasons. Reject missing references, self-references, duplicate edges, a predecessor in both fields, and cycles across the combined graph. Recursively inspect referenced existing issues, including those outside the milestone. Milestone order must permit every prerequisite to finish before its successor; milestone membership alone supplies no edge. Identify serial prerequisites, concurrent work, and safety-critical issues.
+- Map every in-scope requirement to a draft key, an existing issue, or verified implementation. Record exclusions and deferrals with reasons. Give each shared invariant an owning issue and name the consumers that enforce it.
+- Size each issue as one coherent result, implementable and verifiable in one pull request (PR) after its prerequisites. No fixed issue count or milestone size. Keep inseparable changes together; split large candidates by `validate-issue` step 7.
+- Derive milestones from prerequisite order plus a verifiable completion outcome. Reuse suitable milestones and the user's release names; never pull deferred roadmap features into the requested release.
+- **Depends on**: the successor needs the predecessor's code or product result. **Runs after**: ordering only, such as independent edits to one package that must not overlap; name the actual conflict, since a shared location alone is not enough.
+- Reject missing references, self-references, duplicate edges, a predecessor in both fields, and cycles across the combined graph, recursing into referenced existing issues outside the milestone. Milestone order must let every prerequisite finish first; membership alone is no edge. Mark serial prerequisites, concurrent work, and safety-critical issues.
 
-If a missing product decision prevents a complete specification, hold that issue and its affected successors. Use [prd-questions](../prd-questions/SKILL.md) only for the blocking decision and the affected source sections; do not start a whole-roadmap sweep. Continue independent drafts and file complete independent issues within existing scope authorization, unless the user required the whole backlog to be settled first. Record the held requirements and report partial completion; never file a stub or treat the subset as full coverage.
+If a missing product decision blocks a complete spec, hold that issue and its successors. Run [prd-questions](../prd-questions/SKILL.md) for that decision only. Keep drafting and filing independent issues within existing authorization unless the user wants the whole backlog settled first. Report the held requirements as partial completion; never file a stub.
 
 ## 3. Draft complete issues and execution metadata
 
-Use `github-issue-format` for the title, rationale, body order, mandatory `## Plain simple English` section, and footer. Embed the issue's relevant requirements and acceptance criteria so that the PRD supplies context without becoming a substitute for the specification.
+Use `github-issue-format` for title, rationale, body order, the mandatory `## Plain simple English` section, and footer. Embed the issue's requirements and acceptance criteria; the PRD gives context, never the spec.
 
-State the result, scope boundaries, implementation contracts, prerequisite outputs, and verification method. Include applicable failure paths and money, privacy, authorization, data-integrity, and irreversible-deletion invariants. Carry the PRD's worked examples into acceptance tests, checking their inputs and expected results against the stated rules. Resolve contradictions before filing; do not silently choose a rule.
+State the result, scope boundaries, contracts, prerequisite outputs, and verification method. Include failure paths and money, privacy, authorization, data-integrity, and irreversible-deletion invariants. Carry the PRD's worked examples into acceptance tests after checking them against the stated rules; resolve contradictions before filing.
 
-Grade all five complexity axes from the proposed edit list and the proof required. Distinguish proposed sites from inspected sites, and record the evidence for each grade. Recompute the title score, rationale, and execution defaults together after scope changes.
+Grade all five axes from the proposed edit list and required proof, recording evidence per grade and marking proposed versus inspected sites. Re-score title, rationale, and execution defaults together after any scope change.
 
-Append exactly one Execution block before the footer. Use these field names with concrete values; local keys are permitted only in unpublished drafts:
+Append exactly one Execution block before the footer; local keys appear only in unpublished drafts:
 
-- **Depends on:** comma-separated actual issue references, or `none`
-- **Runs after:** comma-separated actual issue references, or `none`
-- **Build model:** the score band's Build model
-- **Effort:** the score band's Build effort
-- **fableplan first:** the score band's `Yes` or `No`
+- **Depends on:** issue references, comma-separated, or `none`
+- **Runs after:** issue references, comma-separated, or `none`
+- **Build model:** the band's Build model
+- **Effort:** the band's Build effort
+- **fableplan first:** the band's `Yes` or `No`
 - **PR review:** standard `@claude` review trigger
 
-The standard PR review line leaves first-review routing to the pipeline and the `validate-issue` step 6 first-review table. Do not copy review boundaries or re-review rules here.
+First-review routing belongs to the pipeline and the `validate-issue` step 6 table; copy no review rules here. Omit **Validate effort:** and **Plan effort:** unless requested. Never stamp a validate model. Never stamp Fable 5.1 as the Build model without a specific user instruction. Never stamp an external CLI harness as the Build model without one either; CLI overrides use `<Name> (Codex CLI[, <model-id>])` or `<Name> (Cursor CLI[, <model-id>])`. For user-directed overrides, apply the validation and clamp rules in [execution-plan-review](../execution-plan-review/SKILL.md) without running its workflow.
 
-Omit **Validate effort:** and **Plan effort:** at initial filing unless explicitly requested; the owners supply the defaults. Never stamp a validate model. Never stamp Fable 5.1 as the Build model without a specific user instruction. Never stamp an external CLI harness as the Build model without a specific user instruction. Command-line interface (CLI) overrides use `<Name> (Codex CLI[, <model-id>])` or `<Name> (Cursor CLI[, <model-id>])`.
+## 4. Review the filing plan
 
-For user-directed model, effort, planner, or review overrides, read [execution-plan-review](../execution-plan-review/SKILL.md) and apply its validation and clamp rules to the draft. Preserve valid overrides. Do not execute the referenced build or review workflow.
+Before any write, present the drafts and coverage map with a table of draft key, title, milestone, score, typed predecessors, and action. Confirm every requirement is covered, every criterion is verifiable, the graph is acyclic, routing matches scores or overrides, and each milestone has a completion outcome.
 
-## 4. Review the complete filing plan
-
-Before writing to GitHub, make the complete drafts and coverage map available with a compact table of draft key, title, milestone, score, typed predecessors, and create/reuse/update action. Check that each in-scope requirement is covered, every criterion is verifiable, the combined graph is acyclic, routing matches scores or explicit overrides, and each milestone has a completion outcome.
-
-Honor existing authorization to file. If the user requested review first or has not authorized filing, stop at this concrete plan and ask for the required approval. Do not ask again when the session already authorizes the proposed scope. When invoked through `new-app-pipeline`, preserve its stage checkpoints. A material scope or dependency change after approval needs reconciliation before filing.
+Honor existing authorization. If the user asked to review first or has not authorized filing, stop here and ask; do not ask again when the session already covers this scope. Under `new-app-pipeline`, keep its stage checkpoints. A material scope or dependency change after approval needs reconciliation first.
 
 ## 5. File in dependency order and verify
 
-Recheck GitHub for concurrent changes before writes. Reuse matching milestones; create only missing ones with their completion outcome in the description. Use an explicit target repository on every GitHub operation. Pass issue bodies as data through `gh issue create --body-file` or a structured tool argument; never interpolate PRD text into executable shell code.
+- Recheck GitHub for concurrent changes. Reuse matching milestones; create missing ones with their completion outcome. Name the target repo on every GitHub call. Pass bodies as data via `gh issue create --body-file`; never interpolate PRD text into shell code.
+- Create issues one at a time in topological order over both edge types, resolving each predecessor to its verified GitHub number first so every body and Execution block is final at creation. Use the numbers GitHub returns; never predict them. Read back each issue before continuing.
+- For approved updates, re-fetch the body and apply only the intended delta, preserving unrelated content and valid overrides. Never close, reopen, delete, or move existing work to make the backlog fit.
+- On a failed or uncertain write, stop dependent writes. Search GitHub for the source reference, title, and milestone before retrying so nothing is filed twice. Never rerun the batch blindly or roll back by closing or deleting filed work. Report what was filed, what remains, and the blocker.
+- Read back the full set, reused items included. Check titles, bodies, source references, milestones, scores, routing fields, and dependency targets against the plan; rerun the graph and coverage checks and fix mismatches before reporting. Cross-milestone prerequisites stay explicit; [milestone-workflow run planning](../milestone-workflow/run-plan.md) owns their execution.
 
-Create issues sequentially in topological order across both edge types. Resolve each predecessor key to its verified GitHub number before creating the successor, so every new issue has its complete body and final Execution block at creation. Use the identifiers returned by GitHub; never predict numbering. Read back each created issue and confirm its number before proceeding.
+## 6. Report
 
-For approved updates to existing issues, re-fetch the body and apply only the intended changes, preserving unrelated content and valid overrides. Revalidate the combined graph after any concurrent change. Do not close, reopen, delete, or move existing work merely to make the backlog fit.
-
-If a create or update fails or returns an uncertain result, stop dependent writes. After an uncertain create, search GitHub for the source reference, title, and milestone before retrying, so the same issue is not filed twice. Never rerun the whole batch blindly, and never close or delete successful work as rollback. Report what was filed, what remains, and the blocker.
-
-Read back the full filed set, including reused issues and milestones. Check saved titles, bodies, source references, milestone assignments, scores, routing fields, and actual dependency targets against the plan; rerun the combined graph and coverage checks. Resolve mismatches before reporting completion. Cross-milestone prerequisites remain explicit; [milestone-workflow run planning](../milestone-workflow/run-plan.md) owns their execution treatment.
-
-## 6. Report the result
-
-Return links to the milestones and created or updated issues, a compact score/title table, and any unresolved or deferred scope. Distinguish reused and already implemented work from new filings. Report partial completion and the next required decision when blocked. Do not claim the backlog is ready until the saved bodies and graph pass verification.
+Return milestone and issue links, a compact score/title table, and any unresolved or deferred scope. Separate reused and already-implemented work from new filings. When blocked, report partial completion and the next decision. Claim readiness only after the saved bodies and graph pass verification.

--- a/skills/prd-to-issues/SKILL.md
+++ b/skills/prd-to-issues/SKILL.md
@@ -73,6 +73,3 @@ Read back the full filed set, including reused issues and milestones. Check save
 ## 6. Report the result
 
 Return links to the milestones and created or updated issues, a compact score/title table, and any unresolved or deferred scope. Distinguish reused and already implemented work from new filings. Report partial completion and the next required decision when blocked. Do not claim the backlog is ready until the saved bodies and graph pass verification.
-
----
-Updated with LLM: GPT-6 | high | Harness: Codex

--- a/tests/complexity-score.test.js
+++ b/tests/complexity-score.test.js
@@ -94,16 +94,18 @@ describe('complexity score band encoding', () => {
     })
   })
 
-  test('the prd-to-issues band table states the same build routing as the owner', () => {
-    const owner = ownerBands()
-    const rows = [...prdToIssues.matchAll(/^\| (\d) \| (\d+)–(\d+) \| (Sonnet 5|Opus 5|Fable 5.1)[^|]*\| (\*\*Yes\*\*|No) \| (\w+) ?\|/gm)]
-    expect(rows.length, 'prd-to-issues states six bands').toBe(owner.length)
-    rows.forEach(([, band, min, max, model, fableplan, effort], index) => {
-      const row = owner[index]
-      expect({ band: Number(band), min: Number(min), max: Number(max) }, `row ${band} bounds`).toEqual({ band: row.band, min: row.min, max: row.max })
-      expect(fableplan === '**Yes**', `row ${band} fableplan`).toBe(row.fableplan)
-      expect({ model: MODEL_KEY[model], effort }, `row ${band} build`).toEqual(row.build)
-    })
+  test('prd-to-issues resolves scoring and routing to the canonical sources', async () => {
+    for (const target of ['../validate-issue/SKILL.md#6-score-complexity', '../validate-issue/complexity-scoring.md']) {
+      const links = [...prdToIssues.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)].map(([, href]) => href)
+      expect(links).toContain(target)
+      const resolved = new URL(target, new URL('skills/prd-to-issues/SKILL.md', root))
+      const anchor = resolved.hash
+      resolved.hash = ''
+      const content = await Bun.file(resolved).text()
+      if (anchor) expect(content).toContain('### 6. Score complexity')
+      else expect(content).toContain('## Axis anchors')
+    }
+    expect(prdToIssues).not.toMatch(/^\| \d \| \d+–\d+ \|/m)
   })
 
   test('the milestoneplan validate copy covers every owner band with the owner routing', () => {

--- a/tests/issue-plain-simple-english-contract.test.js
+++ b/tests/issue-plain-simple-english-contract.test.js
@@ -33,8 +33,17 @@ const texts = Object.fromEntries(await Promise.all(ALL.map(async (path) => [path
 const normalized = Object.fromEntries(Object.entries(texts).map(([path, source]) => [path, source.replace(/\s+/g, ' ')]))
 
 describe('Issue-body Plain simple English contract', () => {
-  test('every issue-composing file requires the section with its 55-word cap', () => {
+  test('every issue-composing file requires the section and its shared definition', async () => {
     for (const path of ISSUE_BODY_CONSUMERS) {
+      if (path === 'skills/prd-to-issues/SKILL.md') {
+        const reference = texts[path].match(/\[github-issue-format\]\(([^)]+)\)/)
+        expect(reference).not.toBeNull()
+        const resolved = new URL(reference[1], new URL(path, root))
+        expect(resolved.href).toBe(new URL(OWNER, root).href)
+        expect(await Bun.file(resolved).text()).toBe(texts[OWNER])
+        expect(normalized[path]).toContain('mandatory `## Plain simple English` section')
+        continue
+      }
       expect(normalized[path], path).toMatch(
         /## Plain simple English[\s\S]{0,320}55 words|55 words[\s\S]{0,320}## Plain simple English/,
       )


### PR DESCRIPTION
## Summary

Rework prd-to-issues so a GitHub filing covers every requirement, reconciles existing work, and never guesses dependency numbers. Replace issue quotas and copied routing tables with scope-based sizing and references to the shared rules.

Add requirement coverage, existing-work reconciliation, complete drafts, typed dependency validation, safe body submission, and checks of saved GitHub content. Honor prior filing authorization and preserve pipeline checkpoints. Update the README and related skill references.

The persisted filing record and the resume-after-failure path were removed on request. A failed or uncertain write still stops dependent writes, is searched on GitHub before a retry, and is never rolled back by closing or deleting filed work.

## Verification

- Bun: 319 tests passed.
- Python: 91 Claude workflow tests and 55 Codex workflow tests passed.
- Skill validator and git diff whitespace check passed.
- Independent simulated filing checked requirement coverage, closed-issue reuse, and nonconsecutive issue numbers. Its authorization ambiguity was resolved: complete independent work can proceed under existing scope authorization; blocked requirements remain explicit. No live backlog was filed.

Complexity C64: Capability 2 (Risk 3, Uncertainty 1); Volume 14 (Scope 3, Coupling 2, Verification 2). The skill controls recoverable tracker writes; six files cover known workflow, reference, and contract-test changes.

## Test changes

Both edits are Outdated. Ground: the user requested removal of repetition, and CLAUDE.md Response Style requires references to shared rules.

- tests/complexity-score.test.js replaces the copied routing-table expectation with checks of canonical scoring links and absence of a duplicate table. Runtime band parity remains covered.
- tests/issue-plain-simple-english-contract.test.js replaces the local word-cap expectation for this skill with checks of the resolved format reference and mandatory section. The shared owner's word-cap check remains.

## Plain simple English

The skill now checks that requirements have complete issues and valid dependencies. It reads the issues it filed to confirm they are correct, and it stops safely if a write fails. Shared rules stay in their owning skills, so later changes have fewer copies to update.

https://claude.ai/code/session_01PPvKgRHDermNgPpE5Ywbef

---
Updated with LLM: GPT-6 | high | Harness: Codex
Updated with LLM: Opus 5 | high | Harness: Claude Code

