### PR TITLE
fix(work-on-issue): allow PRs with unavailable checks [C85, GPT-6, high]

### DIFF
--- a/skills/work-on-issue/SKILL.md
+++ b/skills/work-on-issue/SKILL.md
@@ -68,6 +68,3 @@ Read back `gh pr view <url> --json state,headRefName,headRefOid,baseRefName,body
 ### 7. Report to the user
 
 The skill ends here; the caller triggers review and waits on CI. Report the worktree/branch, a non-default target, what was implemented, the verification result, the commit SHA, and the PR URL. On a blocker, state the stage, the evidence, the preserved worktree, and which commit, push, or PR already exists per branch history and GitHub. When step 3 stopped on an ungrounded failing test, name its `file:line`, assertion, and conflict. Name unfiled follow-on work. Cap the report at 55 words, plain simple English in ASD-STE100, per the Response Style rules.
-
----
-Updated with LLM: GPT-6 | high | Harness: Codex

--- a/skills/work-on-issue/SKILL.md
+++ b/skills/work-on-issue/SKILL.md
@@ -51,7 +51,7 @@ The repository's test-edit rules own stale-test edits: the cases Outdated, Wrong
 
 Run the project's build, tests, and linters plus the step 2 acceptance checks. Review the full diff against the base for omissions, unrelated changes, and generated files. Close every plan item with evidence or a deviation.
 
-Fix failures this change caused; check an alleged pre-existing failure against the unchanged base first. Failing or unrunnable required checks block the PR, except under a caller instruction that forbids running the project's code and defers to continuous integration (CI); then the PR body names the checks left to CI. Rerun affected checks after later edits. Local success is not CI success.
+Fix failures this change caused; check an alleged pre-existing failure against the unchanged base first. Failures caused by this change block the PR until fixed. Unavailable checks and verified pre-existing failures do not block opening the PR. Name each outstanding check, why it did not pass or run, and any checks deferred to continuous integration (CI) in the PR body; keep required release checks outstanding until verified. Rerun affected checks after later edits. Local success is not CI success.
 
 ### 5. Commit and push
 
@@ -68,3 +68,6 @@ Read back `gh pr view <url> --json state,headRefName,headRefOid,baseRefName,body
 ### 7. Report to the user
 
 The skill ends here; the caller triggers review and waits on CI. Report the worktree/branch, a non-default target, what was implemented, the verification result, the commit SHA, and the PR URL. On a blocker, state the stage, the evidence, the preserved worktree, and which commit, push, or PR already exists per branch history and GitHub. When step 3 stopped on an ungrounded failing test, name its `file:line`, assertion, and conflict. Name unfiled follow-on work. Cap the report at 55 words, plain simple English in ASD-STE100, per the Response Style rules.
+
+---
+Updated with LLM: GPT-6 | high | Harness: Codex


### PR DESCRIPTION
## Summary

Remove the work-on-issue requirement that unavailable checks or confirmed baseline failures prevent opening a pull request (PR). Require clear disclosure of outstanding checks and their reasons. Failures caused by the change still block publication, and release checks remain outstanding until verified.

## Verification

- All 306 repository tests pass; git diff --check passes.
- No tests were edited. This is a focused instruction change.
- The optional skill frontmatter validator could not run because its Python environment lacks PyYAML. Frontmatter is unchanged.

Complexity: 85/100. Capability 3 (Risk 4: directly changes a protective publication gate; Uncertainty 0: the requested rule and edit site are known); Volume 10 (Scope 1: one file with rule and attribution edits; Coupling 2: shared work-on-issue contract changes; Verification 2: repository contract tests read several files).

## Plain simple English

Missing device checks and confirmed existing failures will no longer stop an agent from opening a PR. The agent must list those gaps. It must still fix failures caused by its changes before it opens the PR.

---
Created with LLM: GPT-6 | high | Harness: Codex
